### PR TITLE
Add Kokoro support (Japanese & Korean TTS)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -104,12 +104,13 @@ val ndk = "$androidSdkRoot/ndk/28.0.12674087"
 val bindingsAndroidApi = 28
 val onnxRuntimeRootDir = file("../third_party/onnxruntime")
 val onnxRuntimeSourceFingerprint =
-  providers.exec {
-    workingDir = onnxRuntimeRootDir
-    commandLine(
-      "bash",
-      "-lc",
-      """
+  providers
+    .exec {
+      workingDir = onnxRuntimeRootDir
+      commandLine(
+        "bash",
+        "-lc",
+        """
         set -euo pipefail
         if [ ! -e .git ]; then
           echo missing
@@ -120,11 +121,9 @@ val onnxRuntimeSourceFingerprint =
         git status --short --untracked-files=normal
         git submodule status --recursive
         git submodule foreach --quiet --recursive 'printf "%s\n" "${'$'}displaypath"; git rev-parse HEAD; git stash create || true; git status --short --untracked-files=normal'
-      """
-        .trimIndent(),
-    )
-  }
-    .standardOutput
+        """.trimIndent(),
+      )
+    }.standardOutput
     .asText
     .map(String::trim)
 
@@ -206,6 +205,7 @@ val abiToOnnxRuntimeTask =
           "--disable_ml_ops",
           "--disable_generation_ops",
           "--no_kleidiai",
+          "--use_xnnpack",
           "--no_sve",
           "--cmake_extra_defines",
           "CMAKE_CXX_STANDARD=20",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -211,6 +211,7 @@ val abiToOnnxRuntimeTask =
           "CMAKE_CXX_STANDARD=20",
           "CMAKE_CXX_STANDARD_REQUIRED=ON",
           "CMAKE_CXX_EXTENSIONS=OFF",
+          "onnxruntime_USE_ARM_NEON_NCHWC=ON",
           "--skip_submodule_sync",
         )
       }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -48,9 +48,11 @@
 # Keep Mucab native library integration
 -keep class dev.davidv.translator.MucabBinding { *; }
 
-# Keep classes instantiated directly from Rust/JNI
+# Keep speech JNI entrypoints and classes instantiated directly from Rust/JNI
+-keep class dev.davidv.translator.SpeechBinding { *; }
 -keep class dev.davidv.translator.PcmAudio { *; }
 -keep class dev.davidv.translator.NativePhonemeChunk { *; }
+-keep class dev.davidv.translator.NativeTtsVoice { *; }
 
 -keepclasseswithmembernames class * {
     native <methods>;

--- a/app/src/main/assets/index.json
+++ b/app/src/main/assets/index.json
@@ -1,6 +1,6 @@
 {
   "formatVersion": 2,
-  "generatedAt": 1775919157,
+  "generatedAt": 1775921546,
   "translationModelsBaseUrl": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data",
   "tesseractModelsBaseUrl": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main",
   "dictionaryBaseUrl": "https://translator.davidv.dev/dictionaries",
@@ -826,10 +826,18 @@
         "ocr": {
           "tesseract": "ocr-tesseract-ja"
         },
-        "support": [
-          "support-ja-mucab"
-        ],
         "dictionary": "dict-ja"
+      },
+      "tts": {
+        "defaultRegion": "JP",
+        "regions": {
+          "JP": {
+            "displayName": "Japan",
+            "voices": [
+              "tts-kokoro-ja-jp-jf-alpha-kokoro-v1.0"
+            ]
+          }
+        }
       }
     },
     "kn": {
@@ -866,6 +874,17 @@
           "tesseract": "ocr-tesseract-ko"
         },
         "dictionary": "dict-ko"
+      },
+      "tts": {
+        "defaultRegion": "KR",
+        "regions": {
+          "KR": {
+            "displayName": "South Korea",
+            "voices": [
+              "tts-kokoro-ko-kr-jf-alpha-kokoro-v1.0"
+            ]
+          }
+        }
       }
     },
     "lt": {
@@ -2101,7 +2120,9 @@
           "sourcePath": "1/ja.dict"
         }
       ],
-      "dependsOn": [],
+      "dependsOn": [
+        "support-ja-mucab"
+      ],
       "metadata": {
         "date": 1758204389,
         "type": "bilingual",
@@ -6874,6 +6895,36 @@
         "tts-espeak-core-v1"
       ]
     },
