### PR TITLE
OCR: improve handling of line breaks

### DIFF
--- a/app/src/main/java/dev/davidv/translator/ImagePainting.kt
+++ b/app/src/main/java/dev/davidv/translator/ImagePainting.kt
@@ -351,6 +351,7 @@ fun paintTranslatedTextOver(
       lineColors[index] = fg
     }
 
+    // only false if we would need to have text size < 8f
     if (fitResult is TextFitResult.Fits) {
       textBlock.lines.forEachIndexed { lineIndex, line ->
         // Set color for this specific line

--- a/app/src/main/java/dev/davidv/translator/ui/components/StyledTextField.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/components/StyledTextField.kt
@@ -129,15 +129,16 @@ fun StyledTextField(
     )
 
     DisposableEffect(lifecycleOwner) {
-      val observer = LifecycleEventObserver { _, event ->
-        when (event) {
-          Lifecycle.Event.ON_PAUSE -> {
-            val currentFocus = (context as? android.app.Activity)?.currentFocus
-            currentFocus?.clearFocus()
+      val observer =
+        LifecycleEventObserver { _, event ->
+          when (event) {
+            Lifecycle.Event.ON_PAUSE -> {
+              val currentFocus = (context as? android.app.Activity)?.currentFocus
+              currentFocus?.clearFocus()
+            }
+            else -> {}
           }
-          else -> {}
         }
-      }
       lifecycleOwner.lifecycle.addObserver(observer)
       onDispose {
         lifecycleOwner.lifecycle.removeObserver(observer)

--- a/app/src/test/java/dev/davidv/translator/OCRServiceTest.kt
+++ b/app/src/test/java/dev/davidv/translator/OCRServiceTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OCRServiceTest {
+  @Test
+  fun `mergeHyphenatedWords with Dutch text`() {
+    val words =
+      listOf(
+        WordInfo("Baruch", 90f, Rect(0, 0, 50, 20), null, true, false, false),
+        WordInfo("of", 95f, Rect(55, 0, 70, 20), null, false, false, false),
+        WordInfo("Bento", 92f, Rect(75, 0, 120, 20), null, false, true, false),
+        WordInfo("de", 88f, Rect(0, 25, 20, 45), null, true, false, false),
+        WordInfo("Spinoza", 93f, Rect(25, 25, 85, 45), null, false, false, false),
+        WordInfo("sprak", 91f, Rect(90, 25, 130, 45), null, false, true, false),
+        WordInfo("zich", 89f, Rect(0, 50, 35, 70), null, true, false, false),
+        WordInfo("uit", 94f, Rect(40, 50, 60, 70), null, false, false, false),
+        WordInfo("voor", 96f, Rect(65, 50, 95, 70), null, false, false, false),
+        WordInfo("ge-", 87f, Rect(100, 50, 120, 70), null, false, true, false),
+        WordInfo("loofsvrijheid", 85f, Rect(0, 75, 110, 95), null, true, false, false),
+        WordInfo("en", 98f, Rect(115, 75, 130, 95), null, false, true, false),
+        WordInfo("voor", 92f, Rect(0, 100, 35, 120), null, true, false, false),
+        WordInfo("de", 90f, Rect(40, 100, 55, 120), null, false, false, false),
+        WordInfo("vrijheid", 88f, Rect(60, 100, 120, 120), null, false, false, false),
+        WordInfo("om", 95f, Rect(125, 100, 145, 120), null, false, true, false),
+        WordInfo("je", 93f, Rect(0, 125, 15, 145), null, true, false, false),
+        WordInfo("mening", 91f, Rect(20, 125, 70, 145), null, false, false, false),
+        WordInfo("ook", 89f, Rect(75, 125, 100, 145), null, false, false, false),
+        WordInfo("op", 94f, Rect(105, 125, 120, 145), null, false, true, false),
+        WordInfo("dat", 92f, Rect(0, 150, 25, 170), null, true, false, false),
+        WordInfo("gebied", 87f, Rect(30, 150, 75, 170), null, false, false, false),
+        WordInfo("onbe-", 86f, Rect(80, 150, 115, 170), null, false, true, false),
+        WordInfo("lemmerd", 84f, Rect(0, 175, 60, 195), null, true, false, false),
+        WordInfo("te", 97f, Rect(65, 175, 80, 195), null, false, false, false),
+        WordInfo("uiten.", 90f, Rect(85, 175, 125, 195), null, false, true, true),
+      )
+
+    val result = mergeHyphenatedWords(words)
+
+    val expectedTexts =
+      listOf(
+        "Baruch",
+        "of",
+        "Bento",
+        "de",
+        "Spinoza",
+        "sprak",
+        "zich",
+        "uit",
+        "voor",
+        // vvv geloofsvrijheid is merged
+        "geloofsvrijheid",
+        "en",
+        "voor",
+        "de",
+        "vrijheid",
+        "om",
+        "je",
+        "mening",
+        "ook",
+        "op",
+        "dat",
+        "gebied",
+        // vvv onbelemmerd is merged
+        "onbelemmerd",
+        "te",
+        "uiten.",
+      )
+
+    assertEquals(expectedTexts.size, result.size)
+    assertEquals(expectedTexts, result.map { it.text })
+
+    val geloofsvrijheidWord = result.find { it.text == "geloofsvrijheid" }!!
+    assertEquals(false, geloofsvrijheidWord.isFirstInLine)
+    assertEquals(true, geloofsvrijheidWord.isLastInLine)
+    assertEquals(false, geloofsvrijheidWord.isLastInPara)
+    assertEquals(85f, geloofsvrijheidWord.confidence, 0.01f)
+
+    val onbelemmerdWord = result.find { it.text == "onbelemmerd" }!!
+    assertEquals(false, onbelemmerdWord.isFirstInLine)
+    assertEquals(true, onbelemmerdWord.isLastInLine)
+    assertEquals(false, onbelemmerdWord.isLastInPara)
+    assertEquals(84f, onbelemmerdWord.confidence, 0.01f)
+  }
+
+  @Test
+  fun `mergeHyphenatedWords does not merge non-hyphenated words`() {
+    val words =
+      listOf(
+        WordInfo("word", 90f, Rect(0, 0, 50, 20), null, true, true, false),
+        WordInfo("next", 85f, Rect(0, 25, 40, 45), null, true, true, false),
+      )
+
+    val result = mergeHyphenatedWords(words)
+
+    println(result)
+    assertEquals(2, result.size)
+    assertEquals("word", result[0].text)
+    assertEquals("next", result[1].text)
+  }
+
+  @Test
+  fun `mergeHyphenatedWords handles empty list`() {
+    val result = mergeHyphenatedWords(emptyList())
+    assertEquals(0, result.size)
+  }
+}

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -4,4 +4,5 @@
 - Add setting for default 'source' language
 - Improved translation performance & quality
 - Improved startup speed and translation responsiveness (UI interactions)
+- Improve OCR image overlay quality
 - Reduced memory usage for CJK and Russian models (needs redownload)


### PR DESCRIPTION
Fixes #59.

I found this sign on the street:

<img width="400" alt="Image" src="https://github.com/user-attachments/assets/fabdd484-851e-4de4-8834-a851f0d94655" />

The word breaks (`ge-` and `onbe-`) were not really handled well, and the text didn't even fit fully:

| Before | After |
|---------|---------|
| <img alt="image" src="https://github.com/user-attachments/assets/4739b158-4952-4b52-ae8e-56225a6f8813" /> | <img alt="image" src="https://github.com/user-attachments/assets/5c0c1b0b-19b6-43e4-ac40-103c525302a9" /> |