### PR TITLE
Improve CI

### DIFF
--- a/app/bergamot/build.gradle.kts
+++ b/app/bergamot/build.gradle.kts
@@ -3,6 +3,9 @@ plugins {
   alias(libs.plugins.kotlin.android)
 }
 
+val defaultAbis = listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+val targetAbi = project.findProperty("targetAbi")?.toString()
+
 android {
   namespace = "dev.davidv.bergamot"
   compileSdk = 34
@@ -15,7 +18,7 @@ android {
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     consumerProguardFiles("consumer-rules.pro")
     ndk {
-      abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+      abiFilters += if (targetAbi != null) listOf(targetAbi) else defaultAbis
     }
     externalNativeBuild {
       cmake {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,22 +128,19 @@ val abiToCargoTarget =
     "x86" to "x86",
   )
 
-val prepareOnnxRuntimeSubmodule =
-  tasks.register("prepareOnnxRuntimeSubmodule", Exec::class) {
-    group = "build"
-    description = "Initialize ONNX Runtime submodules"
-    workingDir = rootProject.projectDir
-    commandLine(
-      "git",
-      "-C",
-      onnxRuntimeRootDir.absolutePath,
-      "submodule",
-      "update",
-      "--init",
-      "--recursive",
-      "--depth",
-      "1",
-    )
+val verifyOnnxRuntimeSources =
+  tasks.register("verifyOnnxRuntimeSources") {
+    group = "verification"
+    description = "Verify the ONNX Runtime source tree is already present"
+    doLast {
+      val buildScript = onnxRuntimeRootDir.resolve("tools/ci_build/build.py")
+      if (!buildScript.isFile) {
+        error(
+          "ONNX Runtime sources are missing at ${onnxRuntimeRootDir.absolutePath}. " +
+            "Initialize submodules before running Gradle.",
+        )
+      }
+    }
   }
 
 val abiToOnnxRuntimeTask =
@@ -153,7 +150,7 @@ val abiToOnnxRuntimeTask =
       tasks.register("buildOnnxRuntime$taskSuffix", Exec::class) {
         group = "build"
         description = "Build ONNX Runtime for $abi"
-        dependsOn(prepareOnnxRuntimeSubmodule)
+        dependsOn(verifyOnnxRuntimeSources)
         workingDir = onnxRuntimeRootDir
         // The ONNX Runtime checkout includes test fixtures with non-portable Unicode paths.
         // Gradle 8.9 fingerprints Exec task inputs eagerly and fails on CI before the build


### PR DESCRIPTION
this was 
- doing submodule update in gradle 
- ignoring targetAbi for bergamot

which made the last build take 45' :grimacing: this should bring it down to (still terrible) ~25'