+    "tts-espeak-dict-ja": {
+      "feature": "support",
+      "kind": "tts-espeak-dict",
+      "files": [
+        {
+          "name": "ja_dict",
+          "sizeBytes": 0,
+          "installPath": "bin/espeak-ng-data/ja_dict",
+          "url": "https://translator.davidv.dev/tts/1/espeak-ng-data/ja_dict"
+        }
+      ],
+      "dependsOn": [
+        "tts-espeak-core-v1"
+      ]
+    },
+    "tts-espeak-dict-ko": {
+      "feature": "support",
+      "kind": "tts-espeak-dict",
+      "files": [
+        {
+          "name": "ko_dict",
+          "sizeBytes": 0,
+          "installPath": "bin/espeak-ng-data/ko_dict",
+          "url": "https://translator.davidv.dev/tts/1/espeak-ng-data/ko_dict"
+        }
+      ],
+      "dependsOn": [
+        "tts-espeak-core-v1"
+      ]
+    },
     "tts-espeak-dict-lv": {
       "feature": "support",
       "kind": "tts-espeak-dict",
@@ -7128,6 +7179,25 @@
       "dependsOn": [
         "tts-espeak-core-v1"
       ]
+    },
+    "tts-kokoro-v1.0-core": {
+      "feature": "support",
+      "kind": "tts-kokoro-core",
+      "files": [
+        {
+          "name": "kokoro-v1.0.int8.onnx",
+          "sizeBytes": 92361271,
+          "installPath": "bin/kokoro/kokoro-v1.0.int8.onnx",
+          "url": "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.int8.onnx"
+        },
+        {
+          "name": "voices-v1.0.bin",
+          "sizeBytes": 28214398,
+          "installPath": "bin/kokoro/voices-v1.0.bin",
+          "url": "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin"
+        }
+      ],
+      "dependsOn": []
     },
     "tts-piper-ar-jo-kareem-medium": {
       "feature": "tts",
@@ -8698,6 +8768,39 @@
       ],
       "dependsOn": [
         "tts-espeak-dict-it"
+      ]
+    },
+    "tts-kokoro-ja-jp-jf-alpha-kokoro-v1.0": {
+      "feature": "tts",
+      "engine": "kokoro",
+      "language": "ja",
+      "locale": "ja_JP",
+      "region": "JP",
+      "voice": "jf_alpha",
+      "quality": "medium",
+      "numSpeakers": 1,
+      "aliases": [],
+      "files": [],
+      "dependsOn": [
+        "tts-espeak-dict-ja",
+        "tts-kokoro-v1.0-core",
+        "support-ja-mucab"
+      ]
+    },
+    "tts-kokoro-ko-kr-jf-alpha-kokoro-v1.0": {
+      "feature": "tts",
+      "engine": "kokoro",
+      "language": "ko",
+      "locale": "ko_KR",
+      "region": "KR",
+      "voice": "jf_alpha",
+      "quality": "medium",
+      "numSpeakers": 1,
+      "aliases": [],
+      "files": [],
+      "dependsOn": [
+        "tts-espeak-dict-ko",
+        "tts-kokoro-v1.0-core"
       ]
     },
     "tts-piper-lv-lv-aivars-medium": {

--- a/app/src/main/bindings/Cargo.lock
+++ b/app/src/main/bindings/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "espeak-rs"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#1bbbc96c94f0930b234253c7e04fe016049697ad"
+source = "git+https://github.com/DavidVentura/piper-rs#ec2ad26c7f861b9f5ee357462ad1dfba629d3c17"
 dependencies = [
  "espeak-rs-sys",
 ]
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "espeak-rs-sys"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#1bbbc96c94f0930b234253c7e04fe016049697ad"
+source = "git+https://github.com/DavidVentura/piper-rs#ec2ad26c7f861b9f5ee357462ad1dfba629d3c17"
 dependencies = [
  "bindgen 0.69.5",
  "cmake",
@@ -1031,7 +1031,7 @@ dependencies = [
 [[package]]
 name = "mucab"
 version = "0.1.0"
-source = "git+https://github.com/DavidVentura/mucab#d2b31acf7253fd00d9c5c487400dcb25b5a32d99"
+source = "git+https://github.com/DavidVentura/mucab#d65aafbb0c0b83c7aa58eb4e1e3c9f54c05bd48f"
 dependencies = [
  "encoding_rs",
  "glob",
@@ -1224,7 +1224,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "piper-rs"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#1bbbc96c94f0930b234253c7e04fe016049697ad"
+source = "git+https://github.com/DavidVentura/piper-rs#ec2ad26c7f861b9f5ee357462ad1dfba629d3c17"
 dependencies = [
  "espeak-rs",
  "mucab",

--- a/app/src/main/bindings/Cargo.lock
+++ b/app/src/main/bindings/Cargo.lock
@@ -3,12 +3,27 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -106,6 +121,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -194,6 +230,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +329,7 @@ dependencies = [
 [[package]]
 name = "espeak-rs"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#665f7c2896c3ba14c2588021231d27101c44e081"
+source = "git+https://github.com/DavidVentura/piper-rs#1bbbc96c94f0930b234253c7e04fe016049697ad"
 dependencies = [
  "espeak-rs-sys",
 ]
@@ -240,7 +337,7 @@ dependencies = [
 [[package]]
 name = "espeak-rs-sys"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#665f7c2896c3ba14c2588021231d27101c44e081"
+source = "git+https://github.com/DavidVentura/piper-rs#1bbbc96c94f0930b234253c7e04fe016049697ad"
 dependencies = [
  "bindgen 0.69.5",
  "cmake",
@@ -265,6 +362,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +398,12 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "home"
@@ -687,6 +810,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e10b0e5e87a2c84bd5fa407705732052edebe69291d347d0c3033785470edbf"
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,7 +869,7 @@ dependencies = [
  "combine",
  "jni-sys 0.3.1",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -799,7 +932,7 @@ checksum = "cc7a74c43d6f090d39158d233f326f47cd8bba545217595c93662b4e31156f42"
 dependencies = [
  "leptonica-sys",
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -886,9 +1019,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mucab"
 version = "0.1.0"
-source = "git+https://github.com/DavidVentura/mucab#7d1a1b7dfa33fe5cdb08f844c80f3624048645b1"
+source = "git+https://github.com/DavidVentura/mucab#d2b31acf7253fd00d9c5c487400dcb25b5a32d99"
 dependencies = [
  "encoding_rs",
  "glob",
@@ -924,6 +1067,20 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "ndarray-npy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b313788c468c49141a9d9b6131fc15f403e6ef4e8446a0b2e18f664ddb278a9"
+dependencies = [
+ "byteorder",
+ "ndarray 0.16.1",
+ "num-complex",
+ "num-traits",
+ "py_literal",
+ "zip",
 ]
 
 [[package]]
@@ -1016,6 +1173,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,10 +1224,12 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "piper-rs"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#665f7c2896c3ba14c2588021231d27101c44e081"
+source = "git+https://github.com/DavidVentura/piper-rs#1bbbc96c94f0930b234253c7e04fe016049697ad"
 dependencies = [
  "espeak-rs",
+ "mucab",
  "ndarray 0.16.1",
+ "ndarray-npy",
  "ort",
  "serde",
  "serde_json",
@@ -1083,6 +1285,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "py_literal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-traits",
+ "pest",
+ "pest_derive",
 ]
 
 [[package]]
@@ -1213,10 +1428,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -1291,7 +1523,7 @@ source = "git+https://github.com/DavidVentura/tesseract-rs#076ad96fe4521b542e7e8
 dependencies = [
  "tesseract-plumbing",
  "tesseract-sys",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1301,7 +1533,7 @@ source = "git+https://github.com/DavidVentura/tesseract-plumbing#52a33a992a7988d
 dependencies = [
  "leptonica-plumbing",
  "tesseract-sys",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1321,7 +1553,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1329,6 +1570,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1381,6 +1633,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1676,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1717,10 +1987,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd-safe"

--- a/app/src/main/bindings/Cargo.lock
+++ b/app/src/main/bindings/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "espeak-rs"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#ec2ad26c7f861b9f5ee357462ad1dfba629d3c17"
+source = "git+https://github.com/DavidVentura/piper-rs#2dbdc08e5ce3a615c8ca8f239d0c13820e284d1d"
 dependencies = [
  "espeak-rs-sys",
 ]
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "espeak-rs-sys"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#ec2ad26c7f861b9f5ee357462ad1dfba629d3c17"
+source = "git+https://github.com/DavidVentura/piper-rs#2dbdc08e5ce3a615c8ca8f239d0c13820e284d1d"
 dependencies = [
  "bindgen 0.69.5",
  "cmake",
@@ -1224,7 +1224,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 [[package]]
 name = "piper-rs"
 version = "0.1.9"
-source = "git+https://github.com/DavidVentura/piper-rs#ec2ad26c7f861b9f5ee357462ad1dfba629d3c17"
+source = "git+https://github.com/DavidVentura/piper-rs#2dbdc08e5ce3a615c8ca8f239d0c13820e284d1d"
 dependencies = [
  "espeak-rs",
  "mucab",

--- a/app/src/main/bindings/Cargo.toml
+++ b/app/src/main/bindings/Cargo.toml
@@ -21,8 +21,8 @@ jni = { version = "0.21.1", optional = true }
 tarkka = { git = "https://github.com/DavidVentura/tarkka", optional = true }
 tesseract = { git = "https://github.com/DavidVentura/tesseract-rs", optional = true }
 mucab = { git = "https://github.com/DavidVentura/mucab", optional = true }
-#piper-rs = { path = "~/git/piper-rs", optional = true }
-piper-rs = { git = "https://github.com/DavidVentura/piper-rs", optional = true }
+#piper-rs = { path = "~/git/piper-rs", optional = true, features = ["japanese"] }
+piper-rs = { git = "https://github.com/DavidVentura/piper-rs", optional = true, features = ["japanese"] }
 
 
 icu_experimental = { version = "0.4", features = ["compiled_data"] }

--- a/app/src/main/bindings/src/speech.rs
+++ b/app/src/main/bindings/src/speech.rs
@@ -1,9 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::time::Instant;
 
-use piper_rs::{BoundaryAfter, PhonemeChunk, Piper};
+use piper_rs::{BoundaryAfter, KokoroModel, PhonemeChunk, PiperModel};
 
 use crate::logging::{ANDROID_LOG_DEBUG, ANDROID_LOG_ERROR, android_log_with_level};
 
@@ -19,17 +19,32 @@ fn log_error(message: impl AsRef<str>) {
 }
 
 static ESPEAK_DATA_DIR: OnceLock<String> = OnceLock::new();
-static PIPER_CACHE: OnceLock<Mutex<Option<CachedPiper>>> = OnceLock::new();
+static MODEL_CACHE: OnceLock<Mutex<Option<CachedSpeechModel>>> = OnceLock::new();
 
 pub struct PcmAudio {
     pub sample_rate: i32,
     pub pcm_samples: Vec<i16>,
 }
 
-struct CachedPiper {
+fn audio_duration_ms(sample_count: usize, sample_rate: u32) -> u64 {
+    if sample_rate == 0 {
+        return 0;
+    }
+    ((sample_count as u64) * 1000) / u64::from(sample_rate)
+}
+
+enum SpeechModel {
+    Piper(PiperModel),
+    Kokoro(KokoroModel),
+}
+
+struct CachedSpeechModel {
+    engine: String,
     model_path: String,
-    config_path: String,
-    piper: Piper,
+    aux_path: String,
+    language_code: String,
+    support_data_root: String,
+    model: SpeechModel,
 }
 
 fn log_timing(step: &str, started_at: Instant) {
@@ -64,51 +79,110 @@ fn boundary_after_code(boundary_after: BoundaryAfter) -> i32 {
     }
 }
 
-fn piper_cache() -> &'static Mutex<Option<CachedPiper>> {
-    PIPER_CACHE.get_or_init(|| Mutex::new(None))
+fn model_cache() -> &'static Mutex<Option<CachedSpeechModel>> {
+    MODEL_CACHE.get_or_init(|| Mutex::new(None))
 }
 
-fn with_cached_piper<T>(
+fn derive_japanese_dict_path(support_data_root: &str, language_code: &str) -> Option<PathBuf> {
+    if language_code != "ja" || support_data_root.is_empty() {
+        return None;
+    }
+
+    let candidate = Path::new(support_data_root).join("mucab.bin");
+    candidate.exists().then_some(candidate)
+}
+
+fn load_speech_model(
+    engine: &str,
     model_path: &str,
-    config_path: &str,
-    f: impl FnOnce(&mut Piper) -> Result<T, String>,
+    aux_path: &str,
+    language_code: &str,
+    support_data_root: &str,
+) -> Result<SpeechModel, String> {
+    if aux_path.is_empty() {
+        return Err(format!("Missing auxiliary path for TTS engine `{engine}`"));
+    }
+
+    match engine {
+        "kokoro" => {
+            let mut model = KokoroModel::new(
+                Path::new(model_path),
+                Path::new(aux_path),
+                language_code,
+            )
+            .map_err(|err| format!("Failed to load Kokoro voice: {err}"))?;
+            if let Some(dict_path) = derive_japanese_dict_path(support_data_root, language_code) {
+                model
+                    .load_japanese_dict(dict_path.to_string_lossy().as_ref())
+                    .map_err(|err| format!("Failed to load Japanese dictionary: {err}"))?;
+            }
+            Ok(SpeechModel::Kokoro(model))
+        }
+        "piper" => PiperModel::new(Path::new(model_path), Path::new(aux_path))
+            .map(SpeechModel::Piper)
+            .map_err(|err| format!("Failed to load Piper voice: {err}")),
+        other => Err(format!("Unsupported TTS engine `{other}`")),
+    }
+}
+
+fn with_cached_model<T>(
+    engine: &str,
+    model_path: &str,
+    aux_path: &str,
+    language_code: &str,
+    support_data_root: &str,
+    f: impl FnOnce(&mut SpeechModel) -> Result<T, String>,
 ) -> Result<T, String> {
     let load_started_at = Instant::now();
-    let mut cache = piper_cache()
+    let mut cache = model_cache()
         .lock()
-        .map_err(|_| "Failed to lock Piper cache".to_owned())?;
+        .map_err(|_| "Failed to lock TTS model cache".to_owned())?;
 
     let cache_hit = cache
         .as_ref()
-        .map(|cached| cached.model_path == model_path && cached.config_path == config_path)
+        .map(|cached| {
+            cached.engine == engine
+                && cached.model_path == model_path
+                && cached.aux_path == aux_path
+                && cached.language_code == language_code
+                && cached.support_data_root == support_data_root
+        })
         .unwrap_or(false);
 
     if !cache_hit {
-        log_debug("piper_cache miss; loading model");
-        let piper = Piper::new(Path::new(model_path), Path::new(config_path))
-            .map_err(|err| format!("Failed to load Piper voice: {err}"))?;
-        *cache = Some(CachedPiper {
+        log_debug(format!("tts_cache miss; loading {engine} model"));
+        let model = load_speech_model(
+            engine,
+            model_path,
+            aux_path,
+            language_code,
+            support_data_root,
+        )?;
+        *cache = Some(CachedSpeechModel {
+            engine: engine.to_owned(),
             model_path: model_path.to_owned(),
-            config_path: config_path.to_owned(),
-            piper,
+            aux_path: aux_path.to_owned(),
+            language_code: language_code.to_owned(),
+            support_data_root: support_data_root.to_owned(),
+            model,
         });
     } else {
-        log_debug("piper_cache hit; reusing last model");
+        log_debug("tts_cache hit; reusing last model");
     }
     log_timing("load_model", load_started_at);
 
     let cached = cache
         .as_mut()
-        .ok_or_else(|| "Piper cache was unexpectedly empty".to_owned())?;
-    f(&mut cached.piper)
+        .ok_or_else(|| "TTS model cache was unexpectedly empty".to_owned())?;
+    f(&mut cached.model)
 }
 
-fn configure_espeak_data_directory(espeak_data_path: Option<&str>) {
-    let Some(espeak_data_path) = espeak_data_path.filter(|path| !path.is_empty()) else {
+fn configure_support_data_root(support_data_root: Option<&str>) {
+    let Some(support_data_root) = support_data_root.filter(|path| !path.is_empty()) else {
         return;
     };
 
-    let data_root = Path::new(espeak_data_path);
+    let data_root = Path::new(support_data_root);
     let required = ["phondata", "phonindex", "phontab", "intonations"];
     let direct_layout_ok = required.iter().all(|name| data_root.join(name).exists());
     let nested_layout_ok = required
@@ -116,33 +190,76 @@ fn configure_espeak_data_directory(espeak_data_path: Option<&str>) {
         .all(|name| data_root.join("espeak-ng-data").join(name).exists());
 
     log_debug(format!(
-        "eSpeak data probe root={espeak_data_path} direct_layout_ok={direct_layout_ok} nested_layout_ok={nested_layout_ok}"
+        "eSpeak data probe root={support_data_root} direct_layout_ok={direct_layout_ok} nested_layout_ok={nested_layout_ok}"
     ));
 
-    match ESPEAK_DATA_DIR.set(espeak_data_path.to_owned()) {
+    match ESPEAK_DATA_DIR.set(support_data_root.to_owned()) {
         Ok(()) => {
-            // piper-rs discovers eSpeak data through process-global lookup.
-            // Set the path once before the first synthesis attempt.
             unsafe {
-                std::env::set_var(ESPEAK_DATA_ENV, espeak_data_path);
+                std::env::set_var(ESPEAK_DATA_ENV, support_data_root);
             }
             log_debug(format!(
-                "Configured eSpeak data directory at {espeak_data_path}"
+                "Configured eSpeak data directory at {support_data_root}"
             ));
         }
-        Err(existing) if existing == espeak_data_path => {}
+        Err(existing) if existing == support_data_root => {}
         Err(existing) => {
             log_error(format!(
-                "Ignoring alternate eSpeak data directory {espeak_data_path}; already using {existing}"
+                "Ignoring alternate eSpeak data directory {support_data_root}; already using {existing}"
             ));
         }
     }
 }
 
+fn phonemize(model: &mut SpeechModel, text: &str) -> Result<String, String> {
+    match model {
+        SpeechModel::Piper(model) => model
+            .phonemize(text)
+            .map_err(|err| format!("Speech synthesis failed: {err}")),
+        SpeechModel::Kokoro(model) => model
+            .phonemize(text)
+            .map_err(|err| format!("Speech synthesis failed: {err}")),
+    }
+}
+
+fn synthesize(
+    model: &mut SpeechModel,
+    text: &str,
+    speaker_id: Option<i64>,
+    is_phonemes: bool,
+) -> Result<(Vec<f32>, u32), String> {
+    match model {
+        SpeechModel::Piper(model) => {
+            if is_phonemes {
+                model
+                    .synthesize_phonemes(text, speaker_id)
+                    .map_err(|err| format!("Speech synthesis failed: {err}"))
+            } else {
+                model
+                    .synthesize(text, speaker_id)
+                    .map_err(|err| format!("Speech synthesis failed: {err}"))
+            }
+        }
+        SpeechModel::Kokoro(model) => {
+            if is_phonemes {
+                model
+                    .synthesize_phonemes(text, speaker_id, None)
+                    .map_err(|err| format!("Speech synthesis failed: {err}"))
+            } else {
+                model
+                    .synthesize(text, speaker_id, None)
+                    .map_err(|err| format!("Speech synthesis failed: {err}"))
+            }
+        }
+    }
+}
+
 pub fn synthesize_pcm(
+    engine: &str,
     model_path: &str,
-    config_path: &str,
-    espeak_data_path: Option<&str>,
+    aux_path: &str,
+    support_data_root: Option<&str>,
+    language_code: &str,
     text: &str,
     speaker_id: Option<i64>,
     is_phonemes: bool,
@@ -152,50 +269,52 @@ pub fn synthesize_pcm(
     }
 
     let total_started_at = Instant::now();
-    configure_espeak_data_directory(espeak_data_path);
+    configure_support_data_root(support_data_root);
+    let support_data_root = support_data_root.unwrap_or_default();
 
-    log_debug(format!("Synthesizing speech with model {model_path}"));
-    let (samples, sample_rate) = with_cached_piper(model_path, config_path, |piper| {
-        if is_phonemes {
-            log_debug(format!(
-                "synthesizing direct phoneme chunk with {} phoneme char(s)",
-                text.chars().count()
-            ));
-        } else {
-            let phonemize_started_at = Instant::now();
-            let phoneme_chunks = piper
-                .phonemize_chunks(text)
-                .map_err(|err| format!("Speech synthesis failed: {err}"))?;
-            let total_phoneme_chars: usize = phoneme_chunks
-                .iter()
-                .map(|chunk| chunk.phonemes.chars().count())
-                .sum();
-            log_debug(format!(
-                "phonemize produced {} chunk(s), {} phoneme char(s), chunk sizes [{}]",
-                phoneme_chunks.len(),
-                total_phoneme_chars,
-                summarize_phoneme_chunk_sizes(&phoneme_chunks),
-            ));
-            log_timing("phonemize", phonemize_started_at);
-        }
+    log_debug(format!(
+        "Synthesizing speech with engine={engine} model={model_path}"
+    ));
+    let (samples, sample_rate) = with_cached_model(
+        engine,
+        model_path,
+        aux_path,
+        language_code,
+        support_data_root,
+        |model| {
+            if is_phonemes {
+                log_debug(format!(
+                    "synthesizing direct phoneme chunk with {} phoneme char(s)",
+                    text.chars().count()
+                ));
+            } else {
+                let phonemize_started_at = Instant::now();
+                let phonemes = phonemize(model, text)?;
+                log_debug(format!(
+                    "phonemize produced 1 chunk, {} phoneme char(s)",
+                    phonemes.chars().count(),
+                ));
+                log_timing("phonemize", phonemize_started_at);
+            }
 
-        let synth_started_at = Instant::now();
-        let result = piper
-            .create(text, is_phonemes, speaker_id, None, None, None)
-            .map_err(|err| format!("Speech synthesis failed: {err}"))?;
-        log_timing("infer", synth_started_at);
-        Ok(result)
-    })?;
+            let synth_started_at = Instant::now();
+            let result = synthesize(model, text, speaker_id, is_phonemes)?;
+            log_timing("infer", synth_started_at);
+            Ok(result)
+        },
+    )?;
 
     let convert_started_at = Instant::now();
     let pcm_samples: Vec<i16> = samples
         .into_iter()
         .map(|sample| (sample.clamp(-1.0, 1.0) * i16::MAX as f32).round() as i16)
         .collect();
+    let duration_ms = audio_duration_ms(pcm_samples.len(), sample_rate);
     log_debug(format!(
-        "convert_to_pcm produced {} sample(s) at {} Hz",
+        "convert_to_pcm produced {} sample(s) at {} Hz (~{} ms audio)",
         pcm_samples.len(),
-        sample_rate
+        sample_rate,
+        duration_ms,
     ));
     log_timing("convert_to_pcm", convert_started_at);
     log_timing("synthesize_total", total_started_at);
@@ -207,36 +326,47 @@ pub fn synthesize_pcm(
 }
 
 pub fn phonemize_chunks(
+    engine: &str,
     model_path: &str,
-    config_path: &str,
-    espeak_data_path: Option<&str>,
+    aux_path: &str,
+    support_data_root: Option<&str>,
+    language_code: &str,
     text: &str,
 ) -> Result<Vec<PhonemeChunk>, String> {
     if text.trim().is_empty() {
         return Err("Text is empty".to_owned());
     }
 
-    configure_espeak_data_directory(espeak_data_path);
-    log_debug(format!("Phonemizing text with model {model_path}"));
+    configure_support_data_root(support_data_root);
+    let support_data_root = support_data_root.unwrap_or_default();
 
-    with_cached_piper(model_path, config_path, |piper| {
-        let phonemize_started_at = Instant::now();
-        let phoneme_chunks = piper
-            .phonemize_chunks(text)
-            .map_err(|err| format!("Speech synthesis failed: {err}"))?;
-        let total_phoneme_chars: usize = phoneme_chunks
-            .iter()
-            .map(|chunk| chunk.phonemes.chars().count())
-            .sum();
-        log_debug(format!(
-            "phonemize produced {} chunk(s), {} phoneme char(s), chunk sizes [{}]",
-            phoneme_chunks.len(),
-            total_phoneme_chars,
-            summarize_phoneme_chunk_sizes(&phoneme_chunks),
-        ));
-        log_timing("phonemize", phonemize_started_at);
-        Ok(phoneme_chunks)
-    })
+    log_debug(format!(
+        "Phonemizing text with engine={engine} model={model_path}"
+    ));
+
+    with_cached_model(
+        engine,
+        model_path,
+        aux_path,
+        language_code,
+        support_data_root,
+        |model| {
+            let phonemize_started_at = Instant::now();
+            let phonemes = phonemize(model, text)?;
+            let phoneme_chunks = vec![PhonemeChunk {
+                phonemes,
+                boundary_after: BoundaryAfter::Paragraph,
+            }];
+            log_debug(format!(
+                "phonemize produced {} chunk(s), {} phoneme char(s), chunk sizes [{}]",
+                phoneme_chunks.len(),
+                phoneme_chunks[0].phonemes.chars().count(),
+                summarize_phoneme_chunk_sizes(&phoneme_chunks),
+            ));
+            log_timing("phonemize", phonemize_started_at);
+            Ok(phoneme_chunks)
+        },
+    )
 }
 
 #[cfg(feature = "android")]
@@ -250,24 +380,36 @@ mod jni_bridge {
     pub unsafe extern "C" fn Java_dev_davidv_translator_SpeechBinding_nativeSynthesizePcm(
         mut env: JNIEnv,
         _: JClass,
+        java_engine: JString,
         java_model_path: JString,
-        java_config_path: JString,
-        java_espeak_data_path: JString,
+        java_aux_path: JString,
+        java_support_data_root: JString,
+        java_language_code: JString,
         java_text: JString,
         speaker_id: jint,
         is_phonemes: jboolean,
     ) -> jobject {
+        let engine: String = match env.get_string(&java_engine) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
         let model_path: String = match env.get_string(&java_model_path) {
             Ok(value) => value.into(),
             Err(_) => return std::ptr::null_mut(),
         };
 
-        let config_path: String = match env.get_string(&java_config_path) {
+        let aux_path: String = match env.get_string(&java_aux_path) {
             Ok(value) => value.into(),
             Err(_) => return std::ptr::null_mut(),
         };
 
-        let espeak_data_path: String = match env.get_string(&java_espeak_data_path) {
+        let support_data_root: String = match env.get_string(&java_support_data_root) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let language_code: String = match env.get_string(&java_language_code) {
             Ok(value) => value.into(),
             Err(_) => return std::ptr::null_mut(),
         };
@@ -284,9 +426,11 @@ mod jni_bridge {
         };
 
         match synthesize_pcm(
+            &engine,
             &model_path,
-            &config_path,
-            Some(espeak_data_path.as_str()),
+            &aux_path,
+            Some(support_data_root.as_str()),
+            &language_code,
             &text,
             speaker_id,
             is_phonemes != 0,
@@ -323,22 +467,34 @@ mod jni_bridge {
     pub unsafe extern "C" fn Java_dev_davidv_translator_SpeechBinding_nativePhonemizeChunks(
         mut env: JNIEnv,
         _: JClass,
+        java_engine: JString,
         java_model_path: JString,
-        java_config_path: JString,
-        java_espeak_data_path: JString,
+        java_aux_path: JString,
+        java_support_data_root: JString,
+        java_language_code: JString,
         java_text: JString,
     ) -> jobjectArray {
+        let engine: String = match env.get_string(&java_engine) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
         let model_path: String = match env.get_string(&java_model_path) {
             Ok(value) => value.into(),
             Err(_) => return std::ptr::null_mut(),
         };
 
-        let config_path: String = match env.get_string(&java_config_path) {
+        let aux_path: String = match env.get_string(&java_aux_path) {
             Ok(value) => value.into(),
             Err(_) => return std::ptr::null_mut(),
         };
 
-        let espeak_data_path: String = match env.get_string(&java_espeak_data_path) {
+        let support_data_root: String = match env.get_string(&java_support_data_root) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let language_code: String = match env.get_string(&java_language_code) {
             Ok(value) => value.into(),
             Err(_) => return std::ptr::null_mut(),
         };
@@ -349,9 +505,11 @@ mod jni_bridge {
         };
 
         let phoneme_chunks = match phonemize_chunks(
+            &engine,
             &model_path,
-            &config_path,
-            Some(espeak_data_path.as_str()),
+            &aux_path,
+            Some(support_data_root.as_str()),
+            &language_code,
             &text,
         ) {
             Ok(chunks) => chunks,

--- a/app/src/main/bindings/src/speech.rs
+++ b/app/src/main/bindings/src/speech.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::time::Instant;
 
-use piper_rs::{BoundaryAfter, KokoroModel, PhonemeChunk, PiperModel};
+use piper_rs::{Backend, BoundaryAfter, KokoroModel, PhonemeChunk, PiperModel};
 
 use crate::logging::{ANDROID_LOG_DEBUG, ANDROID_LOG_ERROR, android_log_with_level};
 
@@ -291,6 +291,7 @@ fn load_speech_model(
                 Path::new(model_path),
                 Path::new(aux_path),
                 language_code,
+                &Backend::Cpu,
             )
             .map_err(|err| format!("Failed to load Kokoro voice: {err}"))?;
             if let Some(dict_path) = derive_japanese_dict_path(support_data_root, language_code) {
@@ -300,7 +301,7 @@ fn load_speech_model(
             }
             Ok(SpeechModel::Kokoro(model))
         }
-        "piper" => PiperModel::new(Path::new(model_path), Path::new(aux_path))
+        "piper" => PiperModel::new(Path::new(model_path), Path::new(aux_path), &Backend::Cpu)
             .map(SpeechModel::Piper)
             .map_err(|err| format!("Failed to load Piper voice: {err}")),
         other => Err(format!("Unsupported TTS engine `{other}`")),

--- a/app/src/main/bindings/src/speech.rs
+++ b/app/src/main/bindings/src/speech.rs
@@ -44,6 +44,8 @@ struct CachedSpeechModel {
     aux_path: String,
     language_code: String,
     support_data_root: String,
+    voices: Vec<(String, i64)>,
+    default_voice: Option<(String, i64)>,
     model: SpeechModel,
 }
 
@@ -77,6 +79,75 @@ fn boundary_after_code(boundary_after: BoundaryAfter) -> i32 {
         BoundaryAfter::Sentence => 1,
         BoundaryAfter::Paragraph => 2,
     }
+}
+
+fn normalized_language_family(language_code: &str) -> &str {
+    language_code
+        .split(['-', '_'])
+        .next()
+        .unwrap_or(language_code)
+}
+
+fn kokoro_voice_prefixes(language_code: &str) -> &'static [&'static str] {
+    match normalized_language_family(language_code) {
+        "en" => &["a", "b"],
+        "es" => &["e"],
+        "fr" => &["f"],
+        "hi" => &["h"],
+        "it" => &["i"],
+        "ja" => &["j"],
+        "ko" => &["j"],
+        "pt" => &["p"],
+        "zh" => &["z"],
+        _ => &[],
+    }
+}
+
+fn available_voices(model: &SpeechModel) -> Vec<(String, i64)> {
+    let mut voices = match model {
+        SpeechModel::Piper(model) => model
+            .voices()
+            .map(|voices| {
+                voices
+                    .iter()
+                    .map(|(name, id)| (name.clone(), *id))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+        SpeechModel::Kokoro(model) => model
+            .voices()
+            .map(|voices| {
+                voices
+                    .iter()
+                    .map(|(name, id)| (name.clone(), *id))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default(),
+    };
+    voices.sort_by(|left, right| left.0.cmp(&right.0));
+    voices
+}
+
+fn select_default_voice(
+    engine: &str,
+    language_code: &str,
+    voices: &[(String, i64)],
+) -> Option<(String, i64)> {
+    if voices.is_empty() {
+        return None;
+    }
+
+    if engine != "kokoro" {
+        return None;
+    }
+
+    for prefix in kokoro_voice_prefixes(language_code) {
+        if let Some((name, id)) = voices.iter().find(|(name, _)| name.starts_with(prefix)) {
+            return Some((name.clone(), *id));
+        }
+    }
+
+    Some(voices[0].clone())
 }
 
 fn model_cache() -> &'static Mutex<Option<CachedSpeechModel>> {
@@ -131,7 +202,7 @@ fn with_cached_model<T>(
     aux_path: &str,
     language_code: &str,
     support_data_root: &str,
-    f: impl FnOnce(&mut SpeechModel) -> Result<T, String>,
+    f: impl FnOnce(&mut CachedSpeechModel) -> Result<T, String>,
 ) -> Result<T, String> {
     let load_started_at = Instant::now();
     let mut cache = model_cache()
@@ -158,12 +229,31 @@ fn with_cached_model<T>(
             language_code,
             support_data_root,
         )?;
+        let voices = available_voices(&model);
+        let default_voice = select_default_voice(engine, language_code, &voices);
+        if voices.is_empty() {
+            log_debug(format!(
+                "loaded {engine} model without selectable voices for language={language_code}"
+            ));
+        } else if let Some((name, id)) = default_voice.as_ref() {
+            log_debug(format!(
+                "loaded {engine} model with {} voice(s); default voice for language={language_code} is {name}={id}",
+                voices.len()
+            ));
+        } else {
+            log_debug(format!(
+                "loaded {engine} model with {} voice(s); no automatic default selected for language={language_code}",
+                voices.len()
+            ));
+        }
         *cache = Some(CachedSpeechModel {
             engine: engine.to_owned(),
             model_path: model_path.to_owned(),
             aux_path: aux_path.to_owned(),
             language_code: language_code.to_owned(),
             support_data_root: support_data_root.to_owned(),
+            voices,
+            default_voice,
             model,
         });
     } else {
@@ -174,7 +264,7 @@ fn with_cached_model<T>(
     let cached = cache
         .as_mut()
         .ok_or_else(|| "TTS model cache was unexpectedly empty".to_owned())?;
-    f(&mut cached.model)
+    f(cached)
 }
 
 fn configure_support_data_root(support_data_root: Option<&str>) {
@@ -223,31 +313,42 @@ fn phonemize(model: &mut SpeechModel, text: &str) -> Result<String, String> {
 }
 
 fn synthesize(
-    model: &mut SpeechModel,
+    cached_model: &mut CachedSpeechModel,
     text: &str,
     speaker_id: Option<i64>,
     is_phonemes: bool,
 ) -> Result<(Vec<f32>, u32), String> {
-    match model {
+    let effective_speaker_id = speaker_id.or(cached_model.default_voice.as_ref().map(|(_, id)| *id));
+    match &mut cached_model.model {
         SpeechModel::Piper(model) => {
             if is_phonemes {
                 model
-                    .synthesize_phonemes(text, speaker_id)
+                    .synthesize_phonemes(text, effective_speaker_id)
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             } else {
                 model
-                    .synthesize(text, speaker_id)
+                    .synthesize(text, effective_speaker_id)
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             }
         }
         SpeechModel::Kokoro(model) => {
+            if speaker_id.is_none() {
+                if let Some((name, id)) = cached_model.default_voice.as_ref() {
+                    log_debug(format!(
+                        "using cached default voice {name}={id} for engine={} language={} ({} available)",
+                        cached_model.engine,
+                        cached_model.language_code,
+                        cached_model.voices.len()
+                    ));
+                }
+            }
             if is_phonemes {
                 model
-                    .synthesize_phonemes(text, speaker_id, None)
+                    .synthesize_phonemes(text, effective_speaker_id, None)
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             } else {
                 model
-                    .synthesize(text, speaker_id, None)
+                    .synthesize(text, effective_speaker_id, None)
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             }
         }
@@ -281,7 +382,7 @@ pub fn synthesize_pcm(
         aux_path,
         language_code,
         support_data_root,
-        |model| {
+        |cached_model| {
             if is_phonemes {
                 log_debug(format!(
                     "synthesizing direct phoneme chunk with {} phoneme char(s)",
@@ -289,7 +390,7 @@ pub fn synthesize_pcm(
                 ));
             } else {
                 let phonemize_started_at = Instant::now();
-                let phonemes = phonemize(model, text)?;
+                let phonemes = phonemize(&mut cached_model.model, text)?;
                 log_debug(format!(
                     "phonemize produced 1 chunk, {} phoneme char(s)",
                     phonemes.chars().count(),
@@ -298,7 +399,7 @@ pub fn synthesize_pcm(
             }
 
             let synth_started_at = Instant::now();
-            let result = synthesize(model, text, speaker_id, is_phonemes)?;
+            let result = synthesize(cached_model, text, speaker_id, is_phonemes)?;
             log_timing("infer", synth_started_at);
             Ok(result)
         },
@@ -350,9 +451,9 @@ pub fn phonemize_chunks(
         aux_path,
         language_code,
         support_data_root,
-        |model| {
+        |cached_model| {
             let phonemize_started_at = Instant::now();
-            let phonemes = phonemize(model, text)?;
+            let phonemes = phonemize(&mut cached_model.model, text)?;
             let phoneme_chunks = vec![PhonemeChunk {
                 phonemes,
                 boundary_after: BoundaryAfter::Paragraph,

--- a/app/src/main/bindings/src/speech.rs
+++ b/app/src/main/bindings/src/speech.rs
@@ -26,6 +26,13 @@ pub struct PcmAudio {
     pub pcm_samples: Vec<i16>,
 }
 
+#[derive(Clone)]
+pub struct TtsVoiceInfo {
+    pub name: String,
+    pub speaker_id: i64,
+    pub display_name: String,
+}
+
 fn audio_duration_ms(sample_count: usize, sample_rate: u32) -> u64 {
     if sample_rate == 0 {
         return 0;
@@ -128,6 +135,68 @@ fn available_voices(model: &SpeechModel) -> Vec<(String, i64)> {
     voices
 }
 
+fn is_kokoro_voice_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(
+        (chars.next(), chars.next(), chars.next()),
+        (Some(first), Some(second), Some('_'))
+            if first.is_ascii_lowercase() && second.is_ascii_lowercase()
+    )
+}
+
+fn format_voice_display_name(name: &str) -> String {
+    let trimmed = if is_kokoro_voice_name(name) {
+        &name[3..]
+    } else {
+        name
+    };
+
+    trimmed
+        .split(['_', '-'])
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => {
+                    let mut formatted = String::new();
+                    formatted.extend(first.to_uppercase());
+                    formatted.push_str(chars.as_str());
+                    formatted
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn visible_voices(engine: &str, language_code: &str, voices: &[(String, i64)]) -> Vec<TtsVoiceInfo> {
+    let filtered = if engine == "kokoro" {
+        let prefixes = kokoro_voice_prefixes(language_code);
+        let matching = voices
+            .iter()
+            .filter(|(name, _)| prefixes.iter().any(|prefix| name.starts_with(prefix)))
+            .cloned()
+            .collect::<Vec<_>>();
+        if matching.is_empty() {
+            voices.to_vec()
+        } else {
+            matching
+        }
+    } else {
+        voices.to_vec()
+    };
+
+    filtered
+        .into_iter()
+        .map(|(name, speaker_id)| TtsVoiceInfo {
+            display_name: format_voice_display_name(&name),
+            name,
+            speaker_id,
+        })
+        .collect()
+}
+
 fn select_default_voice(
     engine: &str,
     language_code: &str,
@@ -148,6 +217,48 @@ fn select_default_voice(
     }
 
     Some(voices[0].clone())
+}
+
+fn resolve_requested_voice(
+    cached_model: &CachedSpeechModel,
+    requested_voice_name: Option<&str>,
+    speaker_id: Option<i64>,
+) -> Option<(String, i64)> {
+    if let Some(requested_voice_name) = requested_voice_name.filter(|value| !value.is_empty()) {
+        if let Some((name, id)) = cached_model
+            .voices
+            .iter()
+            .find(|(name, _)| name == requested_voice_name)
+        {
+            return Some((name.clone(), *id));
+        }
+        log_error(format!(
+            "requested voice `{requested_voice_name}` was not found for engine={} language={}; falling back",
+            cached_model.engine, cached_model.language_code
+        ));
+    }
+
+    if let Some(speaker_id) = speaker_id {
+        if let Some((name, id)) = cached_model
+            .voices
+            .iter()
+            .find(|(_, id)| *id == speaker_id)
+        {
+            return Some((name.clone(), *id));
+        }
+    }
+
+    cached_model.default_voice.clone().or_else(|| {
+        speaker_id.map(|id| (format!("speaker_{id}"), id))
+    })
+}
+
+fn clamp_speech_speed(speech_speed: f32) -> f32 {
+    speech_speed.clamp(0.5, 2.0)
+}
+
+fn piper_length_scale_for_speed(speech_speed: f32) -> f32 {
+    1.0 / clamp_speech_speed(speech_speed)
 }
 
 fn model_cache() -> &'static Mutex<Option<CachedSpeechModel>> {
@@ -315,40 +426,60 @@ fn phonemize(model: &mut SpeechModel, text: &str) -> Result<String, String> {
 fn synthesize(
     cached_model: &mut CachedSpeechModel,
     text: &str,
+    speech_speed: f32,
+    voice_name: Option<&str>,
     speaker_id: Option<i64>,
     is_phonemes: bool,
 ) -> Result<(Vec<f32>, u32), String> {
-    let effective_speaker_id = speaker_id.or(cached_model.default_voice.as_ref().map(|(_, id)| *id));
+    let selected_voice = resolve_requested_voice(cached_model, voice_name, speaker_id);
+    let effective_speaker_id = selected_voice.as_ref().map(|(_, id)| *id);
+    let clamped_speech_speed = clamp_speech_speed(speech_speed);
     match &mut cached_model.model {
         SpeechModel::Piper(model) => {
+            if let Some((name, id)) = selected_voice.as_ref() {
+                log_debug(format!(
+                    "using voice {name}={id} for engine={} language={} speech_speed={} length_scale={}",
+                    cached_model.engine,
+                    cached_model.language_code,
+                    clamped_speech_speed,
+                    piper_length_scale_for_speed(clamped_speech_speed)
+                ));
+            }
             if is_phonemes {
                 model
-                    .synthesize_phonemes(text, effective_speaker_id)
+                    .synthesize_phonemes_with_options(
+                        text,
+                        effective_speaker_id,
+                        Some(piper_length_scale_for_speed(clamped_speech_speed)),
+                    )
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             } else {
                 model
-                    .synthesize(text, effective_speaker_id)
+                    .synthesize_with_options(
+                        text,
+                        effective_speaker_id,
+                        Some(piper_length_scale_for_speed(clamped_speech_speed)),
+                    )
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             }
         }
         SpeechModel::Kokoro(model) => {
-            if speaker_id.is_none() {
-                if let Some((name, id)) = cached_model.default_voice.as_ref() {
-                    log_debug(format!(
-                        "using cached default voice {name}={id} for engine={} language={} ({} available)",
-                        cached_model.engine,
-                        cached_model.language_code,
-                        cached_model.voices.len()
-                    ));
-                }
+            if let Some((name, id)) = selected_voice.as_ref() {
+                log_debug(format!(
+                    "using voice {name}={id} for engine={} language={} speech_speed={} ({} available)",
+                    cached_model.engine,
+                    cached_model.language_code,
+                    clamped_speech_speed,
+                    cached_model.voices.len()
+                ));
             }
             if is_phonemes {
                 model
-                    .synthesize_phonemes(text, effective_speaker_id, None)
+                    .synthesize_phonemes(text, effective_speaker_id, Some(clamped_speech_speed))
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             } else {
                 model
-                    .synthesize(text, effective_speaker_id, None)
+                    .synthesize(text, effective_speaker_id, Some(clamped_speech_speed))
                     .map_err(|err| format!("Speech synthesis failed: {err}"))
             }
         }
@@ -362,6 +493,8 @@ pub fn synthesize_pcm(
     support_data_root: Option<&str>,
     language_code: &str,
     text: &str,
+    speech_speed: f32,
+    voice_name: Option<&str>,
     speaker_id: Option<i64>,
     is_phonemes: bool,
 ) -> Result<PcmAudio, String> {
@@ -399,7 +532,14 @@ pub fn synthesize_pcm(
             }
 
             let synth_started_at = Instant::now();
-            let result = synthesize(cached_model, text, speaker_id, is_phonemes)?;
+            let result = synthesize(
+                cached_model,
+                text,
+                speech_speed,
+                voice_name,
+                speaker_id,
+                is_phonemes,
+            )?;
             log_timing("infer", synth_started_at);
             Ok(result)
         },
@@ -424,6 +564,32 @@ pub fn synthesize_pcm(
         sample_rate: sample_rate as i32,
         pcm_samples,
     })
+}
+
+pub fn list_voices(
+    engine: &str,
+    model_path: &str,
+    aux_path: &str,
+    support_data_root: Option<&str>,
+    language_code: &str,
+) -> Result<Vec<TtsVoiceInfo>, String> {
+    configure_support_data_root(support_data_root);
+    let support_data_root = support_data_root.unwrap_or_default();
+
+    with_cached_model(
+        engine,
+        model_path,
+        aux_path,
+        language_code,
+        support_data_root,
+        |cached_model| {
+            Ok(visible_voices(
+                &cached_model.engine,
+                &cached_model.language_code,
+                &cached_model.voices,
+            ))
+        },
+    )
 }
 
 pub fn phonemize_chunks(
@@ -487,6 +653,8 @@ mod jni_bridge {
         java_support_data_root: JString,
         java_language_code: JString,
         java_text: JString,
+        speech_speed: f32,
+        java_voice_name: JString,
         speaker_id: jint,
         is_phonemes: jboolean,
     ) -> jobject {
@@ -520,6 +688,11 @@ mod jni_bridge {
             Err(_) => return std::ptr::null_mut(),
         };
 
+        let voice_name: String = match env.get_string(&java_voice_name) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
         let speaker_id = if speaker_id < 0 {
             None
         } else {
@@ -533,6 +706,8 @@ mod jni_bridge {
             Some(support_data_root.as_str()),
             &language_code,
             &text,
+            speech_speed,
+            Some(voice_name.as_str()),
             speaker_id,
             is_phonemes != 0,
         ) {
@@ -650,6 +825,99 @@ mod jni_bridge {
             };
             if env
                 .set_object_array_element(&array, index as i32, java_chunk)
+                .is_err()
+            {
+                return std::ptr::null_mut();
+            }
+        }
+
+        array.into_raw()
+    }
+
+    #[unsafe(no_mangle)]
+    pub unsafe extern "C" fn Java_dev_davidv_translator_SpeechBinding_nativeListVoices(
+        mut env: JNIEnv,
+        _: JClass,
+        java_engine: JString,
+        java_model_path: JString,
+        java_aux_path: JString,
+        java_support_data_root: JString,
+        java_language_code: JString,
+    ) -> jobjectArray {
+        let engine: String = match env.get_string(&java_engine) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let model_path: String = match env.get_string(&java_model_path) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let aux_path: String = match env.get_string(&java_aux_path) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let support_data_root: String = match env.get_string(&java_support_data_root) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let language_code: String = match env.get_string(&java_language_code) {
+            Ok(value) => value.into(),
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let voices = match list_voices(
+            &engine,
+            &model_path,
+            &aux_path,
+            Some(support_data_root.as_str()),
+            &language_code,
+        ) {
+            Ok(voices) => voices,
+            Err(error) => {
+                log_error(error);
+                return std::ptr::null_mut();
+            }
+        };
+
+        let voice_class = match env.find_class("dev/davidv/translator/NativeTtsVoice") {
+            Ok(class) => class,
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        let array = match env.new_object_array(voices.len() as i32, voice_class, JObject::null()) {
+            Ok(array) => array,
+            Err(_) => return std::ptr::null_mut(),
+        };
+
+        for (index, voice) in voices.iter().enumerate() {
+            let java_name = match env.new_string(&voice.name) {
+                Ok(value) => value,
+                Err(_) => return std::ptr::null_mut(),
+            };
+            let java_name = JObject::from(java_name);
+            let java_display_name = match env.new_string(&voice.display_name) {
+                Ok(value) => value,
+                Err(_) => return std::ptr::null_mut(),
+            };
+            let java_display_name = JObject::from(java_display_name);
+            let java_voice = match env.new_object(
+                "dev/davidv/translator/NativeTtsVoice",
+                "(Ljava/lang/String;ILjava/lang/String;)V",
+                &[
+                    JValue::Object(&java_name),
+                    JValue::Int(voice.speaker_id as jint),
+                    JValue::Object(&java_display_name),
+                ],
+            ) {
+                Ok(value) => value,
+                Err(_) => return std::ptr::null_mut(),
+            };
+            if env
+                .set_object_array_element(&array, index as i32, java_voice)
                 .is_err()
             {
                 return std::ptr::null_mut();

--- a/app/src/main/java/dev/davidv/translator/AppSettings.kt
+++ b/app/src/main/java/dev/davidv/translator/AppSettings.kt
@@ -42,4 +42,6 @@ data class AppSettings(
   val showFilePickerInImagePicker: Boolean = false,
   val showTransliterationOnInput: Boolean = false,
   val addSpacesForJapaneseTransliteration: Boolean = true,
+  val ttsPlaybackSpeed: Float = 1.0f,
+  val ttsVoiceOverrides: Map<String, String> = emptyMap(),
 )

--- a/app/src/main/java/dev/davidv/translator/FilePathManager.kt
+++ b/app/src/main/java/dev/davidv/translator/FilePathManager.kt
@@ -8,9 +8,11 @@ import kotlinx.coroutines.flow.StateFlow
 import org.json.JSONObject
 import java.io.File
 
-data class PiperVoiceFiles(
+data class TtsVoiceFiles(
+  val engine: String,
   val model: File,
-  val config: File,
+  val aux: File,
+  val languageCode: String,
   val speakerId: Int? = null,
 )
 
@@ -79,28 +81,50 @@ class FilePathManager(
     )
   }
 
-  fun getPiperVoiceFiles(language: Language): PiperVoiceFiles? {
+  fun getTtsVoiceFiles(language: Language): TtsVoiceFiles? {
     val catalog = loadCatalog() ?: return null
     val resolver = PackResolver(catalog, this)
     val voicePackId = catalog.installedTtsPackIdForLanguage(language.code, resolver::isInstalled) ?: return null
     val voicePack = catalog.pack(voicePackId) ?: return null
-    val configAsset = voicePack.files.firstOrNull { it.name.endsWith(".onnx.json") } ?: return null
-    val modelAsset = voicePack.files.firstOrNull { it.name.endsWith(".onnx") && !it.name.endsWith(".onnx.json") } ?: return null
+    val engine = voicePack.engine ?: "piper"
+    val packFiles =
+      catalog
+        .dependencyClosure(setOf(voicePackId))
+        .mapNotNull(catalog::pack)
+        .flatMap { it.files }
+    val modelAsset = packFiles.firstOrNull { it.name.endsWith(".onnx") && !it.name.endsWith(".onnx.json") } ?: return null
     val modelFile = resolveInstallPath(modelAsset.installPath)
-    val configFile = resolveInstallPath(configAsset.installPath)
+    if (!modelFile.exists()) return null
 
-    return if (modelFile.exists() && configFile.exists()) {
-      PiperVoiceFiles(
-        model = modelFile,
-        config = configFile,
-        speakerId = voicePack.defaultSpeakerId,
-      )
-    } else {
-      null
+    return when (engine) {
+      "kokoro" -> {
+        val voicesAsset = packFiles.firstOrNull { it.name.endsWith(".bin") } ?: return null
+        val auxFile = resolveInstallPath(voicesAsset.installPath)
+        if (!auxFile.exists()) return null
+        TtsVoiceFiles(
+          engine = engine,
+          model = modelFile,
+          aux = auxFile,
+          languageCode = language.code,
+          speakerId = voicePack.defaultSpeakerId,
+        )
+      }
+      else -> {
+        val configAsset = packFiles.firstOrNull { it.name.endsWith(".onnx.json") } ?: return null
+        val auxFile = resolveInstallPath(configAsset.installPath)
+        if (!auxFile.exists()) return null
+        TtsVoiceFiles(
+          engine = engine,
+          model = modelFile,
+          aux = auxFile,
+          languageCode = language.code,
+          speakerId = voicePack.defaultSpeakerId,
+        )
+      }
     }
   }
 
-  fun getPiperEspeakDataRoot(): File? {
+  fun getTtsSupportDataRoot(): File? {
     val dataDir = getDataDir()
     val espeakDataDir = File(dataDir, "espeak-ng-data")
     return dataDir.takeIf { espeakDataDir.exists() }

--- a/app/src/main/java/dev/davidv/translator/LanguageCatalog.kt
+++ b/app/src/main/java/dev/davidv/translator/LanguageCatalog.kt
@@ -157,14 +157,18 @@ data class LanguageCatalog(
     isInstalled: (String) -> Boolean,
   ): String? = ttsPackIdsForLanguage(languageCode).firstOrNull(isInstalled)
 
-  fun ttsSizeBytesForLanguage(languageCode: String): Long =
-    defaultTtsPackIdForLanguage(languageCode)
-      ?.let(packs::get)
-      ?.files
-      ?.sumOf { it.sizeBytes }
-      ?: 0L
+  fun ttsSizeBytesForLanguage(languageCode: String): Long = defaultTtsPackIdForLanguage(languageCode)?.let(::packSizeBytes) ?: 0L
 
-  fun packSizeBytes(packId: String): Long = packs[packId]?.files?.sumOf { it.sizeBytes } ?: 0L
+  fun packSizeBytes(packId: String): Long {
+    val seenInstallPaths = mutableSetOf<String>()
+    return dependencyClosure(listOf(packId))
+      .mapNotNull(packs::get)
+      .sumOf { pack ->
+        pack.files.sumOf { file ->
+          if (seenInstallPaths.add(file.installPath)) file.sizeBytes else 0L
+        }
+      }
+  }
 
   fun translationPackId(
     from: String,

--- a/app/src/main/java/dev/davidv/translator/PcmAudioPlayer.kt
+++ b/app/src/main/java/dev/davidv/translator/PcmAudioPlayer.kt
@@ -5,6 +5,7 @@ import android.media.AudioFormat
 import android.media.AudioTrack
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,6 +16,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -44,8 +46,10 @@ class PcmAudioPlayer(
         var totalFrames = 0
 
         try {
-          audioChunks.collect { audio ->
+          var chunkIndex = 0
+          audioChunks.buffer(capacity = 2).collect { audio ->
             ensureActive()
+            chunkIndex += 1
 
             val currentTrack =
               if (track == null) {
@@ -64,6 +68,11 @@ class PcmAudioPlayer(
                 track!!
               }
 
+            val audioDurationMs = (audio.pcmSamples.size * 1000L) / audio.sampleRate
+            Log.d(
+              "PcmAudioPlayer",
+              "Chunk $chunkIndex: write start samples=${audio.pcmSamples.size} sampleRate=${audio.sampleRate} audioMs=$audioDurationMs playing=${currentTrack.playState == AudioTrack.PLAYSTATE_PLAYING}",
+            )
             val written =
               currentTrack.write(
                 audio.pcmSamples,
@@ -79,9 +88,11 @@ class PcmAudioPlayer(
               currentTrack.release()
               throw IllegalStateException("AudioTrack wrote $written of ${audio.pcmSamples.size} samples")
             }
+            Log.d("PcmAudioPlayer", "Chunk $chunkIndex: write done written=$written")
 
             totalFrames += audio.pcmSamples.size
             if (currentTrack.playState != AudioTrack.PLAYSTATE_PLAYING) {
+              Log.d("PcmAudioPlayer", "Chunk $chunkIndex: playback start")
               currentTrack.play()
             }
           }
@@ -144,16 +155,14 @@ class PcmAudioPlayer(
           .setUsage(AudioAttributes.USAGE_MEDIA)
           .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
           .build(),
-      )
-      .setAudioFormat(
+      ).setAudioFormat(
         AudioFormat
           .Builder()
           .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
           .setSampleRate(audio.sampleRate)
           .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
           .build(),
-      )
-      .setTransferMode(AudioTrack.MODE_STREAM)
+      ).setTransferMode(AudioTrack.MODE_STREAM)
       .setBufferSizeInBytes(maxOf(minBufferSize, audio.pcmSamples.size * Short.SIZE_BYTES))
       .build()
   }

--- a/app/src/main/java/dev/davidv/translator/SettingsManager.kt
+++ b/app/src/main/java/dev/davidv/translator/SettingsManager.kt
@@ -22,6 +22,7 @@ import android.content.SharedPreferences
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.json.JSONObject
 
 class SettingsManager(
   context: Context,
@@ -87,6 +88,12 @@ class SettingsManager(
         "add_spaces_for_japanese_transliteration",
         defaults.addSpacesForJapaneseTransliteration,
       )
+    val ttsPlaybackSpeed = prefs.getFloat("tts_playback_speed", defaults.ttsPlaybackSpeed)
+    val ttsVoiceOverrides =
+      prefs
+        .getString("tts_voice_overrides", null)
+        ?.let(::parseVoiceOverrides)
+        ?: defaults.ttsVoiceOverrides
 
     return AppSettings(
       defaultTargetLanguageCode = defaultTargetLanguageCode,
@@ -106,6 +113,8 @@ class SettingsManager(
       showFilePickerInImagePicker = showFilePickerInImagePicker,
       showTransliterationOnInput = showTransliterationOnInput,
       addSpacesForJapaneseTransliteration = addSpacesForJapaneseTransliteration,
+      ttsPlaybackSpeed = ttsPlaybackSpeed,
+      ttsVoiceOverrides = ttsVoiceOverrides,
     )
   }
 
@@ -193,8 +202,32 @@ class SettingsManager(
         putBoolean("add_spaces_for_japanese_transliteration", newSettings.addSpacesForJapaneseTransliteration)
         modifiedSettings.add("add_spaces_for_japanese_transliteration")
       }
+      if (newSettings.ttsPlaybackSpeed != currentSettings.ttsPlaybackSpeed) {
+        putFloat("tts_playback_speed", newSettings.ttsPlaybackSpeed)
+        modifiedSettings.add("tts_playback_speed")
+      }
+      if (newSettings.ttsVoiceOverrides != currentSettings.ttsVoiceOverrides) {
+        putString("tts_voice_overrides", serializeVoiceOverrides(newSettings.ttsVoiceOverrides))
+        modifiedSettings.add("tts_voice_overrides")
+      }
       apply()
     }
     _settings.value = newSettings
+  }
+
+  private fun parseVoiceOverrides(json: String): Map<String, String> =
+    runCatching {
+      val root = JSONObject(json)
+      root.keys().asSequence().mapNotNull { languageCode ->
+        root.optString(languageCode).takeIf { it.isNotBlank() }?.let { languageCode to it }
+      }.toMap()
+    }.getOrDefault(emptyMap())
+
+  private fun serializeVoiceOverrides(overrides: Map<String, String>): String {
+    val root = JSONObject()
+    overrides.toSortedMap().forEach { (languageCode, voiceName) ->
+      root.put(languageCode, voiceName)
+    }
+    return root.toString()
   }
 }

--- a/app/src/main/java/dev/davidv/translator/SpeechBinding.kt
+++ b/app/src/main/java/dev/davidv/translator/SpeechBinding.kt
@@ -31,45 +31,62 @@ class SpeechBinding {
   }
 
   fun synthesizePcm(
+    engine: String,
     modelPath: String,
-    configPath: String,
-    espeakDataPath: String?,
+    auxPath: String,
+    supportDataPath: String?,
+    languageCode: String,
     text: String,
     speakerId: Int? = null,
     isPhonemes: Boolean = false,
   ): PcmAudio? =
     nativeSynthesizePcm(
+      engine,
       modelPath,
-      configPath,
-      espeakDataPath.orEmpty(),
+      auxPath,
+      supportDataPath.orEmpty(),
+      languageCode,
       text,
       speakerId ?: -1,
       isPhonemes,
     )
 
   fun phonemizeChunks(
+    engine: String,
     modelPath: String,
-    configPath: String,
-    espeakDataPath: String?,
+    auxPath: String,
+    supportDataPath: String?,
+    languageCode: String,
     text: String,
   ): List<PhonemeChunk>? =
-    nativePhonemizeChunks(modelPath, configPath, espeakDataPath.orEmpty(), text)
+    nativePhonemizeChunks(
+      engine,
+      modelPath,
+      auxPath,
+      supportDataPath.orEmpty(),
+      languageCode,
+      text,
+    )
       ?.map { chunk -> PhonemeChunk(content = chunk.content, boundaryAfter = SpeechChunkBoundary.fromNative(chunk.boundaryAfter)) }
       ?.toList()
 
   private external fun nativeSynthesizePcm(
+    engine: String,
     modelPath: String,
-    configPath: String,
-    espeakDataPath: String,
+    auxPath: String,
+    supportDataPath: String,
+    languageCode: String,
     text: String,
     speakerId: Int,
     isPhonemes: Boolean,
   ): PcmAudio?
 
   private external fun nativePhonemizeChunks(
+    engine: String,
     modelPath: String,
-    configPath: String,
-    espeakDataPath: String,
+    auxPath: String,
+    supportDataPath: String,
+    languageCode: String,
     text: String,
   ): Array<NativePhonemeChunk>?
 }

--- a/app/src/main/java/dev/davidv/translator/SpeechBinding.kt
+++ b/app/src/main/java/dev/davidv/translator/SpeechBinding.kt
@@ -18,9 +18,21 @@ data class NativePhonemeChunk(
   val boundaryAfter: Int,
 )
 
+data class NativeTtsVoice(
+  val name: String,
+  val speakerId: Int,
+  val displayName: String,
+)
+
 data class PhonemeChunk(
   val content: String,
   val boundaryAfter: SpeechChunkBoundary,
+)
+
+data class TtsVoiceOption(
+  val name: String,
+  val speakerId: Int,
+  val displayName: String,
 )
 
 class SpeechBinding {
@@ -37,6 +49,8 @@ class SpeechBinding {
     supportDataPath: String?,
     languageCode: String,
     text: String,
+    speechSpeed: Float = 1.0f,
+    voiceName: String? = null,
     speakerId: Int? = null,
     isPhonemes: Boolean = false,
   ): PcmAudio? =
@@ -47,6 +61,8 @@ class SpeechBinding {
       supportDataPath.orEmpty(),
       languageCode,
       text,
+      speechSpeed,
+      voiceName.orEmpty(),
       speakerId ?: -1,
       isPhonemes,
     )
@@ -70,6 +86,23 @@ class SpeechBinding {
       ?.map { chunk -> PhonemeChunk(content = chunk.content, boundaryAfter = SpeechChunkBoundary.fromNative(chunk.boundaryAfter)) }
       ?.toList()
 
+  fun listVoices(
+    engine: String,
+    modelPath: String,
+    auxPath: String,
+    supportDataPath: String?,
+    languageCode: String,
+  ): List<TtsVoiceOption>? =
+    nativeListVoices(
+      engine,
+      modelPath,
+      auxPath,
+      supportDataPath.orEmpty(),
+      languageCode,
+    )?.map { voice ->
+      TtsVoiceOption(name = voice.name, speakerId = voice.speakerId, displayName = voice.displayName)
+    }
+
   private external fun nativeSynthesizePcm(
     engine: String,
     modelPath: String,
@@ -77,6 +110,8 @@ class SpeechBinding {
     supportDataPath: String,
     languageCode: String,
     text: String,
+    speechSpeed: Float,
+    voiceName: String,
     speakerId: Int,
     isPhonemes: Boolean,
   ): PcmAudio?
@@ -89,4 +124,12 @@ class SpeechBinding {
     languageCode: String,
     text: String,
   ): Array<NativePhonemeChunk>?
+
+  private external fun nativeListVoices(
+    engine: String,
+    modelPath: String,
+    auxPath: String,
+    supportDataPath: String,
+    languageCode: String,
+  ): Array<NativeTtsVoice>?
 }

--- a/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationCoordinator.kt
@@ -240,6 +240,8 @@ class TranslationCoordinator(
     language: Language,
     text: String,
   ): SpeechSynthesisResult = translationService.synthesizeSpeech(language, text)
+
+  suspend fun availableTtsVoices(language: Language): List<TtsVoiceOption> = translationService.availableTtsVoices(language)
 }
 
 data class ProcessedImageResult(

--- a/app/src/main/java/dev/davidv/translator/TranslationService.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationService.kt
@@ -357,38 +357,41 @@ alignment: soft
           )
 
       val supportDataPath = filePathManager.getTtsSupportDataRoot()?.absolutePath
-      val phonemeChunks =
+      val speakerId = voiceFiles.speakerId
+      Log.d(
+        "TranslationService",
+        "Using TTS speakerId=$speakerId engine=${voiceFiles.engine} language=${voiceFiles.languageCode}",
+      )
+      var phonemizeFailed = false
+      val phonemizeText: (String) -> List<PhonemeChunk> = { chunkText: String ->
         speechBinding.phonemizeChunks(
           engine = voiceFiles.engine,
           modelPath = voiceFiles.model.absolutePath,
           auxPath = voiceFiles.aux.absolutePath,
           supportDataPath = supportDataPath,
           languageCode = voiceFiles.languageCode,
-          text = text,
-        ) ?: return@withContext SpeechSynthesisResult.Error(
+          text = chunkText,
+        ) ?: run {
+          phonemizeFailed = true
+          emptyList()
+        }
+      }
+
+      val chunkRequests = buildSpeechChunkRequests(text = text, phonemizeText = phonemizeText)
+      if (phonemizeFailed || chunkRequests.isEmpty()) {
+        return@withContext SpeechSynthesisResult.Error(
           "Speech synthesis failed for ${language.displayName}",
         )
-
-      val chunkRequests =
-        buildSpeechChunkRequests(
-          text = text,
-          phonemeChunks = phonemeChunks,
-          phonemizeText = { chunkText ->
-            speechBinding.phonemizeChunks(
-              engine = voiceFiles.engine,
-              modelPath = voiceFiles.model.absolutePath,
-              auxPath = voiceFiles.aux.absolutePath,
-              supportDataPath = supportDataPath,
-              languageCode = voiceFiles.languageCode,
-              text = chunkText,
-            )
-          },
-        )
+      }
 
       SpeechSynthesisResult.Success(
         flow {
-          for (chunkRequest in chunkRequests) {
+          for ((index, chunkRequest) in chunkRequests.withIndex()) {
             currentCoroutineContext().ensureActive()
+            Log.d(
+              "TranslationService",
+              "Speech chunk ${index + 1}/${chunkRequests.size}: synth start isPhonemes=${chunkRequest.isPhonemes} textLen=${chunkRequest.content.length} boundary=${chunkRequest.boundaryAfter} pauseOverride=${chunkRequest.pauseAfterMsOverride}",
+            )
             val pcmAudio =
               speechBinding.synthesizePcm(
                 engine = voiceFiles.engine,
@@ -397,17 +400,30 @@ alignment: soft
                 supportDataPath = supportDataPath,
                 languageCode = voiceFiles.languageCode,
                 text = chunkRequest.content,
-                speakerId = voiceFiles.speakerId,
+                speakerId = speakerId,
                 isPhonemes = chunkRequest.isPhonemes,
               ) ?: throw IllegalStateException(
                 "Speech synthesis failed for ${language.displayName}",
               )
+            val audioDurationMs = (pcmAudio.pcmSamples.size * 1000L) / pcmAudio.sampleRate
+            Log.d(
+              "TranslationService",
+              "Speech chunk ${index + 1}/${chunkRequests.size}: synth ready samples=${pcmAudio.pcmSamples.size} sampleRate=${pcmAudio.sampleRate} audioMs=$audioDurationMs",
+            )
             currentCoroutineContext().ensureActive()
+            Log.d("TranslationService", "Speech chunk ${index + 1}/${chunkRequests.size}: emit start")
             emit(pcmAudio)
+            Log.d("TranslationService", "Speech chunk ${index + 1}/${chunkRequests.size}: emit returned")
 
             val silenceChunk = pauseChunkFor(chunkRequest, pcmAudio.sampleRate)
             if (silenceChunk != null) {
+              val silenceMs = (silenceChunk.pcmSamples.size * 1000L) / silenceChunk.sampleRate
+              Log.d(
+                "TranslationService",
+                "Speech chunk ${index + 1}/${chunkRequests.size}: silence emit start audioMs=$silenceMs",
+              )
               emit(silenceChunk)
+              Log.d("TranslationService", "Speech chunk ${index + 1}/${chunkRequests.size}: silence emit returned")
             }
           }
         },
@@ -416,51 +432,47 @@ alignment: soft
 
   private fun buildSpeechChunkRequests(
     text: String,
-    phonemeChunks: List<PhonemeChunk>,
-    phonemizeText: (String) -> List<PhonemeChunk>?,
+    phonemizeText: (String) -> List<PhonemeChunk>,
+  ): List<SpeechChunkRequest> = clearFinalBoundary(buildSpeechChunkRequestsInternal(text, phonemizeText))
+
+  private fun buildSpeechChunkRequestsInternal(
+    text: String,
+    phonemizeText: (String) -> List<PhonemeChunk>,
   ): List<SpeechChunkRequest> {
     val sourceChunks = splitTextIntoSpeechChunks(text)
-    if (sourceChunks.size == phonemeChunks.size) {
-      val expandedRequests =
+    if (sourceChunks.size > 1) {
+      val requests =
         buildList {
-          for ((sourceChunk, phonemeChunk) in sourceChunks.zip(phonemeChunks)) {
-            val splitRequests = buildSplitChunkRequests(sourceChunk, phonemeChunk, phonemizeText)
-            if (splitRequests != null) {
-              addAll(splitRequests)
-            } else {
-              add(
-                SpeechChunkRequest(
-                  content = phonemeChunk.content,
-                  isPhonemes = true,
-                  boundaryAfter = phonemeChunk.boundaryAfter,
-                  pauseAfterMsOverride = null,
-                ),
-              )
-            }
+          for (sourceChunk in sourceChunks) {
+            addAll(buildSpeechChunkRequestsInternal(sourceChunk, phonemizeText))
           }
         }
-
-      if (expandedRequests.size > 1) {
-        return clearFinalBoundary(expandedRequests)
-      }
-    } else {
-      Log.w(
+      Log.d(
         "TranslationService",
-        "Speech text chunk count mismatch: source=${sourceChunks.size} phonemes=${phonemeChunks.size}; skipping clause-level fast split",
+        "Built speech requests from ${sourceChunks.size} source chunk(s) into ${requests.size} playback chunk(s)",
       )
+      return requests
+    }
+
+    val phonemeChunks = phonemizeText(text).filter { it.content.isNotBlank() }
+    if (phonemeChunks.isEmpty()) {
+      return emptyList()
     }
 
     if (phonemeChunks.size > 1) {
-      return clearFinalBoundary(
-        phonemeChunks.map { chunk ->
-          SpeechChunkRequest(
-            content = chunk.content,
-            isPhonemes = true,
-            boundaryAfter = chunk.boundaryAfter,
-            pauseAfterMsOverride = null,
-          )
-        },
-      )
+      return phonemeChunks.map { chunk ->
+        SpeechChunkRequest(
+          content = chunk.content,
+          isPhonemes = true,
+          boundaryAfter = chunk.boundaryAfter,
+          pauseAfterMsOverride = null,
+        )
+      }
+    }
+
+    val splitRequests = buildSplitChunkRequests(text, phonemeChunks.single(), phonemizeText)
+    if (splitRequests != null) {
+      return splitRequests
     }
 
     return listOf(
@@ -476,19 +488,17 @@ alignment: soft
   private fun buildSplitChunkRequests(
     sourceChunk: String,
     phonemeChunk: PhonemeChunk,
-    phonemizeText: (String) -> List<PhonemeChunk>?,
+    phonemizeText: (String) -> List<PhonemeChunk>,
   ): List<SpeechChunkRequest>? {
     if (phonemeChunk.content.length <= 100) {
       return null
     }
 
     val splitText = splitAtBestPause(sourceChunk) ?: return null
-    val remainingPhonemeChunks = phonemizeText(splitText.second)?.filter { it.content.isNotBlank() }.orEmpty()
-    if (remainingPhonemeChunks.isEmpty()) {
+    val remainingRequests = buildSpeechChunkRequestsInternal(splitText.second, phonemizeText)
+    if (remainingRequests.isEmpty()) {
       return null
     }
-
-    val remainingRequests = buildSpeechChunkRequests(splitText.second, remainingPhonemeChunks, phonemizeText)
 
     Log.d(
       "TranslationService",

--- a/app/src/main/java/dev/davidv/translator/TranslationService.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationService.kt
@@ -357,10 +357,12 @@ alignment: soft
           )
 
       val supportDataPath = filePathManager.getTtsSupportDataRoot()?.absolutePath
+      val speechSpeed = settingsManager.settings.value.ttsPlaybackSpeed.coerceIn(0.5f, 2.0f)
+      val selectedVoiceName = settingsManager.settings.value.ttsVoiceOverrides[voiceFiles.languageCode]
       val speakerId = voiceFiles.speakerId
       Log.d(
         "TranslationService",
-        "Using TTS speakerId=$speakerId engine=${voiceFiles.engine} language=${voiceFiles.languageCode}",
+        "Using TTS speakerId=$speakerId voiceName=$selectedVoiceName speechSpeed=$speechSpeed engine=${voiceFiles.engine} language=${voiceFiles.languageCode}",
       )
       var phonemizeFailed = false
       val phonemizeText: (String) -> List<PhonemeChunk> = { chunkText: String ->
@@ -400,6 +402,8 @@ alignment: soft
                 supportDataPath = supportDataPath,
                 languageCode = voiceFiles.languageCode,
                 text = chunkRequest.content,
+                speechSpeed = speechSpeed,
+                voiceName = selectedVoiceName,
                 speakerId = speakerId,
                 isPhonemes = chunkRequest.isPhonemes,
               ) ?: throw IllegalStateException(
@@ -428,6 +432,19 @@ alignment: soft
           }
         },
       )
+    }
+
+  suspend fun availableTtsVoices(language: Language): List<TtsVoiceOption> =
+    withContext(Dispatchers.IO) {
+      val voiceFiles = filePathManager.getTtsVoiceFiles(language) ?: return@withContext emptyList()
+      val supportDataPath = filePathManager.getTtsSupportDataRoot()?.absolutePath
+      speechBinding.listVoices(
+        engine = voiceFiles.engine,
+        modelPath = voiceFiles.model.absolutePath,
+        auxPath = voiceFiles.aux.absolutePath,
+        supportDataPath = supportDataPath,
+        languageCode = voiceFiles.languageCode,
+      ) ?: emptyList()
     }
 
   private fun buildSpeechChunkRequests(

--- a/app/src/main/java/dev/davidv/translator/TranslationService.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationService.kt
@@ -37,6 +37,9 @@ class TranslationService(
     private const val CLAUSE_PAUSE_MS = 120
     private const val SENTENCE_PAUSE_MS = 180
     private const val PARAGRAPH_PAUSE_MS = 320
+    private const val MIN_PAUSE_SPLIT_CHARS = 12
+    private val SENTENCE_BOUNDARY_CHARS = setOf('.', '?', '!', '。', '？', '！')
+    private val CLAUSE_PAUSE_CHARS = setOf(',', ';', ':', '、', '，', '；', '：')
 
     @Volatile
     private var nativeLibInstance: NativeLib? = null
@@ -348,17 +351,19 @@ alignment: soft
       }
 
       val voiceFiles =
-        filePathManager.getPiperVoiceFiles(language)
+        filePathManager.getTtsVoiceFiles(language)
           ?: return@withContext SpeechSynthesisResult.Error(
-            "No Piper voice installed for ${language.displayName}",
+            "No TTS voice installed for ${language.displayName}",
           )
 
-      val espeakDataPath = filePathManager.getPiperEspeakDataRoot()?.absolutePath
+      val supportDataPath = filePathManager.getTtsSupportDataRoot()?.absolutePath
       val phonemeChunks =
         speechBinding.phonemizeChunks(
+          engine = voiceFiles.engine,
           modelPath = voiceFiles.model.absolutePath,
-          configPath = voiceFiles.config.absolutePath,
-          espeakDataPath = espeakDataPath,
+          auxPath = voiceFiles.aux.absolutePath,
+          supportDataPath = supportDataPath,
+          languageCode = voiceFiles.languageCode,
           text = text,
         ) ?: return@withContext SpeechSynthesisResult.Error(
           "Speech synthesis failed for ${language.displayName}",
@@ -370,9 +375,11 @@ alignment: soft
           phonemeChunks = phonemeChunks,
           phonemizeText = { chunkText ->
             speechBinding.phonemizeChunks(
+              engine = voiceFiles.engine,
               modelPath = voiceFiles.model.absolutePath,
-              configPath = voiceFiles.config.absolutePath,
-              espeakDataPath = espeakDataPath,
+              auxPath = voiceFiles.aux.absolutePath,
+              supportDataPath = supportDataPath,
+              languageCode = voiceFiles.languageCode,
               text = chunkText,
             )
           },
@@ -384,9 +391,11 @@ alignment: soft
             currentCoroutineContext().ensureActive()
             val pcmAudio =
               speechBinding.synthesizePcm(
+                engine = voiceFiles.engine,
                 modelPath = voiceFiles.model.absolutePath,
-                configPath = voiceFiles.config.absolutePath,
-                espeakDataPath = espeakDataPath,
+                auxPath = voiceFiles.aux.absolutePath,
+                supportDataPath = supportDataPath,
+                languageCode = voiceFiles.languageCode,
                 text = chunkRequest.content,
                 speakerId = voiceFiles.speakerId,
                 isPhonemes = chunkRequest.isPhonemes,
@@ -473,15 +482,17 @@ alignment: soft
       return null
     }
 
-    val splitText = splitAtFirstPause(sourceChunk) ?: return null
+    val splitText = splitAtBestPause(sourceChunk) ?: return null
     val remainingPhonemeChunks = phonemizeText(splitText.second)?.filter { it.content.isNotBlank() }.orEmpty()
     if (remainingPhonemeChunks.isEmpty()) {
       return null
     }
 
+    val remainingRequests = buildSpeechChunkRequests(splitText.second, remainingPhonemeChunks, phonemizeText)
+
     Log.d(
       "TranslationService",
-      "Forcing fast speech chunk at first pause for long utterance (${phonemeChunk.content.length} phoneme chars); remainder re-chunked into ${remainingPhonemeChunks.size} chunk(s)",
+      "Forcing fast speech chunk at best pause for long utterance (${phonemeChunk.content.length} phoneme chars); remainder re-chunked into ${remainingRequests.size} chunk(s)",
     )
 
     return buildList {
@@ -493,16 +504,7 @@ alignment: soft
           pauseAfterMsOverride = CLAUSE_PAUSE_MS,
         ),
       )
-      addAll(
-        remainingPhonemeChunks.map { chunk ->
-          SpeechChunkRequest(
-            content = chunk.content,
-            isPhonemes = true,
-            boundaryAfter = chunk.boundaryAfter,
-            pauseAfterMsOverride = null,
-          )
-        },
-      )
+      addAll(remainingRequests)
     }
   }
 
@@ -588,7 +590,7 @@ alignment: soft
     return segments
   }
 
-  private fun isSentenceBoundaryChar(ch: Char): Boolean = ch == '.' || ch == '?' || ch == '!'
+  private fun isSentenceBoundaryChar(ch: Char): Boolean = ch in SENTENCE_BOUNDARY_CHARS
 
   private fun clearFinalBoundary(chunks: List<SpeechChunkRequest>): List<SpeechChunkRequest> {
     if (chunks.isEmpty()) {
@@ -619,19 +621,25 @@ alignment: soft
     return PcmAudio.silence(sampleRate, pauseMs)
   }
 
-  private fun splitAtFirstPause(text: String): Pair<String, String>? {
-    val splitIndex = text.indexOfFirst { it == ',' || it == ';' || it == ':' }
-    if (splitIndex <= 0 || splitIndex >= text.lastIndex) {
-      return null
-    }
+  private fun splitAtBestPause(text: String): Pair<String, String>? {
+    val minSideChars = maxOf(MIN_PAUSE_SPLIT_CHARS, text.length / 4)
+    val midpoint = text.length / 2.0
 
-    val firstChunk = text.substring(0, splitIndex + 1).trim()
-    val secondChunk = text.substring(splitIndex + 1).trim()
-    if (firstChunk.isBlank() || secondChunk.isBlank()) {
-      return null
-    }
-
-    return firstChunk to secondChunk
+    return text.indices
+      .asSequence()
+      .filter { text[it] in CLAUSE_PAUSE_CHARS }
+      .mapNotNull { splitIndex ->
+        val firstChunk = text.substring(0, splitIndex + 1).trim()
+        val secondChunk = text.substring(splitIndex + 1).trim()
+        if (firstChunk.length < minSideChars || secondChunk.length < minSideChars) {
+          return@mapNotNull null
+        }
+        val balancePenalty = kotlin.math.abs(firstChunk.length - secondChunk.length)
+        val midpointPenalty = kotlin.math.abs(midpoint - splitIndex)
+        Triple(balancePenalty, midpointPenalty, firstChunk to secondChunk)
+      }
+      .minWithOrNull(compareBy<Triple<Int, Double, Pair<String, String>>>({ it.first }, { it.second }))
+      ?.third
   }
 }
 

--- a/app/src/main/java/dev/davidv/translator/ui/TranslatorViewModel.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/TranslatorViewModel.kt
@@ -40,6 +40,7 @@ import dev.davidv.translator.TranslatedText
 import dev.davidv.translator.TranslationCoordinator
 import dev.davidv.translator.TranslationResult
 import dev.davidv.translator.TranslatorMessage
+import dev.davidv.translator.TtsVoiceOption
 import dev.davidv.translator.WordWithTaggedEntries
 import dev.davidv.translator.canSwapLanguages
 import dev.davidv.translator.canTranslate
@@ -119,6 +120,9 @@ class TranslatorViewModel(
 
   private val _dictionaryLookupLanguage = MutableStateFlow<Language?>(null)
   val dictionaryLookupLanguage: StateFlow<Language?> = _dictionaryLookupLanguage.asStateFlow()
+
+  private val _ttsVoices = MutableStateFlow<Map<String, List<TtsVoiceOption>>>(emptyMap())
+  val ttsVoices: StateFlow<Map<String, List<TtsVoiceOption>>> = _ttsVoices.asStateFlow()
 
   // One-shot UI events (Toast, errors, etc.)
   private val _uiEvents = MutableSharedFlow<UiEvent>()
@@ -422,6 +426,16 @@ class TranslatorViewModel(
 
   fun setModalVisible(visible: Boolean) {
     _modalVisible.value = visible
+  }
+
+  fun refreshTtsVoices(language: Language) {
+    viewModelScope.launch {
+      _ttsVoices.value = _ttsVoices.value + (language.code to translationCoordinator.availableTtsVoices(language))
+    }
+  }
+
+  fun clearTtsVoices(languageCode: String) {
+    _ttsVoices.value = _ttsVoices.value - languageCode
   }
 
   private fun triggerTranslation() {

--- a/app/src/main/java/dev/davidv/translator/ui/components/SpeechSpeedControl.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/components/SpeechSpeedControl.kt
@@ -1,0 +1,75 @@
+package dev.davidv.translator.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import java.util.Locale
+
+private const val MIN_SPEECH_SPEED = 0.5f
+private const val MAX_SPEECH_SPEED = 2.0f
+private const val SPEECH_SPEED_STEP = 0.1f
+
+@Composable
+fun SpeechSpeedControl(
+  speed: Float,
+  onSpeedChange: (Float) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    SpeechSpeedChip(
+      label = "-",
+      onClick = {
+        onSpeedChange((speed - SPEECH_SPEED_STEP).coerceAtLeast(MIN_SPEECH_SPEED))
+      },
+    )
+    Text(
+      text = String.format(Locale.US, "%.2fx", speed),
+      modifier = Modifier.weight(1f),
+      style = MaterialTheme.typography.bodyMedium,
+      textAlign = TextAlign.Center,
+    )
+    SpeechSpeedChip(
+      label = "+",
+      onClick = {
+        onSpeedChange((speed + SPEECH_SPEED_STEP).coerceAtMost(MAX_SPEECH_SPEED))
+      },
+    )
+  }
+}
+
+@Composable
+private fun SpeechSpeedChip(
+  label: String,
+  onClick: () -> Unit,
+) {
+  Box(
+    modifier =
+      Modifier
+        .clip(RoundedCornerShape(8.dp))
+        .background(MaterialTheme.colorScheme.surfaceVariant)
+        .clickable(onClick = onClick)
+        .padding(horizontal = 12.dp, vertical = 6.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = label,
+      style = MaterialTheme.typography.labelLarge,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+  }
+}

--- a/app/src/main/java/dev/davidv/translator/ui/components/TranslationField.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/components/TranslationField.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -61,7 +60,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -69,7 +67,6 @@ import dev.davidv.translator.R
 import dev.davidv.translator.TranslatedText
 import dev.davidv.translator.TtsVoiceOption
 import dev.davidv.translator.ui.theme.TranslatorTheme
-import java.util.Locale
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -199,8 +196,7 @@ fun TranslationField(
                     onLongClick = {
                       showSpeechOptions = true
                     },
-                  )
-                  .semantics {
+                  ).semantics {
                     contentDescription = if (isAudioPlaying) "Stop audio" else "Speak translation"
                   },
               contentAlignment = Alignment.Center,
@@ -234,37 +230,18 @@ fun TranslationField(
                   text = "Playback speed",
                   style = MaterialTheme.typography.labelLarge,
                 )
-                Row(
+                SpeechSpeedControl(
+                  speed = speechPlaybackSpeed,
+                  onSpeedChange = onSpeechPlaybackSpeedChange,
                   modifier =
                     Modifier
-                      .fillMaxWidth()
                       .padding(top = 8.dp),
-                  verticalAlignment = Alignment.CenterVertically,
-                ) {
-                  SpeechOptionChip(
-                    label = "-",
-                    onClick = {
-                      onSpeechPlaybackSpeedChange((speechPlaybackSpeed - 0.1f).coerceAtLeast(0.5f))
-                    },
-                  )
-                  Text(
-                    text = String.format(Locale.US, "%.2fx", speechPlaybackSpeed),
-                    modifier = Modifier.weight(1f),
-                    style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
-                  )
-                  SpeechOptionChip(
-                    label = "+",
-                    onClick = {
-                      onSpeechPlaybackSpeedChange((speechPlaybackSpeed + 0.1f).coerceAtMost(2.0f))
-                    },
-                  )
-                }
+                )
 
                 HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
 
                 Text(
-                  text = "Voice:",
+                  text = "Voice",
                   style = MaterialTheme.typography.labelLarge,
                 )
                 Column(
@@ -276,7 +253,7 @@ fun TranslationField(
                 ) {
                   if (availableVoices.isEmpty()) {
                     Text(
-                      text = "No voices available",
+                      text = "Default voice",
                       style = MaterialTheme.typography.bodyMedium,
                       color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
@@ -320,29 +297,6 @@ fun TranslationField(
         }
       }
     }
-  }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-private fun SpeechOptionChip(
-  label: String,
-  onClick: () -> Unit,
-) {
-  Box(
-    modifier =
-      Modifier
-        .clip(RoundedCornerShape(8.dp))
-        .background(MaterialTheme.colorScheme.surfaceVariant)
-        .combinedClickable(onClick = onClick, onLongClick = {})
-        .padding(horizontal = 12.dp, vertical = 6.dp),
-    contentAlignment = Alignment.Center,
-  ) {
-    Text(
-      text = label,
-      style = MaterialTheme.typography.labelLarge,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
   }
 }
 

--- a/app/src/main/java/dev/davidv/translator/ui/components/TranslationField.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/components/TranslationField.kt
@@ -22,22 +22,37 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.res.Configuration
 import android.widget.TextView
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -46,13 +61,17 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import dev.davidv.translator.R
 import dev.davidv.translator.TranslatedText
+import dev.davidv.translator.TtsVoiceOption
 import dev.davidv.translator.ui.theme.TranslatorTheme
+import java.util.Locale
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun TranslationField(
   text: TranslatedText?,
@@ -61,9 +80,15 @@ fun TranslationField(
   canSpeak: Boolean = false,
   isAudioPlaying: Boolean = false,
   isAudioLoading: Boolean = false,
+  speechPlaybackSpeed: Float = 1.0f,
+  selectedVoiceName: String? = null,
+  availableVoices: List<TtsVoiceOption> = emptyList(),
   onSpeak: () -> Unit = {},
+  onSpeechPlaybackSpeedChange: (Float) -> Unit = {},
+  onVoiceSelected: (String) -> Unit = {},
 ) {
   val context = LocalContext.current
+  var showSpeechOptions by remember { mutableStateOf(false) }
 
   val actionModeCallback =
     remember(onDictionaryLookup) {
@@ -158,30 +183,166 @@ fun TranslationField(
         }
 
         if (canSpeak || isAudioLoading || isAudioPlaying) {
-          IconButton(
-            onClick = onSpeak,
+          Box(
             modifier =
               Modifier
                 .padding(top = 6.dp)
                 .size(24.dp),
           ) {
-            if (isAudioLoading && !isAudioPlaying) {
-              CircularProgressIndicator(
-                modifier = Modifier.size(18.dp),
-                strokeWidth = 2.dp,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-              )
-            } else {
-              Icon(
-                painter = painterResource(id = if (isAudioPlaying) R.drawable.stop else R.drawable.volume_up),
-                contentDescription = if (isAudioPlaying) "Stop audio" else "Speak translation",
-                tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
-              )
+            Box(
+              modifier =
+                Modifier
+                  .matchParentSize()
+                  .clip(RoundedCornerShape(8.dp))
+                  .combinedClickable(
+                    onClick = onSpeak,
+                    onLongClick = {
+                      showSpeechOptions = true
+                    },
+                  )
+                  .semantics {
+                    contentDescription = if (isAudioPlaying) "Stop audio" else "Speak translation"
+                  },
+              contentAlignment = Alignment.Center,
+            ) {
+              if (isAudioLoading && !isAudioPlaying) {
+                CircularProgressIndicator(
+                  modifier = Modifier.size(18.dp),
+                  strokeWidth = 2.dp,
+                  color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                )
+              } else {
+                Icon(
+                  painter = painterResource(id = if (isAudioPlaying) R.drawable.stop else R.drawable.volume_up),
+                  contentDescription = null,
+                  tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                )
+              }
+            }
+
+            DropdownMenu(
+              expanded = showSpeechOptions,
+              onDismissRequest = { showSpeechOptions = false },
+            ) {
+              Column(
+                modifier =
+                  Modifier
+                    .widthIn(min = 220.dp, max = 280.dp)
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+              ) {
+                Text(
+                  text = "Playback speed",
+                  style = MaterialTheme.typography.labelLarge,
+                )
+                Row(
+                  modifier =
+                    Modifier
+                      .fillMaxWidth()
+                      .padding(top = 8.dp),
+                  verticalAlignment = Alignment.CenterVertically,
+                ) {
+                  SpeechOptionChip(
+                    label = "-",
+                    onClick = {
+                      onSpeechPlaybackSpeedChange((speechPlaybackSpeed - 0.1f).coerceAtLeast(0.5f))
+                    },
+                  )
+                  Text(
+                    text = String.format(Locale.US, "%.2fx", speechPlaybackSpeed),
+                    modifier = Modifier.weight(1f),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                  )
+                  SpeechOptionChip(
+                    label = "+",
+                    onClick = {
+                      onSpeechPlaybackSpeedChange((speechPlaybackSpeed + 0.1f).coerceAtMost(2.0f))
+                    },
+                  )
+                }
+
+                HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
+
+                Text(
+                  text = "Voice:",
+                  style = MaterialTheme.typography.labelLarge,
+                )
+                Column(
+                  modifier =
+                    Modifier
+                      .padding(top = 8.dp)
+                      .heightIn(max = 220.dp)
+                      .verticalScroll(rememberScrollState()),
+                ) {
+                  if (availableVoices.isEmpty()) {
+                    Text(
+                      text = "No voices available",
+                      style = MaterialTheme.typography.bodyMedium,
+                      color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                  } else {
+                    availableVoices.forEach { voice ->
+                      val isSelected = voice.name == selectedVoiceName
+                      Text(
+                        text = voice.displayName,
+                        modifier =
+                          Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .background(
+                              if (isSelected) {
+                                MaterialTheme.colorScheme.secondaryContainer
+                              } else {
+                                MaterialTheme.colorScheme.surface
+                              },
+                            ).combinedClickable(
+                              onClick = {
+                                onVoiceSelected(voice.name)
+                                showSpeechOptions = false
+                              },
+                              onLongClick = {},
+                            ).padding(horizontal = 10.dp, vertical = 8.dp),
+                        color =
+                          if (isSelected) {
+                            MaterialTheme.colorScheme.onSecondaryContainer
+                          } else {
+                            MaterialTheme.colorScheme.onSurface
+                          },
+                        style = MaterialTheme.typography.bodyMedium,
+                      )
+                      Spacer(modifier = Modifier.size(4.dp))
+                    }
+                  }
+                }
+              }
             }
           }
         }
       }
     }
+  }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun SpeechOptionChip(
+  label: String,
+  onClick: () -> Unit,
+) {
+  Box(
+    modifier =
+      Modifier
+        .clip(RoundedCornerShape(8.dp))
+        .background(MaterialTheme.colorScheme.surfaceVariant)
+        .combinedClickable(onClick = onClick, onLongClick = {})
+        .padding(horizontal = 12.dp, vertical = 6.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = label,
+      style = MaterialTheme.typography.labelLarge,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
   }
 }
 

--- a/app/src/main/java/dev/davidv/translator/ui/screens/MainScreen.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/MainScreen.kt
@@ -81,6 +81,7 @@ import dev.davidv.translator.R
 import dev.davidv.translator.ReadingOrder
 import dev.davidv.translator.TranslatedText
 import dev.davidv.translator.TranslatorMessage
+import dev.davidv.translator.TtsVoiceOption
 import dev.davidv.translator.WordWithTaggedEntries
 import dev.davidv.translator.ui.components.DetectedLanguageSection
 import dev.davidv.translator.ui.components.DictionaryBottomSheet
@@ -124,6 +125,10 @@ fun MainScreen(
   languageMetadata: Map<Language, LanguageMetadata>,
   downloadStates: Map<Language, DownloadState> = emptyMap(),
   settings: AppSettings,
+  availableTtsVoices: List<TtsVoiceOption> = emptyList(),
+  selectedTtsVoiceName: String? = null,
+  onTtsPlaybackSpeedChange: (Float) -> Unit = {},
+  onTtsVoiceSelected: (String) -> Unit = {},
   launchMode: LaunchMode,
 ) {
   var showFullScreenImage by remember { mutableStateOf(false) }
@@ -390,6 +395,9 @@ fun MainScreen(
                 canSpeak = availableLanguages[to]?.ttsFiles == true,
                 isAudioPlaying = isAudioPlaying,
                 isAudioLoading = isAudioLoading,
+                speechPlaybackSpeed = settings.ttsPlaybackSpeed,
+                selectedVoiceName = selectedTtsVoiceName,
+                availableVoices = availableTtsVoices,
                 onSpeak = {
                   if (isAudioPlaying || isAudioLoading) {
                     onStopAudio()
@@ -399,6 +407,8 @@ fun MainScreen(
                     }
                   }
                 },
+                onSpeechPlaybackSpeedChange = onTtsPlaybackSpeedChange,
+                onVoiceSelected = onTtsVoiceSelected,
               )
             }
           }

--- a/app/src/main/java/dev/davidv/translator/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/SettingsScreen.kt
@@ -485,6 +485,7 @@ fun SettingsScreen(
           }
         }
       }
+
       // Advanced Settings Section
       var advancedExpanded by remember { mutableStateOf(false) }
       Card(

--- a/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
@@ -67,6 +67,7 @@ import dev.davidv.translator.LaunchMode
 import dev.davidv.translator.PcmAudioPlayer
 import dev.davidv.translator.TarkkaBinding
 import dev.davidv.translator.TranslatorMessage
+import dev.davidv.translator.TtsVoiceOption
 import dev.davidv.translator.ui.TranslatorViewModel
 import dev.davidv.translator.ui.UiEvent
 import kotlinx.coroutines.Dispatchers
@@ -77,6 +78,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import kotlin.math.roundToInt
 
 fun toggleFirstLetterCase(word: String): String {
   if (word.isEmpty()) return word
@@ -85,6 +87,10 @@ fun toggleFirstLetterCase(word: String): String {
   val toggled = if (first.isUpperCase()) first.lowercaseChar() else first.uppercaseChar()
   return toggled + word.drop(1)
 }
+
+private fun defaultVoiceNameForLanguage(voices: List<TtsVoiceOption>): String? = voices.firstOrNull()?.name
+
+private fun quantizePlaybackSpeed(speed: Float): Float = ((speed.coerceIn(0.5f, 2.0f) * 10.0f).roundToInt() / 10.0f)
 
 fun openDictionary(
   language: Language,
@@ -185,6 +191,16 @@ fun TranslatorApp(
     kotlinx.coroutines.flow.MutableStateFlow<Map<Language, DownloadState>>(emptyMap())
   }.collectAsState()
   val isTranslating by viewModel.translationCoordinator.isTranslating.collectAsState()
+  val ttsVoicesByLanguage by viewModel.ttsVoices.collectAsState()
+
+  LaunchedEffect(to?.code, to?.let { languageState.availableLanguageMap[it]?.ttsFiles } == true) {
+    val targetLanguage = to ?: return@LaunchedEffect
+    if (languageState.availableLanguageMap[targetLanguage]?.ttsFiles == true) {
+      viewModel.refreshTtsVoices(targetLanguage)
+    } else {
+      viewModel.clearTtsVoices(targetLanguage.code)
+    }
+  }
 
   // Connect/disconnect download service
   LaunchedEffect(downloadService) {
@@ -368,6 +384,11 @@ fun TranslatorApp(
             val currentFrom = from
             val currentTo = to
             if (currentFrom != null && currentTo != null) {
+              val availableTtsVoices = ttsVoicesByLanguage[currentTo.code].orEmpty()
+              val selectedTtsVoiceName =
+                settings.ttsVoiceOverrides[currentTo.code]
+                  ?.takeIf { voiceName -> availableTtsVoices.any { it.name == voiceName } }
+                  ?: defaultVoiceNameForLanguage(availableTtsVoices)
               MainScreen(
                 onSettings = { navController.navigate("settings") },
                 input = input,
@@ -394,6 +415,20 @@ fun TranslatorApp(
                 languageMetadata = languageMetadata,
                 downloadStates = downloadStates,
                 settings = settings,
+                availableTtsVoices = availableTtsVoices,
+                selectedTtsVoiceName = selectedTtsVoiceName,
+                onTtsPlaybackSpeedChange = { newSpeed ->
+                  viewModel.settingsManager.updateSettings(
+                    settings.copy(ttsPlaybackSpeed = quantizePlaybackSpeed(newSpeed)),
+                  )
+                },
+                onTtsVoiceSelected = { voiceName ->
+                  viewModel.settingsManager.updateSettings(
+                    settings.copy(
+                      ttsVoiceOverrides = settings.ttsVoiceOverrides + (currentTo.code to voiceName),
+                    ),
+                  )
+                },
                 launchMode = currentLaunchMode,
               )
             }

--- a/generate_tts_index.py
+++ b/generate_tts_index.py
@@ -10,8 +10,10 @@ from zipfile import ZIP_DEFLATED, ZipFile
 
 
 PIPER_BASE_URL = "https://huggingface.co/rhasspy/piper-voices/resolve/main"
+KOKORO_BASE_URL = "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0"
 TTS_BASE_URL = "https://translator.davidv.dev/tts"
 TTS_VERSION = 1
+KOKORO_SHARED_PACK_ID = "tts-kokoro-v1.0-core"
 CORE_ESPEAK_FILES = ("phondata", "phonindex", "phontab", "intonations")
 QUALITY_PRIORITY = {
     "medium": 0,
@@ -34,11 +36,11 @@ ESPEAK_DICT_OVERRIDES = {
     "zh": "cmn",
     "zh_hant": "yue",
 }
-
-EXTRA_PIPER_VOICES = {
+EXTRA_TTS_VOICES = {
     # External Polish Piper voice metadata source:
     # https://huggingface.co/WitoldG/polish_piper_models/resolve/main/pl_PL-jarvis_wg_glos-medium.onnx.json
     "pl_PL-jarvis_wg_glos-medium": {
+        "engine": "piper",
         "key": "pl_PL-jarvis_wg_glos-medium",
         "name": "jarvis_wg_glos",
         "language": {
@@ -67,6 +69,7 @@ EXTRA_PIPER_VOICES = {
     # External Hebrew Piper voice metadata source:
     # https://huggingface.co/notmax123/piper-medium-heb/resolve/main/model.config.json
     "he_IL-community_female-medium": {
+        "engine": "piper",
         "key": "he_IL-community_female-medium",
         "name": "community_female",
         "language": {
@@ -95,6 +98,7 @@ EXTRA_PIPER_VOICES = {
     # External Hebrew Piper voice metadata source:
     # https://huggingface.co/notmax123/piper-medium-heb/resolve/main/model.config.json
     "he_IL-community_male-medium": {
+        "engine": "piper",
         "key": "he_IL-community_male-medium",
         "name": "community_male",
         "language": {
@@ -119,6 +123,60 @@ EXTRA_PIPER_VOICES = {
             },
         },
         "aliases": [],
+    },
+    # External Kokoro model metadata source:
+    # https://github.com/thewh1teagle/kokoro-onnx/releases/tag/model-files-v1.0
+    "ja_JP-jf_alpha-kokoro-v1.0": {
+        "engine": "kokoro",
+        "shared_pack": KOKORO_SHARED_PACK_ID,
+        "depends_on": ["support-ja-mucab"],
+        "key": "ja_JP-jf_alpha-kokoro-v1.0",
+        "name": "jf_alpha",
+        "language": {
+            "code": "ja_JP",
+            "family": "ja",
+            "region": "JP",
+            "name_native": "日本語",
+            "name_english": "Japanese",
+            "country_english": "Japan",
+        },
+        "quality": "medium",
+        "num_speakers": 1,
+        "speaker_id_map": {},
+        "files": {},
+        "aliases": [],
+    },
+    # External Kokoro model metadata source:
+    # https://github.com/thewh1teagle/kokoro-onnx/releases/tag/model-files-v1.0
+    "ko_KR-jf_alpha-kokoro-v1.0": {
+        "engine": "kokoro",
+        "shared_pack": KOKORO_SHARED_PACK_ID,
+        "key": "ko_KR-jf_alpha-kokoro-v1.0",
+        "name": "jf_alpha",
+        "language": {
+            "code": "ko_KR",
+            "family": "ko",
+            "region": "KR",
+            "name_native": "한국어",
+            "name_english": "Korean",
+            "country_english": "South Korea",
+        },
+        "quality": "medium",
+        "num_speakers": 1,
+        "speaker_id_map": {},
+        "files": {},
+        "aliases": [],
+    },
+}
+
+KOKORO_SHARED_FILES = {
+    "kokoro-v1.0.int8.onnx": {
+        "size_bytes": 92361271,
+        "url": f"{KOKORO_BASE_URL}/kokoro-v1.0.int8.onnx",
+    },
+    "voices-v1.0.bin": {
+        "size_bytes": 28214398,
+        "url": f"{KOKORO_BASE_URL}/voices-v1.0.bin",
     },
 }
 
@@ -176,7 +234,7 @@ def load_json(path: str) -> dict:
 
 def merge_voice_catalogs(voices: dict) -> dict:
     merged = deepcopy(voices)
-    merged.update(EXTRA_PIPER_VOICES)
+    merged.update(EXTRA_TTS_VOICES)
     return merged
 
 
@@ -294,6 +352,26 @@ def build_espeak_support_packs(
         }
 
 
+def build_shared_tts_support_packs(catalog: dict, voices: dict) -> None:
+    if not any(voice.get("shared_pack") == KOKORO_SHARED_PACK_ID for voice in voices.values()):
+        return
+
+    catalog["packs"][KOKORO_SHARED_PACK_ID] = {
+        "feature": "support",
+        "kind": "tts-kokoro-core",
+        "files": [
+            {
+                "name": filename,
+                "sizeBytes": file_info["size_bytes"],
+                "installPath": f"bin/kokoro/{filename}",
+                "url": file_info["url"],
+            }
+            for filename, file_info in KOKORO_SHARED_FILES.items()
+        ],
+        "dependsOn": [],
+    }
+
+
 def merge_tts(
     base_catalog: dict,
     voices: dict,
@@ -327,6 +405,7 @@ def merge_tts(
         required_dict_codes.add(espeak_dict_code(app_language, voice["language"]["code"]))
 
     build_espeak_support_packs(catalog, required_dict_codes, tts_base_url, tts_version, espeak_core_zip_size)
+    build_shared_tts_support_packs(catalog, voices)
 
     regions_by_language: dict[str, dict[str, dict]] = defaultdict(dict)
     for (app_language, region), region_voices in sorted(grouped.items()):
@@ -334,7 +413,9 @@ def merge_tts(
         voice_ids: list[str] = []
 
         for key, voice in ranked:
-            pack_id = f"tts-piper-{key.replace('_', '-').lower()}"
+            engine = voice.get("engine", "piper")
+            install_root = voice.get("install_root", engine)
+            pack_id = f"tts-{engine}-{key.replace('_', '-').lower()}"
             locale_code = voice["language"]["code"]
             dict_code = espeak_dict_code(app_language, locale_code)
             files = []
@@ -346,7 +427,7 @@ def merge_tts(
                     {
                         "name": filename,
                         "sizeBytes": file_info.get("size_bytes", 0),
-                        "installPath": f"bin/piper/{source_path}",
+                        "installPath": f"bin/{install_root}/{source_path}",
                         "url": file_info.get("url") or f"{piper_base_url.rstrip('/')}/{source_path}",
                     }
                 )
@@ -356,9 +437,15 @@ def merge_tts(
             if speaker_id_map:
                 default_speaker_id = sorted(speaker_id_map.values())[0]
 
+            depends_on = [f"tts-espeak-dict-{dict_code}"]
+            shared_pack = voice.get("shared_pack")
+            if shared_pack:
+                depends_on.append(shared_pack)
+            depends_on.extend(voice.get("depends_on", []))
+
             pack = {
                 "feature": "tts",
-                "engine": "piper",
+                "engine": engine,
                 "language": app_language,
                 "locale": locale_code,
                 "region": region,
@@ -368,7 +455,7 @@ def merge_tts(
                 "defaultSpeakerId": default_speaker_id,
                 "aliases": voice.get("aliases", []),
                 "files": files,
-                "dependsOn": [f"tts-espeak-dict-{dict_code}"],
+                "dependsOn": depends_on,
             }
             if default_speaker_id is None:
                 pack.pop("defaultSpeakerId")

--- a/generate_v2.py
+++ b/generate_v2.py
@@ -99,6 +99,10 @@ OCR_PRIMARY_TRAINEDDATA_OVERRIDES = {
     }
 }
 
+DICTIONARY_DEPENDENCY_OVERRIDES = {
+    "ja": ["support-ja-mucab"],
+}
+
 
 def language_meta_entry(lang: dict) -> dict:
     return {
@@ -231,7 +235,8 @@ def convert_v1_to_v2(language_index: dict, dictionary_index: dict) -> dict:
                 ],
                 "dependsOn": [],
             }
-            add_language_asset_ref(language_entry, "support", support_pack_id)
+            if extra_file != "mucab.bin":
+                add_language_asset_ref(language_entry, "support", support_pack_id)
 
     for dictionary_code, consumer_codes in sorted(dictionary_consumers.items()):
         dict_info = dictionary_index["dictionaries"].get(dictionary_code)
@@ -252,7 +257,7 @@ def convert_v1_to_v2(language_index: dict, dictionary_index: dict) -> dict:
                     source_path=f"{dictionary_version}/{dict_info['filename']}",
                 )
             ],
-            "dependsOn": [],
+            "dependsOn": DICTIONARY_DEPENDENCY_OVERRIDES.get(dictionary_code, []),
             "metadata": {
                 "date": int(dict_info["date"]),
                 "type": dict_info["type"],


### PR DESCRIPTION
Adds support to Korean and Japanese with the kokoro 82M models. My phone (OnePlus 9, 5 years old) _barely_ plays back fast enough (takes 9600ms to generate 9500ms audio, the window is VERY thin)

The model is quantized to `int8`, but still like 105MB

Also allow for voice-picker, on models that have multiple voices (at this moment: japanese, korean, german, dutch, french)

Speed can go between 0.5 and 2x, but some voices glitch out

<img width="500px" alt="Screenshot_20260411-223809_Translator" src="https://github.com/user-attachments/assets/239374fb-b9b4-4a47-b903-960ebd4824f7" />
