### PR TITLE
add image cropping for OCR

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -214,6 +214,7 @@ dependencies {
   implementation(libs.kotlinx.serialization.json)
   implementation(project(":app:bergamot"))
   implementation(libs.kotlinx.serialization.json.v162)
+  implementation("com.vanniktech:android-image-cropper:4.6.0")
 }
 
 ktlint {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,10 @@
         </intent-filter>
       </activity>
 
+      <activity
+        android:name="com.canhub.cropper.CropImageActivity"
+        android:theme="@style/Theme.Translator.CropImage" />
+
         <service
             android:name=".DownloadService"
             android:enabled="true"

--- a/app/src/main/java/dev/davidv/translator/MainActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/MainActivity.kt
@@ -113,7 +113,7 @@ class MainActivity : ComponentActivity() {
     Log.i("MainActivity", "cleaning up")
   }
 
-  public override fun onNewIntent(intent: Intent?) {
+  override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     handleIntent(intent)
   }

--- a/app/src/main/java/dev/davidv/translator/ProcessTextActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/ProcessTextActivity.kt
@@ -114,7 +114,7 @@ class ProcessTextActivity : ComponentActivity() {
     Log.i("ProcessTextActivity", "cleaning up")
   }
 
-  override fun onNewIntent(intent: Intent?) {
+  override fun onNewIntent(intent: Intent) {
     super.onNewIntent(intent)
     handleIntent(intent)
   }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,4 +12,7 @@
         <item name="android:windowSharedElementEnterTransition">@null</item>
         <item name="android:windowSharedElementExitTransition">@null</item>
     </style>
+
+    <style name="Theme.Translator.CropImage" parent="Theme.AppCompat.Light.DarkActionBar">
+    </style>
 </resources>

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,6 +1,7 @@
+- Implement cropping for OCR images
 - Implement 'share' for the translated image (@jheld)
 - Add option to add spaces for Japanese kanji transliteration
 - Fix external storage usage for Android 10
-- Add support for x86
 - Allow starring 'English'
-- Update Bulgarian, Czech, Dutch, Estonian, Finnish, French, German, Italian, Polish, Portuguese, Spanish (needs redownload)
+
+Update Bulgarian, Czech, Dutch, Estonian, Finnish, French, German, Italian, Polish, Portuguese, Spanish (needs redownload)


### PR DESCRIPTION
Uses CanHub dependency, it's not nice but it does work
I'll eventually replace it with something that allows for single-degree rotation which should be better for OCR detection

<img width="400" alt="image" src="https://github.com/user-attachments/assets/58a63035-b77d-441c-9e60-54c3d87009c6" />
