### PR TITLE
Emit messages for languages added/removed

### DIFF
--- a/app/src/main/java/dev/davidv/translator/DownloadEvent.kt
+++ b/app/src/main/java/dev/davidv/translator/DownloadEvent.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator
+
+sealed class DownloadEvent {
+  data class NewLanguageAvailable(
+    val language: Language,
+  ) : DownloadEvent()
+
+  data class LanguageDeleted(
+    val language: Language,
+  ) : DownloadEvent()
+}

--- a/app/src/main/java/dev/davidv/translator/LanguageStateManager.kt
+++ b/app/src/main/java/dev/davidv/translator/LanguageStateManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+// TODO: remove either the list or the map
 data class LanguageAvailabilityState(
   val hasLanguages: Boolean = false,
   val availableLanguages: List<Language> = emptyList(),
@@ -82,6 +83,50 @@ class LanguageStateManager(
           isChecking = false,
         )
     }
+  }
+
+  fun addLanguage(language: Language) {
+    val currentState = _languageState.value
+    val updatedLanguageMap = currentState.availableLanguageMap.toMutableMap()
+    updatedLanguageMap[language.code] = true
+
+    val updatedAvailableLanguages =
+      Language.entries.filter { lang ->
+        updatedLanguageMap[lang.code] == true
+      }
+
+    val hasLanguages = updatedAvailableLanguages.any { it != Language.ENGLISH }
+
+    _languageState.value =
+      currentState.copy(
+        hasLanguages = hasLanguages,
+        availableLanguages = updatedAvailableLanguages,
+        availableLanguageMap = updatedLanguageMap,
+      )
+
+    Log.i("LanguageStateManager", "Added language: ${language.displayName}")
+  }
+
+  fun deleteLanguage(language: Language) {
+    val currentState = _languageState.value
+    val updatedLanguageMap = currentState.availableLanguageMap.toMutableMap()
+    updatedLanguageMap[language.code] = false
+
+    val updatedAvailableLanguages =
+      Language.entries.filter { lang ->
+        updatedLanguageMap[lang.code] == true
+      }
+
+    val hasLanguages = updatedAvailableLanguages.any { it != Language.ENGLISH }
+
+    _languageState.value =
+      currentState.copy(
+        hasLanguages = hasLanguages,
+        availableLanguages = updatedAvailableLanguages,
+        availableLanguageMap = updatedLanguageMap,
+      )
+
+    Log.i("LanguageStateManager", "Removed language: ${language.displayName}")
   }
 
   fun getFirstAvailableFromLanguage(excluding: Language? = null): Language? {

--- a/app/src/main/java/dev/davidv/translator/ui/screens/NoLanguagesScreen.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/NoLanguagesScreen.kt
@@ -42,8 +42,6 @@ import dev.davidv.translator.ui.theme.TranslatorTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NoLanguagesScreen(
-  onLanguageDownloaded: () -> Unit,
-  onLanguageDeleted: () -> Unit,
   onDone: () -> Unit,
   onSettings: () -> Unit,
   hasLanguages: Boolean = false,
@@ -91,8 +89,6 @@ fun NoLanguagesScreen(
       )
 
       LanguageManagerScreen(
-        onLanguageDownloaded = onLanguageDownloaded,
-        onLanguageDeleted = onLanguageDeleted,
         embedded = true,
       )
     }
@@ -104,8 +100,6 @@ fun NoLanguagesScreen(
 fun NoLanguagesScreenPreview() {
   TranslatorTheme {
     NoLanguagesScreen(
-      onLanguageDownloaded = {},
-      onLanguageDeleted = {},
       onDone = {},
       onSettings = {},
       hasLanguages = false,


### PR DESCRIPTION
This PR bubbles up 'downloaded' / 'deleted' events, which means it's no longer necessary to call `refreshLanguageAvailability` on progress. `refreshLanguageAvailability` is annoying because it's doing IO to check which files are present


Closes #16