### PR TITLE
Improve japanese OCR

### DIFF
--- a/app/src/main/assets/index.json
+++ b/app/src/main/assets/index.json
@@ -3077,10 +3077,15 @@
       "files": [
         {
           "name": "jpn.traineddata",
-          "sizeBytes": 2471260,
+          "sizeBytes": 14330109,
           "installPath": "tesseract/tessdata/jpn.traineddata",
-          "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/jpn.traineddata",
-          "sourcePath": "jpn.traineddata"
+          "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_best/refs/heads/main/jpn.traineddata"
+        },
+        {
+          "name": "jpn_vert.traineddata",
+          "sizeBytes": 14330809,
+          "installPath": "tesseract/tessdata/jpn_vert.traineddata",
+          "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_best/refs/heads/main/jpn_vert.traineddata"
         }
       ],
       "dependsOn": [

--- a/app/src/main/java/dev/davidv/translator/AidlTranslationService.kt
+++ b/app/src/main/java/dev/davidv/translator/AidlTranslationService.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -17,6 +18,7 @@ class AidlTranslationService : Service() {
   private lateinit var settingsManager: SettingsManager
   private lateinit var translationCoordinator: TranslationCoordinator
   private lateinit var langStateManager: LanguageStateManager
+  private lateinit var ocrService: OCRService
   private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
   override fun onCreate() {
@@ -25,7 +27,8 @@ class AidlTranslationService : Service() {
     val filePathManager = FilePathManager(this, settingsManager.settings)
     langStateManager = LanguageStateManager(serviceScope, filePathManager, null)
     val languageDetector = LanguageDetector(langStateManager::languageByCode)
-    val imageProcessor = ImageProcessor(this, OCRService(filePathManager))
+    ocrService = OCRService(filePathManager)
+    val imageProcessor = ImageProcessor(this, ocrService)
 
     serviceScope.launch {
       langStateManager.catalog.collect { catalog ->
@@ -144,6 +147,10 @@ class AidlTranslationService : Service() {
 
   override fun onDestroy() {
     Log.d(tag, "onDestroy")
+    if (this::ocrService.isInitialized) {
+      ocrService.cleanup()
+    }
+    serviceScope.cancel()
     super.onDestroy()
   }
 }

--- a/app/src/main/java/dev/davidv/translator/ImagePainting.kt
+++ b/app/src/main/java/dev/davidv/translator/ImagePainting.kt
@@ -23,9 +23,12 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.text.TextPaint
+import android.util.Log
 import kotlin.math.floor
 
 data class OverlayColors(val background: Int, val foreground: Int)
+
+private const val REPAINT_DEBUG_TAG = "RepaintBlocks"
 
 fun getOverlayColors(
   bitmap: Bitmap,
@@ -366,6 +369,69 @@ fun doesTextFitInLines(
   }
 }
 
+fun doesTextFitInRect(
+  text: String,
+  bounds: Rect,
+  textPaint: TextPaint,
+): TextFitResult {
+  if (text.isEmpty()) return TextFitResult.Fits(emptyList())
+  if (bounds.width() <= 0 || bounds.height() <= 0) return TextFitResult.DoesNotFit
+
+  val lineHeight = textPaint.descent() - textPaint.ascent()
+  val maxLines = floor(bounds.height() / lineHeight).toInt().coerceAtLeast(1)
+  val lineBreaks = mutableListOf<TextLineBreak>()
+  var start = 0
+
+  while (start < text.length && lineBreaks.size < maxLines) {
+    while (start < text.length && text[start] == ' ') {
+      start++
+    }
+    if (start >= text.length) break
+
+    val newlineIndex = text.indexOf('\n', startIndex = start).let { if (it == -1) text.length else it }
+    val measuredWidth = FloatArray(1)
+    val countedChars =
+      textPaint.breakText(
+        text,
+        start,
+        newlineIndex,
+        true,
+        bounds.width().toFloat(),
+        measuredWidth,
+      )
+    if (countedChars <= 0) {
+      return TextFitResult.DoesNotFit
+    }
+
+    val rawEnd = start + countedChars
+    val endIndex =
+      when {
+        rawEnd >= newlineIndex -> newlineIndex
+        else -> {
+          val previousSpaceIndex = text.lastIndexOf(' ', startIndex = rawEnd - 1)
+          if (previousSpaceIndex >= start) previousSpaceIndex else rawEnd
+        }
+      }
+
+    val safeEnd = if (endIndex <= start) rawEnd else endIndex
+    lineBreaks.add(TextLineBreak(start, safeEnd))
+    start = safeEnd
+
+    while (start < text.length && text[start] == ' ') {
+      start++
+    }
+    if (start < text.length && text[start] == '\n') {
+      start++
+    }
+  }
+
+  return if (start >= text.length) {
+    TextFitResult.Fits(lineBreaks)
+  } else {
+    TextFitResult.DoesNotFit
+  }
+}
+
 fun paintTranslatedTextOver(
   originalBitmap: Bitmap,
   textBlocks: Array<TextBlock>,
@@ -384,6 +450,12 @@ fun paintTranslatedTextOver(
   var allTranslatedText = ""
 
   textBlocks.forEachIndexed { i, textBlock ->
+    debugRepaintBlock(
+      blockIndex = i,
+      textBlock = textBlock,
+      translated = translatedBlocks.getOrNull(i),
+    )
+
     val blockAvgPixelHeight =
       textBlock.lines
         .map { textLine -> textLine.boundingBox.height() }
@@ -463,6 +535,108 @@ fun paintTranslatedTextOver(
 
   return Pair(mutableBitmap, allTranslatedText.trim())
 }
+
+fun paintTranslatedTextOverVerticalBlocks(
+  originalBitmap: Bitmap,
+  textBlocks: Array<TextBlock>,
+  translatedBlocks: List<String>,
+  backgroundMode: BackgroundMode = BackgroundMode.AUTO_DETECT,
+): Pair<Bitmap, String> {
+  val mutableBitmap = originalBitmap.copy(originalBitmap.config, true)
+  val canvas = Canvas(mutableBitmap)
+  val textPaint =
+    TextPaint().apply {
+      isAntiAlias = true
+    }
+
+  var allTranslatedText = ""
+
+  textBlocks.forEachIndexed { i, textBlock ->
+    val translated = translatedBlocks.getOrNull(i) ?: return@forEachIndexed
+    debugRepaintBlock(
+      blockIndex = i,
+      textBlock = textBlock,
+      translated = translated,
+    )
+
+    allTranslatedText = "${allTranslatedText}\n$translated"
+
+    val blockBounds = textBlock.blockBounds()
+    val allWordRects = textBlock.lines.flatMap { it.wordRects.asList() }.toTypedArray()
+    val minTextSize = 8f
+    val initialTextSize =
+      floor(
+        textBlock.lines
+          .map { line -> line.boundingBox.width() }
+          .average()
+          .toFloat(),
+      ).coerceAtLeast(minTextSize)
+
+    textPaint.textSize = initialTextSize
+    var fitResult = doesTextFitInRect(translated, blockBounds, textPaint)
+    while (fitResult is TextFitResult.DoesNotFit && textPaint.textSize > minTextSize) {
+      textPaint.textSize -= 1f
+      fitResult = doesTextFitInRect(translated, blockBounds, textPaint)
+    }
+
+    val foregroundColor =
+      removeTextWithSmartBlur(
+        canvas,
+        mutableBitmap,
+        blockBounds,
+        allWordRects,
+        backgroundMode,
+      )
+    textPaint.color = foregroundColor
+
+    if (fitResult is TextFitResult.Fits) {
+      val lineHeight = textPaint.descent() - textPaint.ascent()
+      val firstBaseline = blockBounds.top.toFloat() - textPaint.ascent()
+      fitResult.lineBreaks.forEachIndexed { lineIndex, lineBreak ->
+        if (lineBreak.startIndex >= translated.length) return@forEachIndexed
+        canvas.drawText(
+          translated,
+          lineBreak.startIndex,
+          lineBreak.endIndex,
+          blockBounds.left.toFloat(),
+          firstBaseline + (lineIndex * lineHeight),
+          textPaint,
+        )
+      }
+    }
+  }
+
+  return Pair(mutableBitmap, allTranslatedText.trim())
+}
+
+private fun debugRepaintBlock(
+  blockIndex: Int,
+  textBlock: TextBlock,
+  translated: String?,
+) {
+  val blockBounds = textBlock.blockBounds()
+  val sourceText = textBlock.lines.joinToString(separator = " | ") { it.text }
+  Log.d(
+    REPAINT_DEBUG_TAG,
+    "block[$blockIndex] bounds=${blockBounds.compactString()} lines=${textBlock.lines.size} src=\"$sourceText\" translated=\"${translated ?: ""}\"",
+  )
+  textBlock.lines.forEachIndexed { lineIndex, line ->
+    val wordRects = line.wordRects.joinToString(separator = ",") { it.compactString() }
+    Log.d(
+      REPAINT_DEBUG_TAG,
+      "block[$blockIndex] line[$lineIndex] bounds=${line.boundingBox.compactString()} words=${line.wordRects.size} text=\"${line.text}\" wordRects=[$wordRects]",
+    )
+  }
+}
+
+private fun TextBlock.blockBounds(): Rect {
+  val first = lines.firstOrNull()?.boundingBox ?: return Rect(0, 0, 0, 0)
+  val combined = Rect(first)
+  lines.drop(1).forEach { combined.union(it.boundingBox) }
+  return combined
+}
+
+private fun Rect.compactString(): String = "[$left,$top,$right,$bottom]"
 
 private fun toAndroidRect(r: Rect): android.graphics.Rect = android.graphics.Rect(r.left, r.top, r.right, r.bottom)
 

--- a/app/src/main/java/dev/davidv/translator/ImageProcessor.kt
+++ b/app/src/main/java/dev/davidv/translator/ImageProcessor.kt
@@ -36,9 +36,10 @@ class ImageProcessor(
     bitmap: Bitmap,
     fromLang: Language,
     minConfidence: Int = 75,
+    readingOrder: ReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
   ): ProcessedImage =
     withContext(Dispatchers.IO) {
-      val textBlocks = ocrService.extractText(bitmap, fromLang, minConfidence)
+      val textBlocks = ocrService.extractText(bitmap, fromLang, minConfidence, readingOrder)
 
       ProcessedImage(
         bitmap = bitmap,

--- a/app/src/main/java/dev/davidv/translator/LanguageCatalog.kt
+++ b/app/src/main/java/dev/davidv/translator/LanguageCatalog.kt
@@ -236,6 +236,7 @@ data class LanguageCatalog(
     val tesseractPack = assets.ocr["tesseract"]?.let(packs::get)
     val tessFile = tesseractPack?.files?.firstOrNull()
     val tessName = tessFile?.name?.removeSuffix(".traineddata") ?: return null
+    val tessdataSizeBytes = tesseractPack?.files?.sumOf { it.sizeBytes } ?: return null
     val dictionaryCode = assets.dictionary?.let(packs::get)?.dictionaryCode ?: code
 
     val supportFiles =
@@ -250,7 +251,7 @@ data class LanguageCatalog(
       tessName = tessName,
       script = meta.script,
       dictionaryCode = dictionaryCode,
-      tessdataSizeBytes = tessFile.sizeBytes,
+      tessdataSizeBytes = tessdataSizeBytes,
       toEnglish = if (code == "en") null else translationDirection(from = code, to = "en"),
       fromEnglish = if (code == "en") null else translationDirection(from = "en", to = code),
       extraFiles = supportFiles,

--- a/app/src/main/java/dev/davidv/translator/OCRService.kt
+++ b/app/src/main/java/dev/davidv/translator/OCRService.kt
@@ -21,6 +21,7 @@ import android.graphics.Bitmap
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.File
 import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.createDirectories
@@ -160,8 +161,11 @@ fun getSentences(
   bitmap: Bitmap,
   tessInstance: TesseractOCR,
   minConfidence: Int = 75,
+  pageSegMode: PageSegMode = PageSegMode.PSM_AUTO_OSD,
+  joinWithoutSpaces: Boolean = false,
+  relaxSingleCharConfidence: Boolean = false,
 ): Array<TextBlock> {
-  tessInstance.setPageSegmentationMode(PageSegMode.PSM_AUTO_OSD)
+  tessInstance.setPageSegmentationMode(pageSegMode)
 
   val detectedWords = tessInstance.processImage(bitmap)
   if (detectedWords == null) {
@@ -184,13 +188,14 @@ fun getSentences(
 
   var filteredWords = mutableListOf<WordInfo>()
   var pendingFirstInLine = false
+  val effectiveMinConfidence = if (relaxSingleCharConfidence) min(minConfidence, 60) else minConfidence
 
   for (i in allWords.indices) {
     val wordInfo = allWords[i]
 
     val shouldInclude =
-      wordInfo.confidence >= minConfidence &&
-        !(wordInfo.text.length == 1 && wordInfo.confidence < min(100, minConfidence + 5))
+      wordInfo.confidence >= effectiveMinConfidence &&
+        (relaxSingleCharConfidence || !(wordInfo.text.length == 1 && wordInfo.confidence < min(100, effectiveMinConfidence + 5)))
 
     if (shouldInclude) {
       val adjustedWordInfo =
@@ -257,7 +262,12 @@ fun getSentences(
           lines.clear()
         }
       } else {
-        line.text = "${line.text} $word".trim()
+        line.text =
+          if (joinWithoutSpaces || line.text.isEmpty()) {
+            line.text + word
+          } else {
+            "${line.text} $word".trim()
+          }
         line.wordRects += boundingBox
         if (boundingBox.right < line.boundingBox.left) {
           Log.e("OCRService", "going to break $boundingBox ${line.boundingBox}")
@@ -282,6 +292,13 @@ fun getSentences(
     lastRight = boundingBox.right
   }
 
+  if (line.text.trim().isNotEmpty()) {
+    lines.add(line)
+  }
+  if (lines.isNotEmpty()) {
+    blocks.add(TextBlock(lines.toTypedArray()))
+  }
+
   return blocks.toTypedArray()
 }
 
@@ -290,22 +307,36 @@ class OCRService(
 ) {
   private var tess: TesseractOCR? = null
   private var initializedToLang: Language? = null
+  private var initializedReadingOrder: ReadingOrder = ReadingOrder.LEFT_TO_RIGHT
 
-  private suspend fun initialize(lang: Language): Boolean =
+  private suspend fun initialize(
+    lang: Language,
+    readingOrder: ReadingOrder,
+  ): Boolean =
     withContext(Dispatchers.IO) {
-      if (initializedToLang == lang) return@withContext true
+      if (initializedToLang == lang && initializedReadingOrder == readingOrder) return@withContext true
 
       try {
         tess?.close()
         tess = null
         initializedToLang = null
+        initializedReadingOrder = ReadingOrder.LEFT_TO_RIGHT
 
         val p = filePathManager.getTesseractDir().toPath()
         val tessdata = Path(p.pathString, "tessdata")
         val dataPath: String = p.absolutePathString()
         tessdata.createDirectories()
 
-        val langs = "${lang.tessName}+eng"
+        val hasJapaneseVerticalModel =
+          lang.code == "ja" &&
+            File(tessdata.pathString, "jpn_vert.traineddata").exists()
+        val langs =
+          when {
+            lang.code == "ja" &&
+              readingOrder == ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT &&
+              hasJapaneseVerticalModel -> "jpn_vert"
+            else -> "${lang.tessName}+eng"
+          }
         Log.i("OCRService", "Initializing tesseract to path $dataPath, languages $langs")
 
         tess = TesseractOCR(tessdata.absolutePathString(), langs)
@@ -321,6 +352,7 @@ class OCRService(
         }
 
         initializedToLang = lang
+        initializedReadingOrder = readingOrder
         Log.i(
           "OCRService",
           "Tesseract initialized successfully with languages: $langs",
@@ -336,19 +368,35 @@ class OCRService(
     bitmap: Bitmap,
     fromLang: Language,
     minConfidence: Int = 75,
+    readingOrder: ReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
   ): Array<TextBlock> =
     withContext(Dispatchers.IO) {
-      if (initializedToLang != fromLang) {
-        val initSuccess = initialize(fromLang)
+      if (initializedToLang != fromLang || initializedReadingOrder != readingOrder) {
+        val initSuccess = initialize(fromLang, readingOrder)
         if (!initSuccess) return@withContext emptyArray()
       }
 
       val tessInstance = tess ?: return@withContext emptyArray()
+      val pageSegMode =
+        when (readingOrder) {
+          ReadingOrder.LEFT_TO_RIGHT -> PageSegMode.PSM_AUTO_OSD
+          ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT -> PageSegMode.PSM_SINGLE_BLOCK_VERT_TEXT
+        }
+      val joinWithoutSpaces = fromLang.code == "ja"
+      val relaxSingleCharConfidence = readingOrder == ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT
 
       val blocks: Array<TextBlock>
       val elapsed =
         measureTimeMillis {
-          blocks = getSentences(bitmap, tessInstance, minConfidence)
+          blocks =
+            getSentences(
+              bitmap = bitmap,
+              tessInstance = tessInstance,
+              minConfidence = minConfidence,
+              pageSegMode = pageSegMode,
+              joinWithoutSpaces = joinWithoutSpaces,
+              relaxSingleCharConfidence = relaxSingleCharConfidence,
+            )
         }
       Log.i("OCRService", "OCR took ${elapsed}ms")
       blocks
@@ -358,6 +406,7 @@ class OCRService(
     tess?.close()
     tess = null
     initializedToLang = null
+    initializedReadingOrder = ReadingOrder.LEFT_TO_RIGHT
     Log.i("OCRService", "OCR service cleaned up")
   }
 }

--- a/app/src/main/java/dev/davidv/translator/ReadingOrder.kt
+++ b/app/src/main/java/dev/davidv/translator/ReadingOrder.kt
@@ -1,0 +1,6 @@
+package dev.davidv.translator
+
+enum class ReadingOrder {
+  LEFT_TO_RIGHT,
+  TOP_TO_BOTTOM_LEFT_TO_RIGHT,
+}

--- a/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
@@ -153,12 +153,13 @@ class TranslationCoordinator(
     to: Language,
     finalBitmap: Bitmap,
     onMessage: (TranslatorMessage.ImageTextDetected) -> Unit,
+    readingOrder: ReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
   ): ProcessedImageResult? {
     _isTranslating.value = true
     return try {
       _isOcrInProgress.value = true
       val minConfidence = settingsManager.settings.value.minConfidence
-      val processedImage = imageProcessor.processImage(finalBitmap, from, minConfidence)
+      val processedImage = imageProcessor.processImage(finalBitmap, from, minConfidence, readingOrder)
       _isOcrInProgress.value = false
 
       Log.d("OCR", "complete, result ${processedImage.textBlocks}")

--- a/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
@@ -194,12 +194,23 @@ class TranslationCoordinator(
       val translatePaint =
         measureTimeMillis {
           val pair =
-            paintTranslatedTextOver(
-              processedImage.bitmap,
-              processedImage.textBlocks,
-              translatedBlocks,
-              settingsManager.settings.value.backgroundMode,
-            )
+            when (readingOrder) {
+              ReadingOrder.LEFT_TO_RIGHT ->
+                paintTranslatedTextOver(
+                  processedImage.bitmap,
+                  processedImage.textBlocks,
+                  translatedBlocks,
+                  settingsManager.settings.value.backgroundMode,
+                )
+
+              ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT ->
+                paintTranslatedTextOverVerticalBlocks(
+                  processedImage.bitmap,
+                  processedImage.textBlocks,
+                  translatedBlocks,
+                  settingsManager.settings.value.backgroundMode,
+                )
+            }
           overlayBitmap = pair.first
           allTranslatedText = pair.second
         }

--- a/app/src/main/java/dev/davidv/translator/TranslatorMessage.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslatorMessage.kt
@@ -38,6 +38,8 @@ sealed class TranslatorMessage {
 
   data object ShareTranslatedImage : TranslatorMessage()
 
+  data object ToggleJapaneseOcrMode : TranslatorMessage()
+
   data object SwapLanguages : TranslatorMessage()
 
   data object ClearInput : TranslatorMessage()

--- a/app/src/main/java/dev/davidv/translator/accessibilityOverlay/OverlayUI.kt
+++ b/app/src/main/java/dev/davidv/translator/accessibilityOverlay/OverlayUI.kt
@@ -30,6 +30,7 @@ import dev.davidv.translator.Language
 import dev.davidv.translator.MainActivity
 import dev.davidv.translator.OverlayColors
 import dev.davidv.translator.R
+import dev.davidv.translator.ReadingOrder
 import dev.davidv.translator.SettingsManager
 import dev.davidv.translator.TranslatedStyledBlock
 import dev.davidv.translator.assistantOverlay.BorderWaveView
@@ -47,6 +48,8 @@ class OverlayUI(
   private var toolbarView: View? = null
   private var sourceLabelView: TextView? = null
   private var targetLabelView: TextView? = null
+  private var readingOrderButtonView: View? = null
+  private var readingOrderIconView: ImageView? = null
   private var ocrButtonView: View? = null
   private var ocrIconView: ImageView? = null
   private val translationOverlays = mutableListOf<View>()
@@ -195,6 +198,7 @@ class OverlayUI(
   fun showToolbar(
     forcedSourceLanguage: Language?,
     forcedTargetLanguage: Language?,
+    readingOrder: ReadingOrder,
   ) {
     if (toolbarView != null) return
 
@@ -209,6 +213,9 @@ class OverlayUI(
         onSourceClick = { service.showLanguagePicker(true) },
         onSwap = { service.swapLanguages() },
         onTargetClick = { service.showLanguagePicker(false) },
+        showReadingOrderButton = forcedSourceLanguage?.code == "ja",
+        readingOrder = readingOrder,
+        onReadingOrderClick = { service.toggleJapaneseOcrMode() },
         showOcrButton = true,
         onOcrClick = { service.startManualOcrSelection() },
         onMenuClick = { service.showDotsMenu() },
@@ -216,6 +223,8 @@ class OverlayUI(
     val toolbar = toolbarViews.root
     sourceLabelView = toolbarViews.sourceLabel
     targetLabelView = toolbarViews.targetLabel
+    readingOrderButtonView = toolbarViews.readingOrderButton
+    readingOrderIconView = toolbarViews.readingOrderIcon
     ocrButtonView = toolbarViews.ocrButton
     ocrIconView = toolbarViews.ocrIcon
 
@@ -241,18 +250,27 @@ class OverlayUI(
       toolbarView = null
       sourceLabelView = null
       targetLabelView = null
+      readingOrderButtonView = null
+      readingOrderIconView = null
       ocrButtonView = null
       ocrIconView = null
     }
   }
 
-  fun updateToolbarLabels(
+  fun updateToolbarState(
     forcedSourceLanguage: Language?,
     forcedTargetLanguage: Language?,
+    readingOrder: ReadingOrder,
   ) {
     sourceLabelView?.text = forcedSourceLanguage?.shortDisplayName ?: "Auto"
     val currentTarget = forcedTargetLanguage ?: service.langStateManager.languageByCode(settingsManager.settings.value.defaultTargetLanguageCode)
     targetLabelView?.text = currentTarget?.shortDisplayName ?: "?"
+    OverlayChromeFactory.updateReadingOrderButtonState(
+      readingButton = readingOrderButtonView,
+      readingIcon = readingOrderIconView,
+      visible = forcedSourceLanguage?.code == "ja",
+      readingOrder = readingOrder,
+    )
   }
 
   fun setOcrButtonVisible(visible: Boolean) {

--- a/app/src/main/java/dev/davidv/translator/accessibilityOverlay/TranslatorAccessibilityService.kt
+++ b/app/src/main/java/dev/davidv/translator/accessibilityOverlay/TranslatorAccessibilityService.kt
@@ -23,6 +23,7 @@ import dev.davidv.translator.LanguageMetadataManager
 import dev.davidv.translator.LanguageStateManager
 import dev.davidv.translator.OCRService
 import dev.davidv.translator.OverlayTextTranslationHelper
+import dev.davidv.translator.ReadingOrder
 import dev.davidv.translator.SettingsManager
 import dev.davidv.translator.TranslatedStyledBlock
 import dev.davidv.translator.TranslationCoordinator
@@ -47,8 +48,10 @@ class TranslatorAccessibilityService : AccessibilityService() {
   private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
   private lateinit var settingsManager: SettingsManager
+  private lateinit var ocrService: OCRService
   private lateinit var imageProcessor: ImageProcessor
   private lateinit var translationCoordinator: TranslationCoordinator
+  private var ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT
   private var lastOcrBitmap: Bitmap? = null
   private var lastOcrRegion: Rect? = null
   private lateinit var overlayTextTranslationHelper: OverlayTextTranslationHelper
@@ -84,7 +87,8 @@ class TranslatorAccessibilityService : AccessibilityService() {
     val filePathManager = FilePathManager(this, settingsManager.settings)
     langStateManager = LanguageStateManager(serviceScope, filePathManager, null)
     val languageDetector = LanguageDetector(langStateManager::languageByCode)
-    imageProcessor = ImageProcessor(this, OCRService(filePathManager))
+    ocrService = OCRService(filePathManager)
+    imageProcessor = ImageProcessor(this, ocrService)
 
     serviceScope.launch {
       langStateManager.catalog.collect { catalog ->
@@ -139,6 +143,9 @@ class TranslatorAccessibilityService : AccessibilityService() {
     ui.removeFloatingButton()
     ui.dismissMenu()
     ui.cleanup()
+    if (this::ocrService.isInitialized) {
+      ocrService.cleanup()
+    }
     serviceScope.cancel()
     super.onDestroy()
   }
@@ -154,7 +161,7 @@ class TranslatorAccessibilityService : AccessibilityService() {
     ui.removeFloatingButton()
     ui.removeTranslationOverlays()
     input.showInteractionOverlay()
-    ui.showToolbar(forcedSourceLanguage, forcedTargetLanguage)
+    ui.showToolbar(forcedSourceLanguage, forcedTargetLanguage, currentReadingOrderFor(forcedSourceLanguage))
     ui.showBorderWave()
     android.os.Handler(android.os.Looper.getMainLooper()).post {
       if (active) {
@@ -181,7 +188,8 @@ class TranslatorAccessibilityService : AccessibilityService() {
     if (!canSwapLanguages(oldSource, oldTarget)) return
     forcedSourceLanguage = oldTarget
     forcedTargetLanguage = oldSource
-    ui.updateToolbarLabels(forcedSourceLanguage, forcedTargetLanguage)
+    syncReadingOrderForSource()
+    ui.updateToolbarState(forcedSourceLanguage, forcedTargetLanguage, currentReadingOrderFor(forcedSourceLanguage))
     if (active) {
       retranslate()
     }
@@ -192,13 +200,27 @@ class TranslatorAccessibilityService : AccessibilityService() {
     ui.showLanguagePicker(isSource, availableLangs) { lang ->
       if (isSource) {
         forcedSourceLanguage = lang
+        syncReadingOrderForSource()
       } else {
         forcedTargetLanguage = lang
       }
-      ui.updateToolbarLabels(forcedSourceLanguage, forcedTargetLanguage)
+      ui.updateToolbarState(forcedSourceLanguage, forcedTargetLanguage, currentReadingOrderFor(forcedSourceLanguage))
       if (active) {
         retranslate()
       }
+    }
+  }
+
+  fun toggleJapaneseOcrMode() {
+    if (forcedSourceLanguage?.code != "ja") return
+    ocrReadingOrder =
+      when (ocrReadingOrder) {
+        ReadingOrder.LEFT_TO_RIGHT -> ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT
+        ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT -> ReadingOrder.LEFT_TO_RIGHT
+      }
+    ui.updateToolbarState(forcedSourceLanguage, forcedTargetLanguage, ocrReadingOrder)
+    if (active) {
+      retranslate()
     }
   }
 
@@ -271,7 +293,7 @@ class TranslatorAccessibilityService : AccessibilityService() {
         object : TakeScreenshotCallback {
           override fun onSuccess(screenshot: ScreenshotResult) {
             input.showInteractionOverlay()
-            ui.showToolbar(forcedSourceLanguage, forcedTargetLanguage)
+            ui.showToolbar(forcedSourceLanguage, forcedTargetLanguage, currentReadingOrderFor(forcedSourceLanguage))
 
             val hwBitmap = Bitmap.wrapHardwareBuffer(screenshot.hardwareBuffer, screenshot.colorSpace)
             screenshot.hardwareBuffer.close()
@@ -305,7 +327,7 @@ class TranslatorAccessibilityService : AccessibilityService() {
           override fun onFailure(errorCode: Int) {
             Log.w(tag, "Screenshot failed: $errorCode")
             input.showInteractionOverlay()
-            ui.showToolbar(forcedSourceLanguage, forcedTargetLanguage)
+            ui.showToolbar(forcedSourceLanguage, forcedTargetLanguage, currentReadingOrderFor(forcedSourceLanguage))
             ui.setOcrButtonVisible(true)
           }
         },
@@ -322,7 +344,13 @@ class TranslatorAccessibilityService : AccessibilityService() {
 
     val result =
       withContext(Dispatchers.IO) {
-        translationCoordinator.translateImageWithOverlay(sourceLang, targetLang, bitmap) {}
+        translationCoordinator.translateImageWithOverlay(
+          sourceLang,
+          targetLang,
+          bitmap,
+          onMessage = {},
+          readingOrder = currentReadingOrderFor(sourceLang),
+        )
       }
 
     if (result != null) {
@@ -332,6 +360,19 @@ class TranslatorAccessibilityService : AccessibilityService() {
     } else {
       ui.removeTranslationOverlays()
       ui.setOcrButtonVisible(true)
+    }
+  }
+
+  private fun currentReadingOrderFor(language: Language?): ReadingOrder =
+    if (language?.code == "ja") {
+      ocrReadingOrder
+    } else {
+      ReadingOrder.LEFT_TO_RIGHT
+    }
+
+  private fun syncReadingOrderForSource() {
+    if (forcedSourceLanguage?.code != "ja") {
+      ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT
     }
   }
 

--- a/app/src/main/java/dev/davidv/translator/assistantOverlay/TranslatorVoiceInteractionSession.kt
+++ b/app/src/main/java/dev/davidv/translator/assistantOverlay/TranslatorVoiceInteractionSession.kt
@@ -29,6 +29,7 @@ import dev.davidv.translator.Language
 import dev.davidv.translator.LanguageStateManager
 import dev.davidv.translator.MainActivity
 import dev.davidv.translator.OverlayTextTranslationHelper
+import dev.davidv.translator.ReadingOrder
 import dev.davidv.translator.SettingsManager
 import dev.davidv.translator.StyledFragment
 import dev.davidv.translator.TranslatedStyledBlock
@@ -82,6 +83,8 @@ class TranslatorVoiceInteractionSession(
   private lateinit var topBarView: View
   private var sourceLabelView: TextView? = null
   private var targetLabelView: TextView? = null
+  private var readingOrderButtonView: View? = null
+  private var readingOrderIconView: ImageView? = null
   private var ocrButtonView: View? = null
   private var ocrIconView: ImageView? = null
   private var menuManager: OverlayMenuManager? = null
@@ -107,6 +110,7 @@ class TranslatorVoiceInteractionSession(
   private var translationJob: Job? = null
   private var forcedSourceLanguage: Language? = null
   private var forcedTargetLanguage: Language? = null
+  private var ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT
   private var lastOcrBitmap: Bitmap? = null
   private var lastOcrRegion: Rect? = null
   private var assistFallbackMessageShown = false
@@ -590,7 +594,7 @@ class TranslatorVoiceInteractionSession(
       sessionScope.launch {
         val result =
           withContext(Dispatchers.IO) {
-            translationCoordinator.translateImageWithOverlay(sourceLanguage, targetLanguage, workingBitmap) {}
+            translationCoordinator.translateImageWithOverlay(sourceLanguage, targetLanguage, workingBitmap, onMessage = {})
           }
         ensureActive()
         processing = false
@@ -785,7 +789,13 @@ class TranslatorVoiceInteractionSession(
       sessionScope.launch {
         val result =
           withContext(Dispatchers.IO) {
-            translationCoordinator.translateImageWithOverlay(sourceLanguage, targetLanguage, bitmap) {}
+            translationCoordinator.translateImageWithOverlay(
+              sourceLanguage,
+              targetLanguage,
+              bitmap,
+              onMessage = {},
+              readingOrder = currentReadingOrderFor(sourceLanguage),
+            )
           }
         ensureActive()
         processing = false
@@ -937,12 +947,17 @@ class TranslatorVoiceInteractionSession(
         onSourceClick = { showLanguagePicker(true) },
         onSwap = { swapLanguages() },
         onTargetClick = { showLanguagePicker(false) },
+        showReadingOrderButton = forcedSourceLanguage?.code == "ja",
+        readingOrder = currentReadingOrderFor(forcedSourceLanguage),
+        onReadingOrderClick = { toggleJapaneseOcrMode() },
         showOcrButton = true,
         onOcrClick = { startManualOcrSelection() },
         onMenuClick = { showDotsMenu() },
       )
     sourceLabelView = toolbarViews.sourceLabel
     targetLabelView = toolbarViews.targetLabel
+    readingOrderButtonView = toolbarViews.readingOrderButton
+    readingOrderIconView = toolbarViews.readingOrderIcon
     ocrButtonView = toolbarViews.ocrButton
     ocrIconView = toolbarViews.ocrIcon
     return toolbarViews.root
@@ -989,6 +1004,7 @@ class TranslatorVoiceInteractionSession(
     val oldTarget = forcedTargetLanguage ?: langStateManager.languageByCode(settingsManager.settings.value.defaultTargetLanguageCode) ?: return
     forcedSourceLanguage = oldTarget
     forcedTargetLanguage = oldSource
+    syncReadingOrderForSource()
     updateToolbarLabels()
     retranslate()
   }
@@ -1014,6 +1030,12 @@ class TranslatorVoiceInteractionSession(
     sourceLabelView?.text = forcedSourceLanguage?.shortDisplayName ?: "Auto"
     val currentTarget = forcedTargetLanguage ?: langStateManager.languageByCode(settingsManager.settings.value.defaultTargetLanguageCode)
     targetLabelView?.text = currentTarget?.shortDisplayName ?: "?"
+    OverlayChromeFactory.updateReadingOrderButtonState(
+      readingButton = readingOrderButtonView,
+      readingIcon = readingOrderIconView,
+      visible = forcedSourceLanguage?.code == "ja",
+      readingOrder = currentReadingOrderFor(forcedSourceLanguage),
+    )
   }
 
   private fun showLanguagePicker(isSource: Boolean) {
@@ -1023,11 +1045,36 @@ class TranslatorVoiceInteractionSession(
     ) { language ->
       if (isSource) {
         forcedSourceLanguage = language
+        syncReadingOrderForSource()
       } else {
         forcedTargetLanguage = language
       }
       updateToolbarLabels()
       retranslate()
+    }
+  }
+
+  private fun toggleJapaneseOcrMode() {
+    if (forcedSourceLanguage?.code != "ja") return
+    ocrReadingOrder =
+      when (ocrReadingOrder) {
+        ReadingOrder.LEFT_TO_RIGHT -> ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT
+        ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT -> ReadingOrder.LEFT_TO_RIGHT
+      }
+    updateToolbarLabels()
+    retranslate()
+  }
+
+  private fun currentReadingOrderFor(language: Language?): ReadingOrder =
+    if (language?.code == "ja") {
+      ocrReadingOrder
+    } else {
+      ReadingOrder.LEFT_TO_RIGHT
+    }
+
+  private fun syncReadingOrderForSource() {
+    if (forcedSourceLanguage?.code != "ja") {
+      ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT
     }
   }
 

--- a/app/src/main/java/dev/davidv/translator/assistantOverlay/TranslatorVoiceInteractionSessionService.kt
+++ b/app/src/main/java/dev/davidv/translator/assistantOverlay/TranslatorVoiceInteractionSessionService.kt
@@ -25,6 +25,7 @@ class TranslatorVoiceInteractionSessionService : VoiceInteractionSessionService(
   private lateinit var settingsManager: SettingsManager
   private lateinit var filePathManager: FilePathManager
   private lateinit var languageMetadataManager: LanguageMetadataManager
+  private lateinit var ocrService: OCRService
   private lateinit var imageProcessor: ImageProcessor
   private lateinit var translationCoordinator: TranslationCoordinator
   private lateinit var overlayTextTranslationHelper: OverlayTextTranslationHelper
@@ -38,7 +39,8 @@ class TranslatorVoiceInteractionSessionService : VoiceInteractionSessionService(
     val catalog = filePathManager.loadCatalog()
     val languagesFlow = kotlinx.coroutines.flow.MutableStateFlow(catalog?.languageList ?: emptyList())
     languageMetadataManager = LanguageMetadataManager(this, languagesFlow)
-    imageProcessor = ImageProcessor(this, OCRService(filePathManager))
+    ocrService = OCRService(filePathManager)
+    imageProcessor = ImageProcessor(this, ocrService)
     val english = catalog?.english ?: dev.davidv.translator.Language(code = "en", displayName = "English", shortDisplayName = "EN", tessName = "eng", script = "Latn", dictionaryCode = "en", tessdataSizeBytes = 0, toEnglish = null, fromEnglish = null, extraFiles = emptyList())
     translationCoordinator =
       TranslationCoordinator(
@@ -67,6 +69,9 @@ class TranslatorVoiceInteractionSessionService : VoiceInteractionSessionService(
     )
 
   override fun onDestroy() {
+    if (this::ocrService.isInitialized) {
+      ocrService.cleanup()
+    }
     serviceScope.cancel()
     super.onDestroy()
   }

--- a/app/src/main/java/dev/davidv/translator/overlayChrome/OverlayChromeFactory.kt
+++ b/app/src/main/java/dev/davidv/translator/overlayChrome/OverlayChromeFactory.kt
@@ -14,11 +14,14 @@ import android.widget.ScrollView
 import android.widget.TextView
 import dev.davidv.translator.Language
 import dev.davidv.translator.R
+import dev.davidv.translator.ReadingOrder
 
 data class LanguageToolbarViews(
   val root: View,
   val sourceLabel: TextView,
   val targetLabel: TextView,
+  val readingOrderButton: View? = null,
+  val readingOrderIcon: ImageView? = null,
   val ocrButton: View? = null,
   val ocrIcon: ImageView? = null,
 )
@@ -36,6 +39,9 @@ object OverlayChromeFactory {
     onSourceClick: () -> Unit,
     onSwap: () -> Unit,
     onTargetClick: () -> Unit,
+    showReadingOrderButton: Boolean = false,
+    readingOrder: ReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
+    onReadingOrderClick: (() -> Unit)? = null,
     showOcrButton: Boolean = false,
     onOcrClick: (() -> Unit)? = null,
     onMenuClick: () -> Unit,
@@ -57,6 +63,33 @@ object OverlayChromeFactory {
         gravity = Gravity.START or Gravity.CENTER_VERTICAL
       },
     )
+
+    var readingOrderIcon: ImageView? = null
+    val readingOrderPill =
+      onReadingOrderClick?.let {
+        val readingBtn =
+          ImageView(context).apply {
+            setPadding(iconPad, iconPad, iconPad, iconPad)
+            setOnClickListener { onReadingOrderClick() }
+          }
+        readingOrderIcon = readingBtn
+        updateReadingOrderButtonState(
+          readingButton = null,
+          readingIcon = readingBtn,
+          visible = showReadingOrderButton,
+          readingOrder = readingOrder,
+        )
+        makePill(context, dpToPx, readingBtn).also { pill ->
+          pill.visibility = if (showReadingOrderButton) View.VISIBLE else View.GONE
+          toolbar.addView(
+            pill,
+            FrameLayout.LayoutParams(btnSize, btnSize).apply {
+              gravity = Gravity.START or Gravity.CENTER_VERTICAL
+              leftMargin = btnSize + dpToPx(6)
+            },
+          )
+        }
+      }
 
     val langRow = LinearLayout(context)
     langRow.orientation = LinearLayout.HORIZONTAL
@@ -142,7 +175,22 @@ object OverlayChromeFactory {
       },
     )
 
-    return LanguageToolbarViews(toolbar, sourceLabel, targetLabel, ocrPill, ocrIcon)
+    return LanguageToolbarViews(toolbar, sourceLabel, targetLabel, readingOrderPill, readingOrderIcon, ocrPill, ocrIcon)
+  }
+
+  fun updateReadingOrderButtonState(
+    readingButton: View?,
+    readingIcon: ImageView?,
+    visible: Boolean,
+    readingOrder: ReadingOrder,
+  ) {
+    readingButton?.visibility = if (visible) View.VISIBLE else View.GONE
+    readingIcon?.apply {
+      val isVertical = readingOrder == ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT
+      setImageResource(if (isVertical) R.drawable.text_rotate_vertical else R.drawable.text_rotation_none)
+      setColorFilter(Color.WHITE)
+      contentDescription = if (isVertical) "Japanese OCR vertical mode" else "Japanese OCR horizontal mode"
+    }
   }
 
   fun setOcrButtonActive(

--- a/app/src/main/java/dev/davidv/translator/ui/TranslatorViewModel.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/TranslatorViewModel.kt
@@ -32,6 +32,7 @@ import dev.davidv.translator.LanguageMetadataManager
 import dev.davidv.translator.LanguageStateManager
 import dev.davidv.translator.LaunchMode
 import dev.davidv.translator.PcmAudio
+import dev.davidv.translator.ReadingOrder
 import dev.davidv.translator.SettingsManager
 import dev.davidv.translator.SpeechSynthesisResult
 import dev.davidv.translator.TarkkaBinding
@@ -90,6 +91,9 @@ class TranslatorViewModel(
   val displayImage: StateFlow<Bitmap?> = _displayImage.asStateFlow()
 
   private val originalImage = MutableStateFlow<Bitmap?>(null)
+
+  private val _ocrReadingOrder = MutableStateFlow(ReadingOrder.LEFT_TO_RIGHT)
+  val ocrReadingOrder: StateFlow<ReadingOrder> = _ocrReadingOrder.asStateFlow()
 
   private val _inputType = MutableStateFlow(InputType.TEXT)
   val inputType: StateFlow<InputType> = _inputType.asStateFlow()
@@ -306,9 +310,11 @@ class TranslatorViewModel(
                 fromLang,
                 toLang,
                 bm,
-              ) { imageTextDetected ->
-                _input.value = imageTextDetected.extractedText
-              }
+                onMessage = { imageTextDetected ->
+                  _input.value = imageTextDetected.extractedText
+                },
+                readingOrder = currentReadingOrderFor(fromLang),
+              )
             result?.let {
               _displayImage.value = it.correctedBitmap
               _output.value = TranslatedText(it.translatedText, null)
@@ -334,6 +340,18 @@ class TranslatorViewModel(
         _inputType.value = InputType.TEXT
         originalImage.value = null
         _currentDetectedLanguage.value = null
+      }
+
+      TranslatorMessage.ToggleJapaneseOcrMode -> {
+        _ocrReadingOrder.value =
+          when (_ocrReadingOrder.value) {
+            ReadingOrder.LEFT_TO_RIGHT -> ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT
+            ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT -> ReadingOrder.LEFT_TO_RIGHT
+          }
+        val fromLang = _from.value
+        if (_inputType.value == InputType.IMAGE && fromLang?.code == "ja") {
+          triggerTranslation()
+        }
       }
 
       is TranslatorMessage.InitializeLanguages -> {
@@ -462,9 +480,11 @@ class TranslatorViewModel(
               fromLang,
               toLang,
               bm,
-            ) { imageTextDetected ->
-              _input.value = imageTextDetected.extractedText
-            }
+              onMessage = { imageTextDetected ->
+                _input.value = imageTextDetected.extractedText
+              },
+              readingOrder = currentReadingOrderFor(fromLang),
+            )
           result?.let {
             _displayImage.value = it.correctedBitmap
             _output.value = TranslatedText(it.translatedText, null)
@@ -473,6 +493,13 @@ class TranslatorViewModel(
       }
     }
   }
+
+  private fun currentReadingOrderFor(fromLang: Language): ReadingOrder =
+    if (fromLang.code == "ja") {
+      _ocrReadingOrder.value
+    } else {
+      ReadingOrder.LEFT_TO_RIGHT
+    }
 
   private suspend fun autoTranslateInitialText(
     initialText: String,

--- a/app/src/main/java/dev/davidv/translator/ui/screens/MainScreen.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/MainScreen.kt
@@ -25,6 +25,7 @@ import android.util.Log
 import android.widget.TextView
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -38,6 +39,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FloatingActionButton
@@ -76,6 +78,7 @@ import dev.davidv.translator.Language
 import dev.davidv.translator.LanguageMetadata
 import dev.davidv.translator.LaunchMode
 import dev.davidv.translator.R
+import dev.davidv.translator.ReadingOrder
 import dev.davidv.translator.TranslatedText
 import dev.davidv.translator.TranslatorMessage
 import dev.davidv.translator.WordWithTaggedEntries
@@ -105,6 +108,7 @@ fun MainScreen(
   to: Language,
   detectedLanguage: Language?,
   displayImage: Bitmap?,
+  ocrReadingOrder: ReadingOrder,
   isTranslating: StateFlow<Boolean>,
   isOcrInProgress: StateFlow<Boolean>,
   dictionaryWord: WordWithTaggedEntries?,
@@ -242,9 +246,21 @@ fun MainScreen(
                   isTranslating = isTranslating,
                   onShowFullScreenImage = { showFullScreenImage = true },
                 )
-                Row(modifier = Modifier.align(Alignment.TopEnd)) {
-                  ClearInput(onMessage)
+                Row(
+                  modifier =
+                    Modifier
+                      .align(Alignment.TopEnd)
+                      .padding(8.dp),
+                  horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                  if (from.code == "ja") {
+                    JapaneseOcrModeToggle(
+                      readingOrder = ocrReadingOrder,
+                      onMessage = onMessage,
+                    )
+                  }
                   ShareImage(onMessage)
+                  ClearInput(onMessage)
                 }
               }
             }
@@ -430,41 +446,42 @@ fun MainScreen(
 
 @Composable
 fun ShareImage(onMessage: (TranslatorMessage) -> Unit) {
-  IconButton(
+  ActionPillButton(
+    iconRes = R.drawable.share,
+    contentDescription = "Share image",
     onClick = { onMessage(TranslatorMessage.ShareTranslatedImage) },
-    modifier =
-      Modifier
-        .size(32.dp),
-  ) {
-    Icon(
-      painterResource(id = R.drawable.share),
-      contentDescription = "Share image",
-      tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-    )
-  }
+  )
+}
+
+@Composable
+fun JapaneseOcrModeToggle(
+  readingOrder: ReadingOrder,
+  onMessage: (TranslatorMessage) -> Unit,
+) {
+  val isVertical = readingOrder == ReadingOrder.TOP_TO_BOTTOM_LEFT_TO_RIGHT
+  ActionPillButton(
+    iconRes = if (isVertical) R.drawable.text_rotate_vertical else R.drawable.text_rotation_none,
+    contentDescription = if (isVertical) "Japanese OCR vertical mode" else "Japanese OCR horizontal mode",
+    onClick = { onMessage(TranslatorMessage.ToggleJapaneseOcrMode) },
+  )
 }
 
 @Composable
 fun ClearInput(onMessage: (TranslatorMessage) -> Unit) {
-  IconButton(
+  ActionPillButton(
+    iconRes = R.drawable.cancel,
+    contentDescription = "Clear input",
     onClick = { onMessage(TranslatorMessage.ClearInput) },
-    modifier =
-      Modifier
-        .size(32.dp),
-  ) {
-    Icon(
-      painterResource(id = R.drawable.cancel),
-      contentDescription = "Clear input",
-      tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-    )
-  }
+  )
 }
 
 @Composable
 fun PasteButton(onMessage: (TranslatorMessage) -> Unit) {
   val context = LocalContext.current
 
-  IconButton(
+  ActionPillButton(
+    iconRes = R.drawable.paste,
+    contentDescription = "Paste",
     onClick = {
       val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
       val clipData = clipboardManager.primaryClip
@@ -473,15 +490,29 @@ fun PasteButton(onMessage: (TranslatorMessage) -> Unit) {
         onMessage(TranslatorMessage.TextInput(text))
       }
     },
-    modifier =
-      Modifier
-        .size(32.dp),
+  )
+}
+
+@Composable
+private fun ActionPillButton(
+  iconRes: Int,
+  contentDescription: String,
+  onClick: () -> Unit,
+) {
+  Surface(
+    shape = CircleShape,
+    color = Color(0xCC303030),
   ) {
-    Icon(
-      painterResource(id = R.drawable.paste),
-      contentDescription = "Paste",
-      tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-    )
+    IconButton(
+      onClick = onClick,
+      modifier = Modifier.size(36.dp),
+    ) {
+      Icon(
+        painterResource(id = iconRes),
+        contentDescription = contentDescription,
+        tint = Color.White,
+      )
+    }
   }
 }
 
@@ -541,6 +572,7 @@ fun PopupMode() {
       to = previewLanguage("es", "Spanish"),
       detectedLanguage = previewLanguage("fr", "French"),
       displayImage = null,
+      ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
       isTranslating = MutableStateFlow(false).asStateFlow(),
       isOcrInProgress = MutableStateFlow(false).asStateFlow(),
       launchMode = LaunchMode.ReadWriteModal {},
@@ -577,6 +609,7 @@ fun MainScreenPreview() {
       to = previewLanguage("es", "Spanish"),
       detectedLanguage = previewLanguage("fr", "French"),
       displayImage = null,
+      ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
       isTranslating = MutableStateFlow(false).asStateFlow(),
       isOcrInProgress = MutableStateFlow(false).asStateFlow(),
       launchMode = LaunchMode.Normal,
@@ -617,6 +650,7 @@ fun PreviewTranslitText() {
       to = previewLanguage("en", "English"),
       detectedLanguage = null,
       displayImage = null,
+      ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
       isTranslating = MutableStateFlow(false).asStateFlow(),
       isOcrInProgress = MutableStateFlow(false).asStateFlow(),
       launchMode = LaunchMode.Normal,
@@ -658,6 +692,7 @@ fun PreviewVeryLongText() {
       to = previewLanguage("en", "English"),
       detectedLanguage = null,
       displayImage = null,
+      ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
       isTranslating = MutableStateFlow(false).asStateFlow(),
       isOcrInProgress = MutableStateFlow(false).asStateFlow(),
       launchMode = LaunchMode.Normal,
@@ -703,6 +738,7 @@ fun PreviewVeryLongTextImage() {
       to = previewLanguage("en", "English"),
       detectedLanguage = null,
       displayImage = bitmap,
+      ocrReadingOrder = ReadingOrder.LEFT_TO_RIGHT,
       isTranslating = MutableStateFlow(false).asStateFlow(),
       isOcrInProgress = MutableStateFlow(false).asStateFlow(),
       launchMode = LaunchMode.Normal,

--- a/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
@@ -169,6 +169,7 @@ fun TranslatorApp(
   val from by viewModel.from.collectAsState()
   val to by viewModel.to.collectAsState()
   val displayImage by viewModel.displayImage.collectAsState()
+  val ocrReadingOrder by viewModel.ocrReadingOrder.collectAsState()
   val currentDetectedLanguage by viewModel.currentDetectedLanguage.collectAsState()
   val currentLaunchMode by viewModel.currentLaunchMode.collectAsState()
   val modalVisible by viewModel.modalVisible.collectAsState()
@@ -376,6 +377,7 @@ fun TranslatorApp(
                 to = currentTo,
                 detectedLanguage = currentDetectedLanguage,
                 displayImage = displayImage,
+                ocrReadingOrder = ocrReadingOrder,
                 isTranslating = viewModel.translationCoordinator.isTranslating,
                 isOcrInProgress = viewModel.translationCoordinator.isOcrInProgress,
                 dictionaryWord = dictionaryWord,

--- a/app/src/main/res/drawable/text_rotate_vertical.xml
+++ b/app/src/main/res/drawable/text_rotate_vertical.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#FF1F1F1F"
+        android:pathData="M436,640l164,-440h80l164,440h-76l-40,-112H552l-40,112h-76zM574,464h132l-64,-182h-4l-64,182zM240,800L100,660l56,-56 44,42V120h80v526l44,-42 56,56 -140,140z" />
+</vector>

--- a/app/src/main/res/drawable/text_rotation_none.xml
+++ b/app/src/main/res/drawable/text_rotation_none.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#FF1F1F1F"
+        android:pathData="M160,760v-80h528l-42,-42 56,-56 138,138 -138,138 -56,-56 42,-42H160zM276,560l164,-440h80l164,440h-76l-38,-112H392l-40,112h-76zM414,384h132l-64,-182h-4l-64,182z" />
+</vector>

--- a/generate_v2.py
+++ b/generate_v2.py
@@ -81,6 +81,25 @@ def make_support_pack_id(language_code: str, file_name: str) -> str:
     return f"support-{language_code}-{stem}"
 
 
+OCR_EXTRA_TRAINEDDATA = {
+    "ja": [
+        {
+            "name": "jpn_vert.traineddata",
+            "sizeBytes": 14330809,
+            "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_best/refs/heads/main/jpn_vert.traineddata",
+        }
+    ]
+}
+
+OCR_PRIMARY_TRAINEDDATA_OVERRIDES = {
+    "ja": {
+        "name": "jpn.traineddata",
+        "sizeBytes": 14330109,
+        "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_best/refs/heads/main/jpn.traineddata",
+    }
+}
+
+
 def language_meta_entry(lang: dict) -> dict:
     return {
         "code": lang["code"],
@@ -162,19 +181,35 @@ def convert_v1_to_v2(language_index: dict, dictionary_index: dict) -> dict:
             add_language_asset_ref(languages_v2[to_code], "translate", pack_id)
 
         ocr_pack_id = make_ocr_pack_id("tesseract", code)
+        primary_traineddata = OCR_PRIMARY_TRAINEDDATA_OVERRIDES.get(code)
+        primary_name = primary_traineddata["name"] if primary_traineddata else f"{lang['tessName']}.traineddata"
+        primary_size = int(primary_traineddata["sizeBytes"]) if primary_traineddata else int(lang["tessdataSizeBytes"])
+        primary_url = primary_traineddata["url"] if primary_traineddata else f"{tesseract_base_url}/{lang['tessName']}.traineddata"
+        ocr_files = [
+            make_file(
+                name=primary_name,
+                size_bytes=primary_size,
+                install_path=f"tesseract/tessdata/{primary_name}",
+                url=primary_url,
+                source_path=None if primary_traineddata else f"{lang['tessName']}.traineddata",
+            )
+        ]
+        for extra_traineddata in OCR_EXTRA_TRAINEDDATA.get(code, []):
+            name = extra_traineddata["name"]
+            ocr_files.append(
+                make_file(
+                    name=name,
+                    size_bytes=int(extra_traineddata["sizeBytes"]),
+                    install_path=f"tesseract/tessdata/{name}",
+                    url=extra_traineddata.get("url", f"{tesseract_base_url}/{name}"),
+                    source_path=None if extra_traineddata.get("url") else name,
+                )
+            )
         packs[ocr_pack_id] = {
             "feature": "ocr",
             "engine": "tesseract",
             "language": code,
-            "files": [
-                make_file(
-                    name=f"{lang['tessName']}.traineddata",
-                    size_bytes=int(lang["tessdataSizeBytes"]),
-                    install_path=f"tesseract/tessdata/{lang['tessName']}.traineddata",
-                    url=f"{tesseract_base_url}/{lang['tessName']}.traineddata",
-                    source_path=f"{lang['tessName']}.traineddata",
-                )
-            ],
+            "files": ocr_files,
             "dependsOn": [] if code == "en" else [make_ocr_pack_id("tesseract", "en")],
         }
         add_language_asset_ref(language_entry, "ocr", {"tesseract": ocr_pack_id})


### PR DESCRIPTION
This version:
- Uses the 'best' model for japanese (instead of 'fast'), which improves quality a little bit
- Exposes a toggle for vertical text

Still, the Japanese mode is not very good. Stylized kanji fail almost 100% of the time. 

https://github.com/user-attachments/assets/b3e07de9-01ba-482a-83c3-70ffdf15df61


Fixes #131 