### PR TITLE
Add Kanji transliteration support via Mucab

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -43,6 +43,9 @@
 -keep class dev.davidv.translator.PageSegMode { *; }
 -keep class dev.davidv.translator.TesseractData** { *; }
 
+# Keep Mucab native library integration
+-keep class dev.davidv.translator.MucabBinding { *; }
+
 -keepclasseswithmembernames class * {
     native <methods>;
 }

--- a/app/src/main/bindings/Cargo.lock
+++ b/app/src/main/bindings/Cargo.lock
@@ -327,7 +327,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mucab"
 version = "0.1.0"
-source = "git+https://github.com/DavidVentura/mucab#3581a3790ebf8fdffeedb302a6b0c09a2b84d1f7"
+source = "git+https://github.com/DavidVentura/mucab#23c9f5740d17f9e05d4b4aa2a2c6f62844493de4"
 dependencies = [
  "encoding_rs",
  "glob",
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]

--- a/app/src/main/bindings/Cargo.lock
+++ b/app/src/main/bindings/Cargo.lock
@@ -56,6 +56,7 @@ name = "bindings"
 version = "0.1.0"
 dependencies = [
  "jni",
+ "mucab",
  "tarkka",
  "tesseract",
 ]
@@ -146,6 +147,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "errno"
@@ -313,6 +323,17 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mucab"
+version = "0.1.0"
+source = "git+https://github.com/DavidVentura/mucab#3581a3790ebf8fdffeedb302a6b0c09a2b84d1f7"
+dependencies = [
+ "encoding_rs",
+ "glob",
+ "regex",
+ "zeekstd",
+]
 
 [[package]]
 name = "nom"

--- a/app/src/main/bindings/Cargo.toml
+++ b/app/src/main/bindings/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 jni = "0.21.1"
 tarkka = { git = "https://github.com/DavidVentura/tarkka" }
 tesseract = { git = "https://github.com/DavidVentura/tesseract-rs" }
+mucab = { git = "https://github.com/DavidVentura/mucab" }
 
 [patch.crates-io]
 leptonica-sys = { git = "https://github.com/DavidVentura/leptonica-sys" }

--- a/app/src/main/bindings/src/lib.rs
+++ b/app/src/main/bindings/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod logging;
+pub mod mucab;
 pub mod tarkka;
 pub mod tesseract;

--- a/app/src/main/bindings/src/mucab.rs
+++ b/app/src/main/bindings/src/mucab.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn Java_dev_davidv_translator_MucabBinding_nativeTranslite
     let text: String = match env.get_string(&java_text) {
         Ok(text) => {
             let t: String = text.into();
-            android_log!(format!("nativeTransliterateJP: Input text: {}", t));
+            android_log!(format!("nativeTransliterateJP: Input text length: {}", t.len()));
             t
         }
         Err(_) => {
@@ -63,13 +63,10 @@ pub unsafe extern "C" fn Java_dev_davidv_translator_MucabBinding_nativeTranslite
         }
     };
 
-    android_log!("nativeTransliterateJP: Getting dictionary from pointer");
     let dict = unsafe { &mut *(dict_ptr as *mut Dictionary) };
-
-    android_log!("nativeTransliterateJP: Calling transliterate");
     let result = transliterate(&text, dict);
 
