### PR TITLE
Android 10: use getExternalFilesDir() for external dirs

### DIFF
--- a/app/src/main/java/dev/davidv/translator/DownloadService.kt
+++ b/app/src/main/java/dev/davidv/translator/DownloadService.kt
@@ -581,6 +581,11 @@ class DownloadService : Service() {
 
     try {
       outputFile.parentFile?.mkdirs()
+    } catch (e: Exception) {
+      Log.e("DownloadService", "Failed to mkdirs", e)
+      return@withContext false
+    }
+    try {
       conn.getInputStream().use { rawInputStream ->
         val trackingStream =
           TrackingInputStream(rawInputStream, size) { incrementalProgress ->
@@ -611,7 +616,7 @@ class DownloadService : Service() {
       }
     } catch (e: Exception) {
       val operation = if (decompress) "decompressing" else "downloading"
-      Log.e("DownloadService", "Error $operation file", e)
+      Log.e("DownloadService", "Error $operation file from $url to $outputFile: ${e.javaClass.simpleName}: ${e.message}", e)
       if (tempFile.exists()) {
         tempFile.delete()
       }

--- a/app/src/main/java/dev/davidv/translator/FilePathManager.kt
+++ b/app/src/main/java/dev/davidv/translator/FilePathManager.kt
@@ -1,6 +1,7 @@
 package dev.davidv.translator
 
 import android.content.Context
+import android.os.Build
 import android.os.Environment
 import android.util.Log
 import kotlinx.coroutines.flow.StateFlow
@@ -13,10 +14,15 @@ class FilePathManager(
   private val baseDir: File
     get() =
       if (settingsFlow.value.useExternalStorage) {
-        val documentsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
-        File(documentsDir, "dev.davidv.translator").also { dir ->
-          if (!dir.exists()) {
-            dir.mkdirs()
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+          val ext = context.getExternalFilesDir(null)
+          ext ?: context.filesDir
+        } else {
+          val documentsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+          File(documentsDir, "dev.davidv.translator").also { dir ->
+            if (!dir.exists()) {
+              dir.mkdirs()
+            }
           }
         }
       } else {


### PR DESCRIPTION
Should fix #81

mkdir now works fine, but can't test because the Android 10 image has no network access :upside_down_face: 