### PR TITLE
Improve bergamot build

### DIFF
--- a/app/bergamot/src/main/cpp/CMakeLists.txt
+++ b/app/bergamot/src/main/cpp/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(${CMAKE_PROJECT_NAME} SHARED
         bergamot.cpp)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "/tmp/build/")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "/tmp/libbuild/")
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 
 set(USE_WASM_COMPATIBLE_SOURCES OFF CACHE BOOL "" FORCE)
 set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
@@ -66,14 +67,15 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DI
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-builtin-macro-redefined")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-builtin-macro-redefined")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdata-sections -ffunction-sections")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffunction-sections -fdata-sections -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdata-sections -ffunction-sections -fvisibility=hidden -fvisibility-inlines-hidden")
 
 # For reproducible builds
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id=none")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--hash-style=gnu")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--strip-all")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
 # sort strings table
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--sort-section=name")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--sort-common")

--- a/app/bergamot/src/main/cpp/bergamot.cpp
+++ b/app/bergamot/src/main/cpp/bergamot.cpp
@@ -73,7 +73,7 @@ std::string func(const char* cfg, const char *input, const char* key) {
     return response.target.text;
 }
 
-extern "C" JNIEXPORT void JNICALL
+extern "C" __attribute__((visibility("default"))) JNIEXPORT void JNICALL
 Java_dev_davidv_bergamot_NativeLib_initializeService(
         JNIEnv* env,
         jobject /* this */) {
@@ -85,7 +85,7 @@ Java_dev_davidv_bergamot_NativeLib_initializeService(
     }
 }
 
-extern "C" JNIEXPORT void JNICALL
+extern "C" __attribute__((visibility("default"))) JNIEXPORT void JNICALL
 Java_dev_davidv_bergamot_NativeLib_loadModelIntoCache(
         JNIEnv* env,
         jobject /* this */,
@@ -108,7 +108,7 @@ Java_dev_davidv_bergamot_NativeLib_loadModelIntoCache(
     env->ReleaseStringUTFChars(key, c_key);
 }
 
-extern "C" JNIEXPORT jstring JNICALL
+extern "C" __attribute__((visibility("default"))) JNIEXPORT jstring JNICALL
 Java_dev_davidv_bergamot_NativeLib_stringFromJNI(
         JNIEnv* env,
         jobject /* this */,
@@ -137,7 +137,7 @@ Java_dev_davidv_bergamot_NativeLib_stringFromJNI(
 }
 
 // Cleanup function to be called when the library is unloaded
-extern "C" JNIEXPORT void JNICALL
+extern "C" __attribute__((visibility("default"))) JNIEXPORT void JNICALL
 Java_dev_davidv_bergamot_NativeLib_cleanup(JNIEnv* env, jobject /* this */) {
     std::lock_guard<std::mutex> lock(service_mutex);
     global_service.reset();
@@ -185,7 +185,7 @@ DetectionResult detectLanguage(const char* text) {
 
 
 
-extern "C" JNIEXPORT jobject JNICALL
+extern "C" __attribute__((visibility("default"))) JNIEXPORT jobject JNICALL
 Java_dev_davidv_bergamot_LangDetect_detectLanguage(
         JNIEnv* env,
         jobject /* this */,


### PR DESCRIPTION
This PR enables LTO & changes visibility to hidden by default for symbols

The resulting `libbergamot-sys.so` goes from 12MB to 8.7MB.

The APK goes from 23MB to 21M.

A similar improvement could be done if we built tesseract instead of pulling it from jitpack, but I am not sure I want to deal with the build times & reproducibility issues