-    android_log!(format!("nativeTransliterateJP: Result: {}", result));
+    android_log!(format!("nativeTransliterateJP: Result length: {}", result.len()));
 
     match env.new_string(&result) {
         Ok(jstring) => jstring.into_raw(),

--- a/app/src/main/bindings/src/mucab.rs
+++ b/app/src/main/bindings/src/mucab.rs
@@ -1,0 +1,92 @@
+use mucab::{Dictionary, transliterate};
+
+extern crate jni;
+use self::jni::JNIEnv;
+use self::jni::objects::{JClass, JString};
+use self::jni::sys::{jlong, jstring};
+
+use crate::logging::android_log_with_level;
+
+macro_rules! android_log {
+    ($msg:expr) => {
+        android_log_with_level(crate::logging::ANDROID_LOG_DEBUG, "MucabNative", &$msg);
+    };
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Java_dev_davidv_translator_MucabBinding_nativeOpen(
+    mut env: JNIEnv,
+    _: JClass,
+    java_path: JString,
+) -> jlong {
+    let path: String = match env.get_string(&java_path) {
+        Ok(path) => path.into(),
+        Err(_) => return 0,
+    };
+
+    match Dictionary::load(&path) {
+        Ok(dict) => {
+            android_log!(format!("Dictionary loaded from {}", path));
+            let boxed_dict = Box::new(dict);
+            Box::into_raw(boxed_dict) as jlong
+        }
+        Err(e) => {
+            android_log!(format!("Failed to load dictionary: {:?}", e));
+            0
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Java_dev_davidv_translator_MucabBinding_nativeTransliterateJP(
+    mut env: JNIEnv,
+    _: JClass,
+    dict_ptr: jlong,
+    java_text: JString,
+) -> jstring {
+    android_log!("nativeTransliterateJP: Started");
+
+    if dict_ptr == 0 {
+        android_log!("nativeTransliterateJP: dict_ptr is 0, returning null");
+        return std::ptr::null_mut();
+    }
+
+    let text: String = match env.get_string(&java_text) {
+        Ok(text) => {
+            let t: String = text.into();
+            android_log!(format!("nativeTransliterateJP: Input text: {}", t));
+            t
+        }
+        Err(_) => {
+            android_log!("nativeTransliterateJP: Failed to get string from java_text");
+            return std::ptr::null_mut();
+        }
+    };
+
+    android_log!("nativeTransliterateJP: Getting dictionary from pointer");
+    let dict = unsafe { &mut *(dict_ptr as *mut Dictionary) };
+
+    android_log!("nativeTransliterateJP: Calling transliterate");
+    let result = transliterate(&text, dict);
+
+    android_log!(format!("nativeTransliterateJP: Result: {}", result));
+
+    match env.new_string(&result) {
+        Ok(jstring) => jstring.into_raw(),
+        Err(_) => {
+            android_log!("nativeTransliterateJP: Failed to create Java string");
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Java_dev_davidv_translator_MucabBinding_nativeClose(
+    _env: JNIEnv,
+    _: JClass,
+    dict_ptr: jlong,
+) {
+    if dict_ptr != 0 {
+        let _ = unsafe { Box::from_raw(dict_ptr as *mut Dictionary) };
+    }
+}

--- a/app/src/main/java/dev/davidv/translator/FileEvent.kt
+++ b/app/src/main/java/dev/davidv/translator/FileEvent.kt
@@ -22,6 +22,10 @@ sealed class FileEvent {
     val index: DictionaryIndex,
   ) : FileEvent()
 
+  data class MucabFileLoaded(
+    val mucabBinding: MucabBinding,
+  ) : FileEvent()
+
   data class LanguageDeleted(
     val language: Language,
   ) : FileEvent()

--- a/app/src/main/java/dev/davidv/translator/FilePathManager.kt
+++ b/app/src/main/java/dev/davidv/translator/FilePathManager.kt
@@ -35,6 +35,8 @@ class FilePathManager(
 
   fun getDictionaryIndexFile(): File = File(baseDir, "dictionaries/index.json")
 
+  fun getMucabFile(): File = File(getDataDir(), "mucab.bin")
+
   fun deleteLanguageFiles(language: Language) {
     val dataPath = getDataDir()
 
@@ -53,6 +55,14 @@ class FilePathManager(
       val file = File(dataPath, fileName)
       if (file.exists() && file.delete()) {
         Log.i("FilePathManager", "Deleted: $fileName")
+      }
+    }
+
+    // Delete extra files
+    extraFiles[language]?.forEach { fileName ->
+      val file = File(dataPath, fileName)
+      if (file.exists() && file.delete()) {
+        Log.i("FilePathManager", "Deleted extra file: $fileName")
       }
     }
 

--- a/app/src/main/java/dev/davidv/translator/ImagePainting.kt
+++ b/app/src/main/java/dev/davidv/translator/ImagePainting.kt
@@ -339,7 +339,7 @@ fun paintTranslatedTextOver(
     }
 
     if (testingBoxes) {
-      textBlock.lines.forEach { println(it) }
+      textBlock.lines.forEach {}
     }
     // Store colors for each line to avoid redundant calculations
     val lineColors = mutableMapOf<Int, Int>()

--- a/app/src/main/java/dev/davidv/translator/Language.kt
+++ b/app/src/main/java/dev/davidv/translator/Language.kt
@@ -190,3 +190,8 @@ val toEnglishFiles =
     Language.UKRAINIAN to LanguageFiles(Pair("model.uken.intgemm.alphas.bin", 12677432), Pair("vocab.uken.spm", 415266), Pair("vocab.uken.spm", 415266), Pair("lex.50.50.uken.s2t.bin", 1790588), ModelType.TINY),
     Language.CHINESE to LanguageFiles(Pair("model.zhen.intgemm.alphas.bin", 32726806), Pair("vocab.zhen.spm", 738862), Pair("vocab.zhen.spm", 738862), Pair("lex.50.50.zhen.s2t.bin", 4822158), ModelType.BASE_MEMORY),
   )
+
+val extraFiles =
+  mapOf(
+    Language.JAPANESE to listOf("mucab.bin"),
+  )

--- a/app/src/main/java/dev/davidv/translator/MucabBinding.kt
+++ b/app/src/main/java/dev/davidv/translator/MucabBinding.kt
@@ -1,0 +1,46 @@
+package dev.davidv.translator
+
+class MucabBinding {
+  companion object {
+    init {
+      System.loadLibrary("bindings")
+    }
+  }
+
+  private var dictPtr: Long = 0
+
+  fun open(path: String): Boolean {
+    close()
+    dictPtr = nativeOpen(path)
+    return dictPtr != 0L
+  }
+
+  fun transliterateJP(text: String): String? =
+    if (dictPtr != 0L) {
+      nativeTransliterateJP(dictPtr, text)
+    } else {
+      null
+    }
+
+  fun close() {
+    if (dictPtr != 0L) {
+      nativeClose(dictPtr)
+      dictPtr = 0
+    }
+  }
+
+  fun isOpen(): Boolean = dictPtr != 0L
+
+  private external fun nativeOpen(path: String): Long
+
+  private external fun nativeTransliterateJP(
+    dictPtr: Long,
+    text: String,
+  ): String?
+
+  private external fun nativeClose(dictPtr: Long)
+
+  protected fun finalize() {
+    close()
+  }
+}

--- a/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
@@ -43,6 +43,10 @@ class TranslationCoordinator(
 
   var lastTranslatedInput: String = ""
 
+  fun setMucabBinding(binding: MucabBinding?) {
+    translationService.setMucabBinding(binding)
+  }
+
   suspend fun preloadModel(
     from: Language,
     to: Language,

--- a/app/src/main/java/dev/davidv/translator/TranslationService.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationService.kt
@@ -49,6 +49,12 @@ class TranslationService(
 
   private val nativeLib = getNativeLib()
 
+  private var mucabBinding: MucabBinding? = null
+
+  fun setMucabBinding(binding: MucabBinding?) {
+    mucabBinding = binding
+  }
+
   // / Requires the translation pairs to be available
   suspend fun preloadModel(
     from: Language,
@@ -106,7 +112,7 @@ class TranslationService(
         result.map { translatedText ->
           val transliterated =
             if (!settingsManager.settings.value.disableTransliteration) {
-              TransliterationService.transliterate(translatedText, to)
+              TransliterationService.transliterate(translatedText, to, mucabBinding = mucabBinding)
             } else {
               null
             }
@@ -164,7 +170,7 @@ class TranslationService(
         Log.d("TranslationService", "Translation took ${elapsed}ms")
         val transliterated =
           if (!settingsManager.settings.value.disableTransliteration) {
-            TransliterationService.transliterate(result, to)
+            TransliterationService.transliterate(result, to, mucabBinding = mucabBinding)
           } else {
             null
           }

--- a/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
@@ -212,10 +212,17 @@ fun TranslatorApp(
           if (currentTo == event.language) {
             setTo(validLangs.filterNot { it.key == currentFrom }.keys.firstOrNull() ?: Language.ENGLISH)
           }
+          if (event.language == Language.JAPANESE) {
+            translationCoordinator.setMucabBinding(null)
+          }
           Log.d("TranslatorApp", "Language deleted: ${event.language}")
         }
         is FileEvent.DictionaryIndexLoaded -> {
           Log.d("TranslatorApp", "Dictionary index loaded from file: ${event.index}")
+        }
+        is FileEvent.MucabFileLoaded -> {
+          translationCoordinator.setMucabBinding(event.mucabBinding)
+          Log.d("TranslatorApp", "Mucab file loaded and set in TranslationCoordinator")
         }
         is FileEvent.DictionaryDeleted -> {
           dictionaryBindings[event.language]?.close()

--- a/generate.py
+++ b/generate.py
@@ -401,6 +401,11 @@ def generate_kotlin_enum(language_pairs: Dict[str, Set[str]], existing_sizes: di
     to_english_lines = ",\n".join(to_english_files_entries)
     from_english_lines = ",\n".join(from_english_files_entries)
     language_lines = ",\n".join(language_entries)
+
+    extra_files_entries = []
+    extra_files_entries.append('    Language.JAPANESE to listOf("mucab.bin")')
+    extra_files_lines = ",\n".join(extra_files_entries)
+
     # Generate the complete enum classes and maps
     kotlin_code = f"""/*
  * Copyright (C) 2024 David V
@@ -462,6 +467,10 @@ val fromEnglishFiles = mapOf(
 
 val toEnglishFiles = mapOf(
 {to_english_lines}
+)
+
+val extraFiles = mapOf(
+{extra_files_lines}
 )"""
 
     return kotlin_code


### PR DESCRIPTION
Closes #52

Uses [mucab](https://github.com/DavidVentura/Mucab) (with Mecab data) to transliterate Kanji to Hiragana, which is then transliterated to "Latin" 

<img width="400" alt="image" src="https://github.com/user-attachments/assets/14abf113-b2b8-4d78-ae1b-2ed30f4855e5" />
 