### PR TITLE
Support for translating shared URLs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,8 +31,8 @@ android {
     applicationId = "dev.davidv.translator"
     minSdk = 21
     targetSdk = 34
-    versionCode = 13
-    versionName = "0.3.2"
+    versionCode = 14
+    versionName = "0.3.3"
 
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
   }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -100,6 +100,11 @@
       </activity>
 
       <activity
+        android:name=".browser.BrowserActivity"
+        android:exported="false"
+        android:label="@string/app_name" />
+
+      <activity
         android:name="com.canhub.cropper.CropImageActivity"
         android:theme="@style/Theme.Translator.CropImage" />
 

--- a/app/src/main/assets/Readability.js
+++ b/app/src/main/assets/Readability.js
@@ -1,0 +1,2812 @@
+/*
+ * Copyright (c) 2010 Arc90 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This code is heavily based on Arc90's readability.js (1.7.1) script
+ * available at: http://code.google.com/p/arc90labs-readability
+ */
+
+/**
+ * Public constructor.
+ * @param {HTMLDocument} doc     The document to parse.
+ * @param {Object}       options The options object.
+ */
+function Readability(doc, options) {
+  // In some older versions, people passed a URI as the first argument. Cope:
+  if (options && options.documentElement) {
+    doc = options;
+    options = arguments[2];
+  } else if (!doc || !doc.documentElement) {
+    throw new Error(
+      "First argument to Readability constructor should be a document object."
+    );
+  }
+  options = options || {};
+
+  this._doc = doc;
+  this._docJSDOMParser = this._doc.firstChild.__JSDOMParser__;
+  this._articleTitle = null;
+  this._articleByline = null;
+  this._articleDir = null;
+  this._articleSiteName = null;
+  this._attempts = [];
+  this._metadata = {};
+
+  // Configurable options
+  this._debug = !!options.debug;
+  this._maxElemsToParse =
+    options.maxElemsToParse || this.DEFAULT_MAX_ELEMS_TO_PARSE;
+  this._nbTopCandidates =
+    options.nbTopCandidates || this.DEFAULT_N_TOP_CANDIDATES;
+  this._charThreshold = options.charThreshold || this.DEFAULT_CHAR_THRESHOLD;
+  this._classesToPreserve = this.CLASSES_TO_PRESERVE.concat(
+    options.classesToPreserve || []
+  );
+  this._keepClasses = !!options.keepClasses;
+  this._serializer =
+    options.serializer ||
+    function (el) {
+      return el.innerHTML;
+    };
+  this._disableJSONLD = !!options.disableJSONLD;
+  this._allowedVideoRegex = options.allowedVideoRegex || this.REGEXPS.videos;
+  this._linkDensityModifier = options.linkDensityModifier || 0;
+
+  // Start with all flags set
+  this._flags =
+    this.FLAG_STRIP_UNLIKELYS |
+    this.FLAG_WEIGHT_CLASSES |
+    this.FLAG_CLEAN_CONDITIONALLY;
+
+  // Control whether log messages are sent to the console
+  if (this._debug) {
+    let logNode = function (node) {
+      if (node.nodeType == node.TEXT_NODE) {
+        return `${node.nodeName} ("${node.textContent}")`;
+      }
+      let attrPairs = Array.from(node.attributes || [], function (attr) {
+        return `${attr.name}="${attr.value}"`;
+      }).join(" ");
+      return `<${node.localName} ${attrPairs}>`;
+    };
+    this.log = function () {
+      if (typeof console !== "undefined") {
+        let args = Array.from(arguments, arg => {
+          if (arg && arg.nodeType == this.ELEMENT_NODE) {
+            return logNode(arg);
+          }
+          return arg;
+        });
+        args.unshift("Reader: (Readability)");
+        // eslint-disable-next-line no-console
+        console.log(...args);
+      } else if (typeof dump !== "undefined") {
+        /* global dump */
+        var msg = Array.prototype.map
+          .call(arguments, function (x) {
+            return x && x.nodeName ? logNode(x) : x;
+          })
+          .join(" ");
+        dump("Reader: (Readability) " + msg + "\n");
+      }
+    };
+  } else {
+    this.log = function () {};
+  }
+}
+
+Readability.prototype = {
+  FLAG_STRIP_UNLIKELYS: 0x1,
+  FLAG_WEIGHT_CLASSES: 0x2,
+  FLAG_CLEAN_CONDITIONALLY: 0x4,
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType
+  ELEMENT_NODE: 1,
+  TEXT_NODE: 3,
+
+  // Max number of nodes supported by this parser. Default: 0 (no limit)
+  DEFAULT_MAX_ELEMS_TO_PARSE: 0,
+
+  // The number of top candidates to consider when analysing how
+  // tight the competition is among candidates.
+  DEFAULT_N_TOP_CANDIDATES: 5,
+
+  // Element tags to score by default.
+  DEFAULT_TAGS_TO_SCORE: "section,h2,h3,h4,h5,h6,p,td,pre"
+    .toUpperCase()
+    .split(","),
+
+  // The default number of chars an article must have in order to return a result
+  DEFAULT_CHAR_THRESHOLD: 500,
+
+  // All of the regular expressions in use within readability.
+  // Defined up here so we don't instantiate them repeatedly in loops.
+  REGEXPS: {
+    // NOTE: These two regular expressions are duplicated in
+    // Readability-readerable.js. Please keep both copies in sync.
+    unlikelyCandidates:
+      /-ad-|ai2html|banner|breadcrumbs|combx|comment|community|cover-wrap|disqus|extra|footer|gdpr|header|legends|menu|related|remark|replies|rss|shoutbox|sidebar|skyscraper|social|sponsor|supplemental|ad-break|agegate|pagination|pager|popup|yom-remote/i,
+    okMaybeItsACandidate:
+      /and|article|body|column|content|main|mathjax|shadow/i,
+
+    positive:
+      /article|body|content|entry|hentry|h-entry|main|page|pagination|post|text|blog|story/i,
+    negative:
+      /-ad-|hidden|^hid$| hid$| hid |^hid |banner|combx|comment|com-|contact|footer|gdpr|masthead|media|meta|outbrain|promo|related|scroll|share|shoutbox|sidebar|skyscraper|sponsor|shopping|tags|widget/i,
+    extraneous:
+      /print|archive|comment|discuss|e[\-]?mail|share|reply|all|login|sign|single|utility/i,
+    byline: /byline|author|dateline|writtenby|p-author/i,
+    replaceFonts: /<(\/?)font[^>]*>/gi,
+    normalize: /\s{2,}/g,
+    videos:
+      /\/\/(www\.)?((dailymotion|youtube|youtube-nocookie|player\.vimeo|v\.qq|bilibili|live.bilibili)\.com|(archive|upload\.wikimedia)\.org|player\.twitch\.tv)/i,
+    shareElements: /(\b|_)(share|sharedaddy)(\b|_)/i,
+    nextLink: /(next|weiter|continue|>([^\|]|$)|»([^\|]|$))/i,
+    prevLink: /(prev|earl|old|new|<|«)/i,
+    tokenize: /\W+/g,
+    whitespace: /^\s*$/,
+    hasContent: /\S$/,
+    hashUrl: /^#.+/,
+    srcsetUrl: /(\S+)(\s+[\d.]+[xw])?(\s*(?:,|$))/g,
+    b64DataUrl: /^data:\s*([^\s;,]+)\s*;\s*base64\s*,/i,
+    // Commas as used in Latin, Sindhi, Chinese and various other scripts.
+    // see: https://en.wikipedia.org/wiki/Comma#Comma_variants
+    commas: /\u002C|\u060C|\uFE50|\uFE10|\uFE11|\u2E41|\u2E34|\u2E32|\uFF0C/g,
+    // See: https://schema.org/Article
+    jsonLdArticleTypes:
+      /^Article|AdvertiserContentArticle|NewsArticle|AnalysisNewsArticle|AskPublicNewsArticle|BackgroundNewsArticle|OpinionNewsArticle|ReportageNewsArticle|ReviewNewsArticle|Report|SatiricalArticle|ScholarlyArticle|MedicalScholarlyArticle|SocialMediaPosting|BlogPosting|LiveBlogPosting|DiscussionForumPosting|TechArticle|APIReference$/,
+    // used to see if a node's content matches words commonly used for ad blocks or loading indicators
+    adWords:
+      /^(ad(vertising|vertisement)?|pub(licité)?|werb(ung)?|广告|Реклама|Anuncio)$/iu,
+    loadingWords:
+      /^((loading|正在加载|Загрузка|chargement|cargando)(…|\.\.\.)?)$/iu,
+  },
+
+  UNLIKELY_ROLES: [
+    "menu",
+    "menubar",
+    "complementary",
+    "navigation",
+    "alert",
+    "alertdialog",
+    "dialog",
+  ],
+
+  DIV_TO_P_ELEMS: new Set([
+    "BLOCKQUOTE",
+    "DL",
+    "DIV",
+    "IMG",
+    "OL",
+    "P",
+    "PRE",
+    "TABLE",
+    "UL",
+  ]),
+
+  ALTER_TO_DIV_EXCEPTIONS: ["DIV", "ARTICLE", "SECTION", "P", "OL", "UL"],
+
+  PRESENTATIONAL_ATTRIBUTES: [
+    "align",
+    "background",
+    "bgcolor",
+    "border",
+    "cellpadding",
+    "cellspacing",
+    "frame",
+    "hspace",
+    "rules",
+    "style",
+    "valign",
+    "vspace",
+  ],
+
+  DEPRECATED_SIZE_ATTRIBUTE_ELEMS: ["TABLE", "TH", "TD", "HR", "PRE"],
+
+  // The commented out elements qualify as phrasing content but tend to be
+  // removed by readability when put into paragraphs, so we ignore them here.
+  PHRASING_ELEMS: [
+    // "CANVAS", "IFRAME", "SVG", "VIDEO",
+    "ABBR",
+    "AUDIO",
+    "B",
+    "BDO",
+    "BR",
+    "BUTTON",
+    "CITE",
+    "CODE",
+    "DATA",
+    "DATALIST",
+    "DFN",
+    "EM",
+    "EMBED",
+    "I",
+    "IMG",
+    "INPUT",
+    "KBD",
+    "LABEL",
+    "MARK",
+    "MATH",
+    "METER",
+    "NOSCRIPT",
+    "OBJECT",
+    "OUTPUT",
+    "PROGRESS",
+    "Q",
+    "RUBY",
+    "SAMP",
+    "SCRIPT",
+    "SELECT",
+    "SMALL",
+    "SPAN",
+    "STRONG",
+    "SUB",
+    "SUP",
+    "TEXTAREA",
+    "TIME",
+    "VAR",
+    "WBR",
+  ],
+
+  // These are the classes that readability sets itself.
+  CLASSES_TO_PRESERVE: ["page"],
+
+  // These are the list of HTML entities that need to be escaped.
+  HTML_ESCAPE_MAP: {
+    lt: "<",
+    gt: ">",
+    amp: "&",
+    quot: '"',
+    apos: "'",
+  },
+
+  /**
+   * Run any post-process modifications to article content as necessary.
+   *
+   * @param Element
+   * @return void
+   **/
+  _postProcessContent(articleContent) {
+    // Readability cannot open relative uris so we convert them to absolute uris.
+    this._fixRelativeUris(articleContent);
+
+    this._simplifyNestedElements(articleContent);
+
+    if (!this._keepClasses) {
+      // Remove classes.
+      this._cleanClasses(articleContent);
+    }
+  },
+
+  /**
+   * Iterates over a NodeList, calls `filterFn` for each node and removes node
+   * if function returned `true`.
+   *
+   * If function is not passed, removes all the nodes in node list.
+   *
+   * @param NodeList nodeList The nodes to operate on
+   * @param Function filterFn the function to use as a filter
+   * @return void
+   */
+  _removeNodes(nodeList, filterFn) {
+    // Avoid ever operating on live node lists.
+    if (this._docJSDOMParser && nodeList._isLiveNodeList) {
+      throw new Error("Do not pass live node lists to _removeNodes");
+    }
+    for (var i = nodeList.length - 1; i >= 0; i--) {
+      var node = nodeList[i];
+      var parentNode = node.parentNode;
+      if (parentNode) {
+        if (!filterFn || filterFn.call(this, node, i, nodeList)) {
+          parentNode.removeChild(node);
+        }
+      }
+    }
+  },
+
+  /**
+   * Iterates over a NodeList, and calls _setNodeTag for each node.
+   *
+   * @param NodeList nodeList The nodes to operate on
+   * @param String newTagName the new tag name to use
+   * @return void
+   */
+  _replaceNodeTags(nodeList, newTagName) {
+    // Avoid ever operating on live node lists.
+    if (this._docJSDOMParser && nodeList._isLiveNodeList) {
+      throw new Error("Do not pass live node lists to _replaceNodeTags");
+    }
+    for (const node of nodeList) {
+      this._setNodeTag(node, newTagName);
+    }
+  },
+
+  /**
+   * Iterate over a NodeList, which doesn't natively fully implement the Array
+   * interface.
+   *
+   * For convenience, the current object context is applied to the provided
+   * iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return void
+   */
+  _forEachNode(nodeList, fn) {
+    Array.prototype.forEach.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, and return the first node that passes
+   * the supplied test function
+   *
+   * For convenience, the current object context is applied to the provided
+   * test function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The test function.
+   * @return void
+   */
+  _findNode(nodeList, fn) {
+    return Array.prototype.find.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, return true if any of the provided iterate
+   * function calls returns true, false otherwise.
+   *
+   * For convenience, the current object context is applied to the
+   * provided iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return Boolean
+   */
+  _someNode(nodeList, fn) {
+    return Array.prototype.some.call(nodeList, fn, this);
+  },
+
+  /**
+   * Iterate over a NodeList, return true if all of the provided iterate
+   * function calls return true, false otherwise.
+   *
+   * For convenience, the current object context is applied to the
+   * provided iterate function.
+   *
+   * @param  NodeList nodeList The NodeList.
+   * @param  Function fn       The iterate function.
+   * @return Boolean
+   */
+  _everyNode(nodeList, fn) {
+    return Array.prototype.every.call(nodeList, fn, this);
+  },
+
+  _getAllNodesWithTag(node, tagNames) {
+    if (node.querySelectorAll) {
+      return node.querySelectorAll(tagNames.join(","));
+    }
+    return [].concat.apply(
+      [],
+      tagNames.map(function (tag) {
+        var collection = node.getElementsByTagName(tag);
+        return Array.isArray(collection) ? collection : Array.from(collection);
+      })
+    );
+  },
+
+  /**
+   * Removes the class="" attribute from every element in the given
+   * subtree, except those that match CLASSES_TO_PRESERVE and
+   * the classesToPreserve array from the options object.
+   *
+   * @param Element
+   * @return void
+   */
+  _cleanClasses(node) {
+    var classesToPreserve = this._classesToPreserve;
+    var className = (node.getAttribute("class") || "")
+      .split(/\s+/)
+      .filter(cls => classesToPreserve.includes(cls))
+      .join(" ");
+
+    if (className) {
+      node.setAttribute("class", className);
+    } else {
+      node.removeAttribute("class");
+    }
+
+    for (node = node.firstElementChild; node; node = node.nextElementSibling) {
+      this._cleanClasses(node);
+    }
+  },
+
+  /**
+   * Tests whether a string is a URL or not.
+   *
+   * @param {string} str The string to test
+   * @return {boolean} true if str is a URL, false if not
+   */
+  _isUrl(str) {
+    try {
+      new URL(str);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  /**
+   * Converts each <a> and <img> uri in the given element to an absolute URI,
+   * ignoring #ref URIs.
+   *
+   * @param Element
+   * @return void
+   */
+  _fixRelativeUris(articleContent) {
+    var baseURI = this._doc.baseURI;
+    var documentURI = this._doc.documentURI;
+    function toAbsoluteURI(uri) {
+      // Leave hash links alone if the base URI matches the document URI:
+      if (baseURI == documentURI && uri.charAt(0) == "#") {
+        return uri;
+      }
+
+      // Otherwise, resolve against base URI:
+      try {
+        return new URL(uri, baseURI).href;
+      } catch (ex) {
+        // Something went wrong, just return the original:
+      }
+      return uri;
+    }
+
+    var links = this._getAllNodesWithTag(articleContent, ["a"]);
+    this._forEachNode(links, function (link) {
+      var href = link.getAttribute("href");
+      if (href) {
+        // Remove links with javascript: URIs, since
+        // they won't work after scripts have been removed from the page.
+        if (href.indexOf("javascript:") === 0) {
+          // if the link only contains simple text content, it can be converted to a text node
+          if (
+            link.childNodes.length === 1 &&
+            link.childNodes[0].nodeType === this.TEXT_NODE
+          ) {
+            var text = this._doc.createTextNode(link.textContent);
+            link.parentNode.replaceChild(text, link);
+          } else {
+            // if the link has multiple children, they should all be preserved
+            var container = this._doc.createElement("span");
+            while (link.firstChild) {
+              container.appendChild(link.firstChild);
+            }
+            link.parentNode.replaceChild(container, link);
+          }
+        } else {
+          link.setAttribute("href", toAbsoluteURI(href));
+        }
+      }
+    });
+
+    var medias = this._getAllNodesWithTag(articleContent, [
+      "img",
+      "picture",
+      "figure",
+      "video",
+      "audio",
+      "source",
+    ]);
+
+    this._forEachNode(medias, function (media) {
+      var src = media.getAttribute("src");
+      var poster = media.getAttribute("poster");
+      var srcset = media.getAttribute("srcset");
+
+      if (src) {
+        media.setAttribute("src", toAbsoluteURI(src));
+      }
+
+      if (poster) {
+        media.setAttribute("poster", toAbsoluteURI(poster));
+      }
+
+      if (srcset) {
+        var newSrcset = srcset.replace(
+          this.REGEXPS.srcsetUrl,
+          function (_, p1, p2, p3) {
+            return toAbsoluteURI(p1) + (p2 || "") + p3;
+          }
+        );
+
+        media.setAttribute("srcset", newSrcset);
+      }
+    });
+  },
+
+  _simplifyNestedElements(articleContent) {
+    var node = articleContent;
+
+    while (node) {
+      if (
+        node.parentNode &&
+        ["DIV", "SECTION"].includes(node.tagName) &&
+        !(node.id && node.id.startsWith("readability"))
+      ) {
+        if (this._isElementWithoutContent(node)) {
+          node = this._removeAndGetNext(node);
+          continue;
+        } else if (
+          this._hasSingleTagInsideElement(node, "DIV") ||
+          this._hasSingleTagInsideElement(node, "SECTION")
+        ) {
+          var child = node.children[0];
+          for (var i = 0; i < node.attributes.length; i++) {
+            child.setAttributeNode(node.attributes[i].cloneNode());
+          }
+          node.parentNode.replaceChild(child, node);
+          node = child;
+          continue;
+        }
+      }
+
+      node = this._getNextNode(node);
+    }
+  },
+
+  /**
+   * Get the article title as an H1.
+   *
+   * @return string
+   **/
+  _getArticleTitle() {
+    var doc = this._doc;
+    var curTitle = "";
+    var origTitle = "";
+
+    try {
+      curTitle = origTitle = doc.title.trim();
+
+      // If they had an element with id "title" in their HTML
+      if (typeof curTitle !== "string") {
+        curTitle = origTitle = this._getInnerText(
+          doc.getElementsByTagName("title")[0]
+        );
+      }
+    } catch (e) {
+      /* ignore exceptions setting the title. */
+    }
+
+    var titleHadHierarchicalSeparators = false;
+    function wordCount(str) {
+      return str.split(/\s+/).length;
+    }
+
+    // If there's a separator in the title, first remove the final part
+    const titleSeparators = /\|\-–—\\\/>»/.source;
+    if (new RegExp(`\\s[${titleSeparators}]\\s`).test(curTitle)) {
+      titleHadHierarchicalSeparators = /\s[\\\/>»]\s/.test(curTitle);
+      let allSeparators = Array.from(
+        origTitle.matchAll(new RegExp(`\\s[${titleSeparators}]\\s`, "gi"))
+      );
+      curTitle = origTitle.substring(0, allSeparators.pop().index);
+
+      // If the resulting title is too short, remove the first part instead:
+      if (wordCount(curTitle) < 3) {
+        curTitle = origTitle.replace(
+          new RegExp(`^[^${titleSeparators}]*[${titleSeparators}]`, "gi"),
+          ""
+        );
+      }
+    } else if (curTitle.includes(": ")) {
+      // Check if we have an heading containing this exact string, so we
+      // could assume it's the full title.
+      var headings = this._getAllNodesWithTag(doc, ["h1", "h2"]);
+      var trimmedTitle = curTitle.trim();
+      var match = this._someNode(headings, function (heading) {
+        return heading.textContent.trim() === trimmedTitle;
+      });
+
+      // If we don't, let's extract the title out of the original title string.
+      if (!match) {
+        curTitle = origTitle.substring(origTitle.lastIndexOf(":") + 1);
+
+        // If the title is now too short, try the first colon instead:
+        if (wordCount(curTitle) < 3) {
+          curTitle = origTitle.substring(origTitle.indexOf(":") + 1);
+          // But if we have too many words before the colon there's something weird
+          // with the titles and the H tags so let's just use the original title instead
+        } else if (wordCount(origTitle.substr(0, origTitle.indexOf(":"))) > 5) {
+          curTitle = origTitle;
+        }
+      }
+    } else if (curTitle.length > 150 || curTitle.length < 15) {
+      var hOnes = doc.getElementsByTagName("h1");
+
+      if (hOnes.length === 1) {
+        curTitle = this._getInnerText(hOnes[0]);
+      }
+    }
+
+    curTitle = curTitle.trim().replace(this.REGEXPS.normalize, " ");
+    // If we now have 4 words or fewer as our title, and either no
+    // 'hierarchical' separators (\, /, > or ») were found in the original
+    // title or we decreased the number of words by more than 1 word, use
+    // the original title.
+    var curTitleWordCount = wordCount(curTitle);
+    if (
+      curTitleWordCount <= 4 &&
+      (!titleHadHierarchicalSeparators ||
+        curTitleWordCount !=
+          wordCount(
+            origTitle.replace(new RegExp(`\\s[${titleSeparators}]\\s`, "g"), "")
+          ) -
+            1)
+    ) {
+      curTitle = origTitle;
+    }
+
+    return curTitle;
+  },
+
+  /**
+   * Prepare the HTML document for readability to scrape it.
+   * This includes things like stripping javascript, CSS, and handling terrible markup.
+   *
+   * @return void
+   **/
+  _prepDocument() {
+    var doc = this._doc;
+
+    // Remove all style tags in head
+    this._removeNodes(this._getAllNodesWithTag(doc, ["style"]));
+
+    if (doc.body) {
+      this._replaceBrs(doc.body);
+    }
+
+    this._replaceNodeTags(this._getAllNodesWithTag(doc, ["font"]), "SPAN");
+  },
+
+  /**
+   * Finds the next node, starting from the given node, and ignoring
+   * whitespace in between. If the given node is an element, the same node is
+   * returned.
+   */
+  _nextNode(node) {
+    var next = node;
+    while (
+      next &&
+      next.nodeType != this.ELEMENT_NODE &&
+      this.REGEXPS.whitespace.test(next.textContent)
+    ) {
+      next = next.nextSibling;
+    }
+    return next;
+  },
+
+  /**
+   * Replaces 2 or more successive <br> elements with a single <p>.
+   * Whitespace between <br> elements are ignored. For example:
+   *   <div>foo<br>bar<br> <br><br>abc</div>
+   * will become:
+   *   <div>foo<br>bar<p>abc</p></div>
+   */
+  _replaceBrs(elem) {
+    this._forEachNode(this._getAllNodesWithTag(elem, ["br"]), function (br) {
+      var next = br.nextSibling;
+
+      // Whether 2 or more <br> elements have been found and replaced with a
+      // <p> block.
+      var replaced = false;
+
+      // If we find a <br> chain, remove the <br>s until we hit another node
+      // or non-whitespace. This leaves behind the first <br> in the chain
+      // (which will be replaced with a <p> later).
+      while ((next = this._nextNode(next)) && next.tagName == "BR") {
+        replaced = true;
+        var brSibling = next.nextSibling;
+        next.remove();
+        next = brSibling;
+      }
+
+      // If we removed a <br> chain, replace the remaining <br> with a <p>. Add
+      // all sibling nodes as children of the <p> until we hit another <br>
+      // chain.
+      if (replaced) {
+        var p = this._doc.createElement("p");
+        br.parentNode.replaceChild(p, br);
+
+        next = p.nextSibling;
+        while (next) {
+          // If we've hit another <br><br>, we're done adding children to this <p>.
+          if (next.tagName == "BR") {
+            var nextElem = this._nextNode(next.nextSibling);
+            if (nextElem && nextElem.tagName == "BR") {
+              break;
+            }
+          }
+
+          if (!this._isPhrasingContent(next)) {
+            break;
+          }
+
+          // Otherwise, make this node a child of the new <p>.
+          var sibling = next.nextSibling;
+          p.appendChild(next);
+          next = sibling;
+        }
+
+        while (p.lastChild && this._isWhitespace(p.lastChild)) {
+          p.lastChild.remove();
+        }
+
+        if (p.parentNode.tagName === "P") {
+          this._setNodeTag(p.parentNode, "DIV");
+        }
+      }
+    });
+  },
+
+  _setNodeTag(node, tag) {
+    this.log("_setNodeTag", node, tag);
+    if (this._docJSDOMParser) {
+      node.localName = tag.toLowerCase();
+      node.tagName = tag.toUpperCase();
+      return node;
+    }
+
+    var replacement = node.ownerDocument.createElement(tag);
+    while (node.firstChild) {
+      replacement.appendChild(node.firstChild);
+    }
+    node.parentNode.replaceChild(replacement, node);
+    if (node.readability) {
+      replacement.readability = node.readability;
+    }
+
+    for (var i = 0; i < node.attributes.length; i++) {
+      replacement.setAttributeNode(node.attributes[i].cloneNode());
+    }
+    return replacement;
+  },
+
+  /**
+   * Prepare the article node for display. Clean out any inline styles,
+   * iframes, forms, strip extraneous <p> tags, etc.
+   *
+   * @param Element
+   * @return void
+   **/
+  _prepArticle(articleContent) {
+    this._cleanStyles(articleContent);
+
+    // Check for data tables before we continue, to avoid removing items in
+    // those tables, which will often be isolated even though they're
+    // visually linked to other content-ful elements (text, images, etc.).
+    this._markDataTables(articleContent);
+
+    this._fixLazyImages(articleContent);
+
+    // Clean out junk from the article content
+    this._cleanConditionally(articleContent, "form");
+    this._cleanConditionally(articleContent, "fieldset");
+    this._clean(articleContent, "object");
+    this._clean(articleContent, "embed");
+    this._clean(articleContent, "footer");
+    this._clean(articleContent, "link");
+    this._clean(articleContent, "aside");
+
+    // Clean out elements with little content that have "share" in their id/class combinations from final top candidates,
+    // which means we don't remove the top candidates even they have "share".
+
+    var shareElementThreshold = this.DEFAULT_CHAR_THRESHOLD;
+
+    this._forEachNode(articleContent.children, function (topCandidate) {
+      this._cleanMatchedNodes(topCandidate, function (node, matchString) {
+        return (
+          this.REGEXPS.shareElements.test(matchString) &&
+          node.textContent.length < shareElementThreshold
+        );
+      });
+    });
+
+    this._clean(articleContent, "iframe");
+    this._clean(articleContent, "input");
+    this._clean(articleContent, "textarea");
+    this._clean(articleContent, "select");
+    this._clean(articleContent, "button");
+    this._cleanHeaders(articleContent);
+
+    // Do these last as the previous stuff may have removed junk
+    // that will affect these
+    this._cleanConditionally(articleContent, "table");
+    this._cleanConditionally(articleContent, "ul");
+    this._cleanConditionally(articleContent, "div");
+
+    // replace H1 with H2 as H1 should be only title that is displayed separately
+    this._replaceNodeTags(
+      this._getAllNodesWithTag(articleContent, ["h1"]),
+      "h2"
+    );
+
+    // Remove extra paragraphs
+    this._removeNodes(
+      this._getAllNodesWithTag(articleContent, ["p"]),
+      function (paragraph) {
+        // At this point, nasty iframes have been removed; only embedded video
+        // ones remain.
+        var contentElementCount = this._getAllNodesWithTag(paragraph, [
+          "img",
+          "embed",
+          "object",
+          "iframe",
+        ]).length;
+        return (
+          contentElementCount === 0 && !this._getInnerText(paragraph, false)
+        );
+      }
+    );
+
+    this._forEachNode(
+      this._getAllNodesWithTag(articleContent, ["br"]),
+      function (br) {
+        var next = this._nextNode(br.nextSibling);
+        if (next && next.tagName == "P") {
+          br.remove();
+        }
+      }
+    );
+
+    // Remove single-cell tables
+    this._forEachNode(
+      this._getAllNodesWithTag(articleContent, ["table"]),
+      function (table) {
+        var tbody = this._hasSingleTagInsideElement(table, "TBODY")
+          ? table.firstElementChild
+          : table;
+        if (this._hasSingleTagInsideElement(tbody, "TR")) {
+          var row = tbody.firstElementChild;
+          if (this._hasSingleTagInsideElement(row, "TD")) {
+            var cell = row.firstElementChild;
+            cell = this._setNodeTag(
+              cell,
+              this._everyNode(cell.childNodes, this._isPhrasingContent)
+                ? "P"
+                : "DIV"
+            );
+            table.parentNode.replaceChild(cell, table);
+          }
+        }
+      }
+    );
+  },
+
+  /**
+   * Initialize a node with the readability object. Also checks the
+   * className/id for special names to add to its score.
+   *
+   * @param Element
+   * @return void
+   **/
+  _initializeNode(node) {
+    node.readability = { contentScore: 0 };
+
+    switch (node.tagName) {
+      case "DIV":
+        node.readability.contentScore += 5;
+        break;
+
+      case "PRE":
+      case "TD":
+      case "BLOCKQUOTE":
+        node.readability.contentScore += 3;
+        break;
+
+      case "ADDRESS":
+      case "OL":
+      case "UL":
+      case "DL":
+      case "DD":
+      case "DT":
+      case "LI":
+      case "FORM":
+        node.readability.contentScore -= 3;
+        break;
+
+      case "H1":
+      case "H2":
+      case "H3":
+      case "H4":
+      case "H5":
+      case "H6":
+      case "TH":
+        node.readability.contentScore -= 5;
+        break;
+    }
+
+    node.readability.contentScore += this._getClassWeight(node);
+  },
+
+  _removeAndGetNext(node) {
+    var nextNode = this._getNextNode(node, true);
+    node.remove();
+    return nextNode;
+  },
+
+  /**
+   * Traverse the DOM from node to node, starting at the node passed in.
+   * Pass true for the second parameter to indicate this node itself
+   * (and its kids) are going away, and we want the next node over.
+   *
+   * Calling this in a loop will traverse the DOM depth-first.
+   *
+   * @param {Element} node
+   * @param {boolean} ignoreSelfAndKids
+   * @return {Element}
+   */
+  _getNextNode(node, ignoreSelfAndKids) {
+    // First check for kids if those aren't being ignored
+    if (!ignoreSelfAndKids && node.firstElementChild) {
+      return node.firstElementChild;
+    }
+    // Then for siblings...
+    if (node.nextElementSibling) {
+      return node.nextElementSibling;
+    }
+    // And finally, move up the parent chain *and* find a sibling
+    // (because this is depth-first traversal, we will have already
+    // seen the parent nodes themselves).
+    do {
+      node = node.parentNode;
+    } while (node && !node.nextElementSibling);
+    return node && node.nextElementSibling;
+  },
+
+  // compares second text to first one
+  // 1 = same text, 0 = completely different text
+  // works the way that it splits both texts into words and then finds words that are unique in second text
+  // the result is given by the lower length of unique parts
+  _textSimilarity(textA, textB) {
+    var tokensA = textA
+      .toLowerCase()
+      .split(this.REGEXPS.tokenize)
+      .filter(Boolean);
+    var tokensB = textB
+      .toLowerCase()
+      .split(this.REGEXPS.tokenize)
+      .filter(Boolean);
+    if (!tokensA.length || !tokensB.length) {
+      return 0;
+    }
+    var uniqTokensB = tokensB.filter(token => !tokensA.includes(token));
+    var distanceB = uniqTokensB.join(" ").length / tokensB.join(" ").length;
+    return 1 - distanceB;
+  },
+
+  /**
+   * Checks whether an element node contains a valid byline
+   *
+   * @param node {Element}
+   * @param matchString {string}
+   * @return boolean
+   */
+  _isValidByline(node, matchString) {
+    var rel = node.getAttribute("rel");
+    var itemprop = node.getAttribute("itemprop");
+    var bylineLength = node.textContent.trim().length;
+
+    return (
+      (rel === "author" ||
+        (itemprop && itemprop.includes("author")) ||
+        this.REGEXPS.byline.test(matchString)) &&
+      !!bylineLength &&
+      bylineLength < 100
+    );
+  },
+
+  _getNodeAncestors(node, maxDepth) {
+    maxDepth = maxDepth || 0;
+    var i = 0,
+      ancestors = [];
+    while (node.parentNode) {
+      ancestors.push(node.parentNode);
+      if (maxDepth && ++i === maxDepth) {
+        break;
+      }
+      node = node.parentNode;
+    }
+    return ancestors;
+  },
+
+  /***
+   * grabArticle - Using a variety of metrics (content score, classname, element types), find the content that is
+   *         most likely to be the stuff a user wants to read. Then return it wrapped up in a div.
+   *
+   * @param page a document to run upon. Needs to be a full document, complete with body.
+   * @return Element
+   **/
+  /* eslint-disable-next-line complexity */
+  _grabArticle(page) {
+    this.log("**** grabArticle ****");
+    var doc = this._doc;
+    var isPaging = page !== null;
+    page = page ? page : this._doc.body;
+
+    // We can't grab an article if we don't have a page!
+    if (!page) {
+      this.log("No body found in document. Abort.");
+      return null;
+    }
+
+    var pageCacheHtml = page.innerHTML;
+
+    while (true) {
+      this.log("Starting grabArticle loop");
+      var stripUnlikelyCandidates = this._flagIsActive(
+        this.FLAG_STRIP_UNLIKELYS
+      );
+
+      // First, node prepping. Trash nodes that look cruddy (like ones with the
+      // class name "comment", etc), and turn divs into P tags where they have been
+      // used inappropriately (as in, where they contain no other block level elements.)
+      var elementsToScore = [];
+      var node = this._doc.documentElement;
+
+      let shouldRemoveTitleHeader = true;
+
+      while (node) {
+        if (node.tagName === "HTML") {
+          this._articleLang = node.getAttribute("lang");
+        }
+
+        var matchString = node.className + " " + node.id;
+
+        if (!this._isProbablyVisible(node)) {
+          this.log("Removing hidden node - " + matchString);
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // User is not able to see elements applied with both "aria-modal = true" and "role = dialog"
+        if (
+          node.getAttribute("aria-modal") == "true" &&
+          node.getAttribute("role") == "dialog"
+        ) {
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // If we don't have a byline yet check to see if this node is a byline; if it is store the byline and remove the node.
+        if (
+          !this._articleByline &&
+          !this._metadata.byline &&
+          this._isValidByline(node, matchString)
+        ) {
+          // Find child node matching [itemprop="name"] and use that if it exists for a more accurate author name byline
+          var endOfSearchMarkerNode = this._getNextNode(node, true);
+          var next = this._getNextNode(node);
+          var itemPropNameNode = null;
+          while (next && next != endOfSearchMarkerNode) {
+            var itemprop = next.getAttribute("itemprop");
+            if (itemprop && itemprop.includes("name")) {
+              itemPropNameNode = next;
+              break;
+            } else {
+              next = this._getNextNode(next);
+            }
+          }
+          this._articleByline = (itemPropNameNode ?? node).textContent.trim();
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        if (shouldRemoveTitleHeader && this._headerDuplicatesTitle(node)) {
+          this.log(
+            "Removing header: ",
+            node.textContent.trim(),
+            this._articleTitle.trim()
+          );
+          shouldRemoveTitleHeader = false;
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        // Remove unlikely candidates
+        if (stripUnlikelyCandidates) {
+          if (
+            this.REGEXPS.unlikelyCandidates.test(matchString) &&
+            !this.REGEXPS.okMaybeItsACandidate.test(matchString) &&
+            !this._hasAncestorTag(node, "table") &&
+            !this._hasAncestorTag(node, "code") &&
+            node.tagName !== "BODY" &&
+            node.tagName !== "A"
+          ) {
+            this.log("Removing unlikely candidate - " + matchString);
+            node = this._removeAndGetNext(node);
+            continue;
+          }
+
+          if (this.UNLIKELY_ROLES.includes(node.getAttribute("role"))) {
+            this.log(
+              "Removing content with role " +
+                node.getAttribute("role") +
+                " - " +
+                matchString
+            );
+            node = this._removeAndGetNext(node);
+            continue;
+          }
+        }
+
+        // Remove DIV, SECTION, and HEADER nodes without any content(e.g. text, image, video, or iframe).
+        if (
+          (node.tagName === "DIV" ||
+            node.tagName === "SECTION" ||
+            node.tagName === "HEADER" ||
+            node.tagName === "H1" ||
+            node.tagName === "H2" ||
+            node.tagName === "H3" ||
+            node.tagName === "H4" ||
+            node.tagName === "H5" ||
+            node.tagName === "H6") &&
+          this._isElementWithoutContent(node)
+        ) {
+          node = this._removeAndGetNext(node);
+          continue;
+        }
+
+        if (this.DEFAULT_TAGS_TO_SCORE.includes(node.tagName)) {
+          elementsToScore.push(node);
+        }
+
+        // Turn all divs that don't have children block level elements into p's
+        if (node.tagName === "DIV") {
+          // Put phrasing content into paragraphs.
+          var childNode = node.firstChild;
+          while (childNode) {
+            var nextSibling = childNode.nextSibling;
+            if (this._isPhrasingContent(childNode)) {
+              var fragment = doc.createDocumentFragment();
+              // Collect all consecutive phrasing content into a fragment.
+              do {
+                nextSibling = childNode.nextSibling;
+                fragment.appendChild(childNode);
+                childNode = nextSibling;
+              } while (childNode && this._isPhrasingContent(childNode));
+
+              // Trim leading and trailing whitespace from the fragment.
+              while (
+                fragment.firstChild &&
+                this._isWhitespace(fragment.firstChild)
+              ) {
+                fragment.firstChild.remove();
+              }
+              while (
+                fragment.lastChild &&
+                this._isWhitespace(fragment.lastChild)
+              ) {
+                fragment.lastChild.remove();
+              }
+
+              // If the fragment contains anything, wrap it in a paragraph and
+              // insert it before the next non-phrasing node.
+              if (fragment.firstChild) {
+                var p = doc.createElement("p");
+                p.appendChild(fragment);
+                node.insertBefore(p, nextSibling);
+              }
+            }
+            childNode = nextSibling;
+          }
+
+          // Sites like http://mobile.slate.com encloses each paragraph with a DIV
+          // element. DIVs with only a P element inside and no text content can be
+          // safely converted into plain P elements to avoid confusing the scoring
+          // algorithm with DIVs with are, in practice, paragraphs.
+          if (
+            this._hasSingleTagInsideElement(node, "P") &&
+            this._getLinkDensity(node) < 0.25
+          ) {
+            var newNode = node.children[0];
+            node.parentNode.replaceChild(newNode, node);
+            node = newNode;
+            elementsToScore.push(node);
+          } else if (!this._hasChildBlockElement(node)) {
+            node = this._setNodeTag(node, "P");
+            elementsToScore.push(node);
+          }
+        }
+        node = this._getNextNode(node);
+      }
+
+      /**
+       * Loop through all paragraphs, and assign a score to them based on how content-y they look.
+       * Then add their score to their parent node.
+       *
+       * A score is determined by things like number of commas, class names, etc. Maybe eventually link density.
+       **/
+      var candidates = [];
+      this._forEachNode(elementsToScore, function (elementToScore) {
+        if (
+          !elementToScore.parentNode ||
+          typeof elementToScore.parentNode.tagName === "undefined"
+        ) {
+          return;
+        }
+
+        // If this paragraph is less than 25 characters, don't even count it.
+        var innerText = this._getInnerText(elementToScore);
+        if (innerText.length < 25) {
+          return;
+        }
+
+        // Exclude nodes with no ancestor.
+        var ancestors = this._getNodeAncestors(elementToScore, 5);
+        if (ancestors.length === 0) {
+          return;
+        }
+
+        var contentScore = 0;
+
+        // Add a point for the paragraph itself as a base.
+        contentScore += 1;
+
+        // Add points for any commas within this paragraph.
+        contentScore += innerText.split(this.REGEXPS.commas).length;
+
+        // For every 100 characters in this paragraph, add another point. Up to 3 points.
+        contentScore += Math.min(Math.floor(innerText.length / 100), 3);
+
+        // Initialize and score ancestors.
+        this._forEachNode(ancestors, function (ancestor, level) {
+          if (
+            !ancestor.tagName ||
+            !ancestor.parentNode ||
+            typeof ancestor.parentNode.tagName === "undefined"
+          ) {
+            return;
+          }
+
+          if (typeof ancestor.readability === "undefined") {
+            this._initializeNode(ancestor);
+            candidates.push(ancestor);
+          }
+
+          // Node score divider:
+          // - parent:             1 (no division)
+          // - grandparent:        2
+          // - great grandparent+: ancestor level * 3
+          if (level === 0) {
+            var scoreDivider = 1;
+          } else if (level === 1) {
+            scoreDivider = 2;
+          } else {
+            scoreDivider = level * 3;
+          }
+          ancestor.readability.contentScore += contentScore / scoreDivider;
+        });
+      });
+
+      // After we've calculated scores, loop through all of the possible
+      // candidate nodes we found and find the one with the highest score.
+      var topCandidates = [];
+      for (var c = 0, cl = candidates.length; c < cl; c += 1) {
+        var candidate = candidates[c];
+
+        // Scale the final candidates score based on link density. Good content
+        // should have a relatively small link density (5% or less) and be mostly
+        // unaffected by this operation.
+        var candidateScore =
+          candidate.readability.contentScore *
+          (1 - this._getLinkDensity(candidate));
+        candidate.readability.contentScore = candidateScore;
+
+        this.log("Candidate:", candidate, "with score " + candidateScore);
+
+        for (var t = 0; t < this._nbTopCandidates; t++) {
+          var aTopCandidate = topCandidates[t];
+
+          if (
+            !aTopCandidate ||
+            candidateScore > aTopCandidate.readability.contentScore
+          ) {
+            topCandidates.splice(t, 0, candidate);
+            if (topCandidates.length > this._nbTopCandidates) {
+              topCandidates.pop();
+            }
+            break;
+          }
+        }
+      }
+
+      var topCandidate = topCandidates[0] || null;
+      var neededToCreateTopCandidate = false;
+      var parentOfTopCandidate;
+
+      // If we still have no top candidate, just use the body as a last resort.
+      // We also have to copy the body node so it is something we can modify.
+      if (topCandidate === null || topCandidate.tagName === "BODY") {
+        // Move all of the page's children into topCandidate
+        topCandidate = doc.createElement("DIV");
+        neededToCreateTopCandidate = true;
+        // Move everything (not just elements, also text nodes etc.) into the container
+        // so we even include text directly in the body:
+        while (page.firstChild) {
+          this.log("Moving child out:", page.firstChild);
+          topCandidate.appendChild(page.firstChild);
+        }
+
+        page.appendChild(topCandidate);
+
+        this._initializeNode(topCandidate);
+      } else if (topCandidate) {
+        // Find a better top candidate node if it contains (at least three) nodes which belong to `topCandidates` array
+        // and whose scores are quite closed with current `topCandidate` node.
+        var alternativeCandidateAncestors = [];
+        for (var i = 1; i < topCandidates.length; i++) {
+          if (
+            topCandidates[i].readability.contentScore /
+              topCandidate.readability.contentScore >=
+            0.75
+          ) {
+            alternativeCandidateAncestors.push(
+              this._getNodeAncestors(topCandidates[i])
+            );
+          }
+        }
+        var MINIMUM_TOPCANDIDATES = 3;
+        if (alternativeCandidateAncestors.length >= MINIMUM_TOPCANDIDATES) {
+          parentOfTopCandidate = topCandidate.parentNode;
+          while (parentOfTopCandidate.tagName !== "BODY") {
+            var listsContainingThisAncestor = 0;
+            for (
+              var ancestorIndex = 0;
+              ancestorIndex < alternativeCandidateAncestors.length &&
+              listsContainingThisAncestor < MINIMUM_TOPCANDIDATES;
+              ancestorIndex++
+            ) {
+              listsContainingThisAncestor += Number(
+                alternativeCandidateAncestors[ancestorIndex].includes(
+                  parentOfTopCandidate
+                )
+              );
+            }
+            if (listsContainingThisAncestor >= MINIMUM_TOPCANDIDATES) {
+              topCandidate = parentOfTopCandidate;
+              break;
+            }
+            parentOfTopCandidate = parentOfTopCandidate.parentNode;
+          }
+        }
+        if (!topCandidate.readability) {
+          this._initializeNode(topCandidate);
+        }
+
+        // Because of our bonus system, parents of candidates might have scores
+        // themselves. They get half of the node. There won't be nodes with higher
+        // scores than our topCandidate, but if we see the score going *up* in the first
+        // few steps up the tree, that's a decent sign that there might be more content
+        // lurking in other places that we want to unify in. The sibling stuff
+        // below does some of that - but only if we've looked high enough up the DOM
+        // tree.
+        parentOfTopCandidate = topCandidate.parentNode;
+        var lastScore = topCandidate.readability.contentScore;
+        // The scores shouldn't get too low.
+        var scoreThreshold = lastScore / 3;
+        while (parentOfTopCandidate.tagName !== "BODY") {
+          if (!parentOfTopCandidate.readability) {
+            parentOfTopCandidate = parentOfTopCandidate.parentNode;
+            continue;
+          }
+          var parentScore = parentOfTopCandidate.readability.contentScore;
+          if (parentScore < scoreThreshold) {
+            break;
+          }
+          if (parentScore > lastScore) {
+            // Alright! We found a better parent to use.
+            topCandidate = parentOfTopCandidate;
+            break;
+          }
+          lastScore = parentOfTopCandidate.readability.contentScore;
+          parentOfTopCandidate = parentOfTopCandidate.parentNode;
+        }
+
+        // If the top candidate is the only child, use parent instead. This will help sibling
+        // joining logic when adjacent content is actually located in parent's sibling node.
+        parentOfTopCandidate = topCandidate.parentNode;
+        while (
+          parentOfTopCandidate.tagName != "BODY" &&
+          parentOfTopCandidate.children.length == 1
+        ) {
+          topCandidate = parentOfTopCandidate;
+          parentOfTopCandidate = topCandidate.parentNode;
+        }
+        if (!topCandidate.readability) {
+          this._initializeNode(topCandidate);
+        }
+      }
+
+      // Now that we have the top candidate, look through its siblings for content
+      // that might also be related. Things like preambles, content split by ads
+      // that we removed, etc.
+      var articleContent = doc.createElement("DIV");
+      if (isPaging) {
+        articleContent.id = "readability-content";
+      }
+
+      var siblingScoreThreshold = Math.max(
+        10,
+        topCandidate.readability.contentScore * 0.2
+      );
+      // Keep potential top candidate's parent node to try to get text direction of it later.
+      parentOfTopCandidate = topCandidate.parentNode;
+      var siblings = parentOfTopCandidate.children;
+
+      for (var s = 0, sl = siblings.length; s < sl; s++) {
+        var sibling = siblings[s];
+        var append = false;
+
+        this.log(
+          "Looking at sibling node:",
+          sibling,
+          sibling.readability
+            ? "with score " + sibling.readability.contentScore
+            : ""
+        );
+        this.log(
+          "Sibling has score",
+          sibling.readability ? sibling.readability.contentScore : "Unknown"
+        );
+
+        if (sibling === topCandidate) {
+          append = true;
+        } else {
+          var contentBonus = 0;
+
+          // Give a bonus if sibling nodes and top candidates have the example same classname
+          if (
+            sibling.className === topCandidate.className &&
+            topCandidate.className !== ""
+          ) {
+            contentBonus += topCandidate.readability.contentScore * 0.2;
+          }
+
+          if (
+            sibling.readability &&
+            sibling.readability.contentScore + contentBonus >=
+              siblingScoreThreshold
+          ) {
+            append = true;
+          } else if (sibling.nodeName === "P") {
+            var linkDensity = this._getLinkDensity(sibling);
+            var nodeContent = this._getInnerText(sibling);
+            var nodeLength = nodeContent.length;
+
+            if (nodeLength > 80 && linkDensity < 0.25) {
+              append = true;
+            } else if (
+              nodeLength < 80 &&
+              nodeLength > 0 &&
+              linkDensity === 0 &&
+              nodeContent.search(/\.( |$)/) !== -1
+            ) {
+              append = true;
+            }
+          }
+        }
+
+        if (append) {
+          this.log("Appending node:", sibling);
+
+          if (!this.ALTER_TO_DIV_EXCEPTIONS.includes(sibling.nodeName)) {
+            // We have a node that isn't a common block level element, like a form or td tag.
+            // Turn it into a div so it doesn't get filtered out later by accident.
+            this.log("Altering sibling:", sibling, "to div.");
+
+            sibling = this._setNodeTag(sibling, "DIV");
+          }
+
+          articleContent.appendChild(sibling);
+          // Fetch children again to make it compatible
+          // with DOM parsers without live collection support.
+          siblings = parentOfTopCandidate.children;
+          // siblings is a reference to the children array, and
+          // sibling is removed from the array when we call appendChild().
+          // As a result, we must revisit this index since the nodes
+          // have been shifted.
+          s -= 1;
+          sl -= 1;
+        }
+      }
+
+      if (this._debug) {
+        this.log("Article content pre-prep: " + articleContent.innerHTML);
+      }
+      // So we have all of the content that we need. Now we clean it up for presentation.
+      this._prepArticle(articleContent);
+      if (this._debug) {
+        this.log("Article content post-prep: " + articleContent.innerHTML);
+      }
+
+      if (neededToCreateTopCandidate) {
+        // We already created a fake div thing, and there wouldn't have been any siblings left
+        // for the previous loop, so there's no point trying to create a new div, and then
+        // move all the children over. Just assign IDs and class names here. No need to append
+        // because that already happened anyway.
+        topCandidate.id = "readability-page-1";
+        topCandidate.className = "page";
+      } else {
+        var div = doc.createElement("DIV");
+        div.id = "readability-page-1";
+        div.className = "page";
+        while (articleContent.firstChild) {
+          div.appendChild(articleContent.firstChild);
+        }
+        articleContent.appendChild(div);
+      }
+
+      if (this._debug) {
+        this.log("Article content after paging: " + articleContent.innerHTML);
+      }
+
+      var parseSuccessful = true;
+
+      // Now that we've gone through the full algorithm, check to see if
+      // we got any meaningful content. If we didn't, we may need to re-run
+      // grabArticle with different flags set. This gives us a higher likelihood of
+      // finding the content, and the sieve approach gives us a higher likelihood of
+      // finding the -right- content.
+      var textLength = this._getInnerText(articleContent, true).length;
+      if (textLength < this._charThreshold) {
+        parseSuccessful = false;
+        // eslint-disable-next-line no-unsanitized/property
+        page.innerHTML = pageCacheHtml;
+
+        this._attempts.push({
+          articleContent,
+          textLength,
+        });
+
+        if (this._flagIsActive(this.FLAG_STRIP_UNLIKELYS)) {
+          this._removeFlag(this.FLAG_STRIP_UNLIKELYS);
+        } else if (this._flagIsActive(this.FLAG_WEIGHT_CLASSES)) {
+          this._removeFlag(this.FLAG_WEIGHT_CLASSES);
+        } else if (this._flagIsActive(this.FLAG_CLEAN_CONDITIONALLY)) {
+          this._removeFlag(this.FLAG_CLEAN_CONDITIONALLY);
+        } else {
+          // No luck after removing flags, just return the longest text we found during the different loops
+          this._attempts.sort(function (a, b) {
+            return b.textLength - a.textLength;
+          });
+
+          // But first check if we actually have something
+          if (!this._attempts[0].textLength) {
+            return null;
+          }
+
+          articleContent = this._attempts[0].articleContent;
+          parseSuccessful = true;
+        }
+      }
+
+      if (parseSuccessful) {
+        // Find out text direction from ancestors of final top candidate.
+        var ancestors = [parentOfTopCandidate, topCandidate].concat(
+          this._getNodeAncestors(parentOfTopCandidate)
+        );
+        this._someNode(ancestors, function (ancestor) {
+          if (!ancestor.tagName) {
+            return false;
+          }
+          var articleDir = ancestor.getAttribute("dir");
+          if (articleDir) {
+            this._articleDir = articleDir;
+            return true;
+          }
+          return false;
+        });
+        return articleContent;
+      }
+    }
+  },
+
+  /**
+   * Converts some of the common HTML entities in string to their corresponding characters.
+   *
+   * @param str {string} - a string to unescape.
+   * @return string without HTML entity.
+   */
+  _unescapeHtmlEntities(str) {
+    if (!str) {
+      return str;
+    }
+
+    var htmlEscapeMap = this.HTML_ESCAPE_MAP;
+    return str
+      .replace(/&(quot|amp|apos|lt|gt);/g, function (_, tag) {
+        return htmlEscapeMap[tag];
+      })
+      .replace(/&#(?:x([0-9a-f]+)|([0-9]+));/gi, function (_, hex, numStr) {
+        var num = parseInt(hex || numStr, hex ? 16 : 10);
+
+        // these character references are replaced by a conforming HTML parser
+        if (num == 0 || num > 0x10ffff || (num >= 0xd800 && num <= 0xdfff)) {
+          num = 0xfffd;
+        }
+
+        return String.fromCodePoint(num);
+      });
+  },
+
+  /**
+   * Try to extract metadata from JSON-LD object.
+   * For now, only Schema.org objects of type Article or its subtypes are supported.
+   * @return Object with any metadata that could be extracted (possibly none)
+   */
+  _getJSONLD(doc) {
+    var scripts = this._getAllNodesWithTag(doc, ["script"]);
+
+    var metadata;
+
+    this._forEachNode(scripts, function (jsonLdElement) {
+      if (
+        !metadata &&
+        jsonLdElement.getAttribute("type") === "application/ld+json"
+      ) {
+        try {
+          // Strip CDATA markers if present
+          var content = jsonLdElement.textContent.replace(
+            /^\s*<!\[CDATA\[|\]\]>\s*$/g,
+            ""
+          );
+          var parsed = JSON.parse(content);
+
+          if (Array.isArray(parsed)) {
+            parsed = parsed.find(it => {
+              return (
+                it["@type"] &&
+                it["@type"].match(this.REGEXPS.jsonLdArticleTypes)
+              );
+            });
+            if (!parsed) {
+              return;
+            }
+          }
+
+          var schemaDotOrgRegex = /^https?\:\/\/schema\.org\/?$/;
+          var matches =
+            (typeof parsed["@context"] === "string" &&
+              parsed["@context"].match(schemaDotOrgRegex)) ||
+            (typeof parsed["@context"] === "object" &&
+              typeof parsed["@context"]["@vocab"] == "string" &&
+              parsed["@context"]["@vocab"].match(schemaDotOrgRegex));
+
+          if (!matches) {
+            return;
+          }
+
+          if (!parsed["@type"] && Array.isArray(parsed["@graph"])) {
+            parsed = parsed["@graph"].find(it => {
+              return (it["@type"] || "").match(this.REGEXPS.jsonLdArticleTypes);
+            });
+          }
+
+          if (
+            !parsed ||
+            !parsed["@type"] ||
+            !parsed["@type"].match(this.REGEXPS.jsonLdArticleTypes)
+          ) {
+            return;
+          }
+
+          metadata = {};
+
+          if (
+            typeof parsed.name === "string" &&
+            typeof parsed.headline === "string" &&
+            parsed.name !== parsed.headline
+          ) {
+            // we have both name and headline element in the JSON-LD. They should both be the same but some websites like aktualne.cz
+            // put their own name into "name" and the article title to "headline" which confuses Readability. So we try to check if either
+            // "name" or "headline" closely matches the html title, and if so, use that one. If not, then we use "name" by default.
+
+            var title = this._getArticleTitle();
+            var nameMatches = this._textSimilarity(parsed.name, title) > 0.75;
+            var headlineMatches =
+              this._textSimilarity(parsed.headline, title) > 0.75;
+
+            if (headlineMatches && !nameMatches) {
+              metadata.title = parsed.headline;
+            } else {
+              metadata.title = parsed.name;
+            }
+          } else if (typeof parsed.name === "string") {
+            metadata.title = parsed.name.trim();
+          } else if (typeof parsed.headline === "string") {
+            metadata.title = parsed.headline.trim();
+          }
+          if (parsed.author) {
+            if (typeof parsed.author.name === "string") {
+              metadata.byline = parsed.author.name.trim();
+            } else if (
+              Array.isArray(parsed.author) &&
+              parsed.author[0] &&
+              typeof parsed.author[0].name === "string"
+            ) {
+              metadata.byline = parsed.author
+                .filter(function (author) {
+                  return author && typeof author.name === "string";
+                })
+                .map(function (author) {
+                  return author.name.trim();
+                })
+                .join(", ");
+            }
+          }
+          if (typeof parsed.description === "string") {
+            metadata.excerpt = parsed.description.trim();
+          }
+          if (parsed.publisher && typeof parsed.publisher.name === "string") {
+            metadata.siteName = parsed.publisher.name.trim();
+          }
+          if (typeof parsed.datePublished === "string") {
+            metadata.datePublished = parsed.datePublished.trim();
+          }
+        } catch (err) {
+          this.log(err.message);
+        }
+      }
+    });
+    return metadata ? metadata : {};
+  },
+
+  /**
+   * Attempts to get excerpt and byline metadata for the article.
+   *
+   * @param {Object} jsonld — object containing any metadata that
+   * could be extracted from JSON-LD object.
+   *
+   * @return Object with optional "excerpt" and "byline" properties
+   */
+  _getArticleMetadata(jsonld) {
+    var metadata = {};
+    var values = {};
+    var metaElements = this._doc.getElementsByTagName("meta");
+
+    // property is a space-separated list of values
+    var propertyPattern =
+      /\s*(article|dc|dcterm|og|twitter)\s*:\s*(author|creator|description|published_time|title|site_name)\s*/gi;
+
+    // name is a single value
+    var namePattern =
+      /^\s*(?:(dc|dcterm|og|twitter|parsely|weibo:(article|webpage))\s*[-\.:]\s*)?(author|creator|pub-date|description|title|site_name)\s*$/i;
+
+    // Find description tags.
+    this._forEachNode(metaElements, function (element) {
+      var elementName = element.getAttribute("name");
+      var elementProperty = element.getAttribute("property");
+      var content = element.getAttribute("content");
+      if (!content) {
+        return;
+      }
+      var matches = null;
+      var name = null;
+
+      if (elementProperty) {
+        matches = elementProperty.match(propertyPattern);
+        if (matches) {
+          // Convert to lowercase, and remove any whitespace
+          // so we can match below.
+          name = matches[0].toLowerCase().replace(/\s/g, "");
+          // multiple authors
+          values[name] = content.trim();
+        }
+      }
+      if (!matches && elementName && namePattern.test(elementName)) {
+        name = elementName;
+        if (content) {
+          // Convert to lowercase, remove any whitespace, and convert dots
+          // to colons so we can match below.
+          name = name.toLowerCase().replace(/\s/g, "").replace(/\./g, ":");
+          values[name] = content.trim();
+        }
+      }
+    });
+
+    // get title
+    metadata.title =
+      jsonld.title ||
+      values["dc:title"] ||
+      values["dcterm:title"] ||
+      values["og:title"] ||
+      values["weibo:article:title"] ||
+      values["weibo:webpage:title"] ||
+      values.title ||
+      values["twitter:title"] ||
+      values["parsely-title"];
+
+    if (!metadata.title) {
+      metadata.title = this._getArticleTitle();
+    }
+
+    const articleAuthor =
+      typeof values["article:author"] === "string" &&
+      !this._isUrl(values["article:author"])
+        ? values["article:author"]
+        : undefined;
+
+    // get author
+    metadata.byline =
+      jsonld.byline ||
+      values["dc:creator"] ||
+      values["dcterm:creator"] ||
+      values.author ||
+      values["parsely-author"] ||
+      articleAuthor;
+
+    // get description
+    metadata.excerpt =
+      jsonld.excerpt ||
+      values["dc:description"] ||
+      values["dcterm:description"] ||
+      values["og:description"] ||
+      values["weibo:article:description"] ||
+      values["weibo:webpage:description"] ||
+      values.description ||
+      values["twitter:description"];
+
+    // get site name
+    metadata.siteName = jsonld.siteName || values["og:site_name"];
+
+    // get article published time
+    metadata.publishedTime =
+      jsonld.datePublished ||
+      values["article:published_time"] ||
+      values["parsely-pub-date"] ||
+      null;
+
+    // in many sites the meta value is escaped with HTML entities,
+    // so here we need to unescape it
+    metadata.title = this._unescapeHtmlEntities(metadata.title);
+    metadata.byline = this._unescapeHtmlEntities(metadata.byline);
+    metadata.excerpt = this._unescapeHtmlEntities(metadata.excerpt);
+    metadata.siteName = this._unescapeHtmlEntities(metadata.siteName);
+    metadata.publishedTime = this._unescapeHtmlEntities(metadata.publishedTime);
+
+    return metadata;
+  },
+
+  /**
+   * Check if node is image, or if node contains exactly only one image
+   * whether as a direct child or as its descendants.
+   *
+   * @param Element
+   **/
+  _isSingleImage(node) {
+    while (node) {
+      if (node.tagName === "IMG") {
+        return true;
+      }
+      if (node.children.length !== 1 || node.textContent.trim() !== "") {
+        return false;
+      }
+      node = node.children[0];
+    }
+    return false;
+  },
+
+  /**
+   * Find all <noscript> that are located after <img> nodes, and which contain only one
+   * <img> element. Replace the first image with the image from inside the <noscript> tag,
+   * and remove the <noscript> tag. This improves the quality of the images we use on
+   * some sites (e.g. Medium).
+   *
+   * @param Element
+   **/
+  _unwrapNoscriptImages(doc) {
+    // Find img without source or attributes that might contains image, and remove it.
+    // This is done to prevent a placeholder img is replaced by img from noscript in next step.
+    var imgs = Array.from(doc.getElementsByTagName("img"));
+    this._forEachNode(imgs, function (img) {
+      for (var i = 0; i < img.attributes.length; i++) {
+        var attr = img.attributes[i];
+        switch (attr.name) {
+          case "src":
+          case "srcset":
+          case "data-src":
+          case "data-srcset":
+            return;
+        }
+
+        if (/\.(jpg|jpeg|png|webp)/i.test(attr.value)) {
+          return;
+        }
+      }
+
+      img.remove();
+    });
+
+    // Next find noscript and try to extract its image
+    var noscripts = Array.from(doc.getElementsByTagName("noscript"));
+    this._forEachNode(noscripts, function (noscript) {
+      // Parse content of noscript and make sure it only contains image
+      if (!this._isSingleImage(noscript)) {
+        return;
+      }
+      var tmp = doc.createElement("div");
+      // We're running in the document context, and using unmodified
+      // document contents, so doing this should be safe.
+      // (Also we heavily discourage people from allowing script to
+      // run at all in this document...)
+      // eslint-disable-next-line no-unsanitized/property
+      tmp.innerHTML = noscript.innerHTML;
+
+      // If noscript has previous sibling and it only contains image,
+      // replace it with noscript content. However we also keep old
+      // attributes that might contains image.
+      var prevElement = noscript.previousElementSibling;
+      if (prevElement && this._isSingleImage(prevElement)) {
+        var prevImg = prevElement;
+        if (prevImg.tagName !== "IMG") {
+          prevImg = prevElement.getElementsByTagName("img")[0];
+        }
+
+        var newImg = tmp.getElementsByTagName("img")[0];
+        for (var i = 0; i < prevImg.attributes.length; i++) {
+          var attr = prevImg.attributes[i];
+          if (attr.value === "") {
+            continue;
+          }
+
+          if (
+            attr.name === "src" ||
+            attr.name === "srcset" ||
+            /\.(jpg|jpeg|png|webp)/i.test(attr.value)
+          ) {
+            if (newImg.getAttribute(attr.name) === attr.value) {
+              continue;
+            }
+
+            var attrName = attr.name;
+            if (newImg.hasAttribute(attrName)) {
+              attrName = "data-old-" + attrName;
+            }
+
+            newImg.setAttribute(attrName, attr.value);
+          }
+        }
+
+        noscript.parentNode.replaceChild(tmp.firstElementChild, prevElement);
+      }
+    });
+  },
+
+  /**
+   * Removes script tags from the document.
+   *
+   * @param Element
+   **/
+  _removeScripts(doc) {
+    this._removeNodes(this._getAllNodesWithTag(doc, ["script", "noscript"]));
+  },
+
+  /**
+   * Check if this node has only whitespace and a single element with given tag
+   * Returns false if the DIV node contains non-empty text nodes
+   * or if it contains no element with given tag or more than 1 element.
+   *
+   * @param Element
+   * @param string tag of child element
+   **/
+  _hasSingleTagInsideElement(element, tag) {
+    // There should be exactly 1 element child with given tag
+    if (element.children.length != 1 || element.children[0].tagName !== tag) {
+      return false;
+    }
+
+    // And there should be no text nodes with real content
+    return !this._someNode(element.childNodes, function (node) {
+      return (
+        node.nodeType === this.TEXT_NODE &&
+        this.REGEXPS.hasContent.test(node.textContent)
+      );
+    });
+  },
+
+  _isElementWithoutContent(node) {
+    return (
+      node.nodeType === this.ELEMENT_NODE &&
+      !node.textContent.trim().length &&
+      (!node.children.length ||
+        node.children.length ==
+          node.getElementsByTagName("br").length +
+            node.getElementsByTagName("hr").length)
+    );
+  },
+
+  /**
+   * Determine whether element has any children block level elements.
+   *
+   * @param Element
+   */
+  _hasChildBlockElement(element) {
+    return this._someNode(element.childNodes, function (node) {
+      return (
+        this.DIV_TO_P_ELEMS.has(node.tagName) ||
+        this._hasChildBlockElement(node)
+      );
+    });
+  },
+
+  /***
+   * Determine if a node qualifies as phrasing content.
+   * https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content
+   **/
+  _isPhrasingContent(node) {
+    return (
+      node.nodeType === this.TEXT_NODE ||
+      this.PHRASING_ELEMS.includes(node.tagName) ||
+      ((node.tagName === "A" ||
+        node.tagName === "DEL" ||
+        node.tagName === "INS") &&
+        this._everyNode(node.childNodes, this._isPhrasingContent))
+    );
+  },
+
+  _isWhitespace(node) {
+    return (
+      (node.nodeType === this.TEXT_NODE &&
+        node.textContent.trim().length === 0) ||
+      (node.nodeType === this.ELEMENT_NODE && node.tagName === "BR")
+    );
+  },
+
+  /**
+   * Get the inner text of a node - cross browser compatibly.
+   * This also strips out any excess whitespace to be found.
+   *
+   * @param Element
+   * @param Boolean normalizeSpaces (default: true)
+   * @return string
+   **/
+  _getInnerText(e, normalizeSpaces) {
+    normalizeSpaces =
+      typeof normalizeSpaces === "undefined" ? true : normalizeSpaces;
+    var textContent = e.textContent.trim();
+
+    if (normalizeSpaces) {
+      return textContent.replace(this.REGEXPS.normalize, " ");
+    }
+    return textContent;
+  },
+
+  /**
+   * Get the number of times a string s appears in the node e.
+   *
+   * @param Element
+   * @param string - what to split on. Default is ","
+   * @return number (integer)
+   **/
+  _getCharCount(e, s) {
+    s = s || ",";
+    return this._getInnerText(e).split(s).length - 1;
+  },
+
+  /**
+   * Remove the style attribute on every e and under.
+   * TODO: Test if getElementsByTagName(*) is faster.
+   *
+   * @param Element
+   * @return void
+   **/
+  _cleanStyles(e) {
+    if (!e || e.tagName.toLowerCase() === "svg") {
+      return;
+    }
+
+    // Remove `style` and deprecated presentational attributes
+    for (var i = 0; i < this.PRESENTATIONAL_ATTRIBUTES.length; i++) {
+      e.removeAttribute(this.PRESENTATIONAL_ATTRIBUTES[i]);
+    }
+
+    if (this.DEPRECATED_SIZE_ATTRIBUTE_ELEMS.includes(e.tagName)) {
+      e.removeAttribute("width");
+      e.removeAttribute("height");
+    }
+
+    var cur = e.firstElementChild;
+    while (cur !== null) {
+      this._cleanStyles(cur);
+      cur = cur.nextElementSibling;
+    }
+  },
+
+  /**
+   * Get the density of links as a percentage of the content
+   * This is the amount of text that is inside a link divided by the total text in the node.
+   *
+   * @param Element
+   * @return number (float)
+   **/
+  _getLinkDensity(element) {
+    var textLength = this._getInnerText(element).length;
+    if (textLength === 0) {
+      return 0;
+    }
+
+    var linkLength = 0;
+
+    // XXX implement _reduceNodeList?
+    this._forEachNode(element.getElementsByTagName("a"), function (linkNode) {
+      var href = linkNode.getAttribute("href");
+      var coefficient = href && this.REGEXPS.hashUrl.test(href) ? 0.3 : 1;
+      linkLength += this._getInnerText(linkNode).length * coefficient;
+    });
+
+    return linkLength / textLength;
+  },
+
+  /**
+   * Get an elements class/id weight. Uses regular expressions to tell if this
+   * element looks good or bad.
+   *
+   * @param Element
+   * @return number (Integer)
+   **/
+  _getClassWeight(e) {
+    if (!this._flagIsActive(this.FLAG_WEIGHT_CLASSES)) {
+      return 0;
+    }
+
+    var weight = 0;
+
+    // Look for a special classname
+    if (typeof e.className === "string" && e.className !== "") {
+      if (this.REGEXPS.negative.test(e.className)) {
+        weight -= 25;
+      }
+
+      if (this.REGEXPS.positive.test(e.className)) {
+        weight += 25;
+      }
+    }
+
+    // Look for a special ID
+    if (typeof e.id === "string" && e.id !== "") {
+      if (this.REGEXPS.negative.test(e.id)) {
+        weight -= 25;
+      }
+
+      if (this.REGEXPS.positive.test(e.id)) {
+        weight += 25;
+      }
+    }
+
+    return weight;
+  },
+
+  /**
+   * Clean a node of all elements of type "tag".
+   * (Unless it's a youtube/vimeo video. People love movies.)
+   *
+   * @param Element
+   * @param string tag to clean
+   * @return void
+   **/
+  _clean(e, tag) {
+    var isEmbed = ["object", "embed", "iframe"].includes(tag);
+
+    this._removeNodes(this._getAllNodesWithTag(e, [tag]), function (element) {
+      // Allow youtube and vimeo videos through as people usually want to see those.
+      if (isEmbed) {
+        // First, check the elements attributes to see if any of them contain youtube or vimeo
+        for (var i = 0; i < element.attributes.length; i++) {
+          if (this._allowedVideoRegex.test(element.attributes[i].value)) {
+            return false;
+          }
+        }
+
+        // For embed with <object> tag, check inner HTML as well.
+        if (
+          element.tagName === "object" &&
+          this._allowedVideoRegex.test(element.innerHTML)
+        ) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  },
+
+  /**
+   * Check if a given node has one of its ancestor tag name matching the
+   * provided one.
+   * @param  HTMLElement node
+   * @param  String      tagName
+   * @param  Number      maxDepth
+   * @param  Function    filterFn a filter to invoke to determine whether this node 'counts'
+   * @return Boolean
+   */
+  _hasAncestorTag(node, tagName, maxDepth, filterFn) {
+    maxDepth = maxDepth || 3;
+    tagName = tagName.toUpperCase();
+    var depth = 0;
+    while (node.parentNode) {
+      if (maxDepth > 0 && depth > maxDepth) {
+        return false;
+      }
+      if (
+        node.parentNode.tagName === tagName &&
+        (!filterFn || filterFn(node.parentNode))
+      ) {
+        return true;
+      }
+      node = node.parentNode;
+      depth++;
+    }
+    return false;
+  },
+
+  /**
+   * Return an object indicating how many rows and columns this table has.
+   */
+  _getRowAndColumnCount(table) {
+    var rows = 0;
+    var columns = 0;
+    var trs = table.getElementsByTagName("tr");
+    for (var i = 0; i < trs.length; i++) {
+      var rowspan = trs[i].getAttribute("rowspan") || 0;
+      if (rowspan) {
+        rowspan = parseInt(rowspan, 10);
+      }
+      rows += rowspan || 1;
+
+      // Now look for column-related info
+      var columnsInThisRow = 0;
+      var cells = trs[i].getElementsByTagName("td");
+      for (var j = 0; j < cells.length; j++) {
+        var colspan = cells[j].getAttribute("colspan") || 0;
+        if (colspan) {
+          colspan = parseInt(colspan, 10);
+        }
+        columnsInThisRow += colspan || 1;
+      }
+      columns = Math.max(columns, columnsInThisRow);
+    }
+    return { rows, columns };
+  },
+
+  /**
+   * Look for 'data' (as opposed to 'layout') tables, for which we use
+   * similar checks as
+   * https://searchfox.org/mozilla-central/rev/f82d5c549f046cb64ce5602bfd894b7ae807c8f8/accessible/generic/TableAccessible.cpp#19
+   */
+  _markDataTables(root) {
+    var tables = root.getElementsByTagName("table");
+    for (var i = 0; i < tables.length; i++) {
+      var table = tables[i];
+      var role = table.getAttribute("role");
+      if (role == "presentation") {
+        table._readabilityDataTable = false;
+        continue;
+      }
+      var datatable = table.getAttribute("datatable");
+      if (datatable == "0") {
+        table._readabilityDataTable = false;
+        continue;
+      }
+      var summary = table.getAttribute("summary");
+      if (summary) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      var caption = table.getElementsByTagName("caption")[0];
+      if (caption && caption.childNodes.length) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      // If the table has a descendant with any of these tags, consider a data table:
+      var dataTableDescendants = ["col", "colgroup", "tfoot", "thead", "th"];
+      var descendantExists = function (tag) {
+        return !!table.getElementsByTagName(tag)[0];
+      };
+      if (dataTableDescendants.some(descendantExists)) {
+        this.log("Data table because found data-y descendant");
+        table._readabilityDataTable = true;
+        continue;
+      }
+
+      // Nested tables indicate a layout table:
+      if (table.getElementsByTagName("table")[0]) {
+        table._readabilityDataTable = false;
+        continue;
+      }
+
+      var sizeInfo = this._getRowAndColumnCount(table);
+
+      if (sizeInfo.columns == 1 || sizeInfo.rows == 1) {
+        // single colum/row tables are commonly used for page layout purposes.
+        table._readabilityDataTable = false;
+        continue;
+      }
+
+      if (sizeInfo.rows >= 10 || sizeInfo.columns > 4) {
+        table._readabilityDataTable = true;
+        continue;
+      }
+      // Now just go by size entirely:
+      table._readabilityDataTable = sizeInfo.rows * sizeInfo.columns > 10;
+    }
+  },
+
+  /* convert images and figures that have properties like data-src into images that can be loaded without JS */
+  _fixLazyImages(root) {
+    this._forEachNode(
+      this._getAllNodesWithTag(root, ["img", "picture", "figure"]),
+      function (elem) {
+        // In some sites (e.g. Kotaku), they put 1px square image as base64 data uri in the src attribute.
+        // So, here we check if the data uri is too short, just might as well remove it.
+        if (elem.src && this.REGEXPS.b64DataUrl.test(elem.src)) {
+          // Make sure it's not SVG, because SVG can have a meaningful image in under 133 bytes.
+          var parts = this.REGEXPS.b64DataUrl.exec(elem.src);
+          if (parts[1] === "image/svg+xml") {
+            return;
+          }
+
+          // Make sure this element has other attributes which contains image.
+          // If it doesn't, then this src is important and shouldn't be removed.
+          var srcCouldBeRemoved = false;
+          for (var i = 0; i < elem.attributes.length; i++) {
+            var attr = elem.attributes[i];
+            if (attr.name === "src") {
+              continue;
+            }
+
+            if (/\.(jpg|jpeg|png|webp)/i.test(attr.value)) {
+              srcCouldBeRemoved = true;
+              break;
+            }
+          }
+
+          // Here we assume if image is less than 100 bytes (or 133 after encoded to base64)
+          // it will be too small, therefore it might be placeholder image.
+          if (srcCouldBeRemoved) {
+            var b64starts = parts[0].length;
+            var b64length = elem.src.length - b64starts;
+            if (b64length < 133) {
+              elem.removeAttribute("src");
+            }
+          }
+        }
+
+        // also check for "null" to work around https://github.com/jsdom/jsdom/issues/2580
+        if (
+          (elem.src || (elem.srcset && elem.srcset != "null")) &&
+          !elem.className.toLowerCase().includes("lazy")
+        ) {
+          return;
+        }
+
+        for (var j = 0; j < elem.attributes.length; j++) {
+          attr = elem.attributes[j];
+          if (
+            attr.name === "src" ||
+            attr.name === "srcset" ||
+            attr.name === "alt"
+          ) {
+            continue;
+          }
+          var copyTo = null;
+          if (/\.(jpg|jpeg|png|webp)\s+\d/.test(attr.value)) {
+            copyTo = "srcset";
+          } else if (/^\s*\S+\.(jpg|jpeg|png|webp)\S*\s*$/.test(attr.value)) {
+            copyTo = "src";
+          }
+          if (copyTo) {
+            //if this is an img or picture, set the attribute directly
+            if (elem.tagName === "IMG" || elem.tagName === "PICTURE") {
+              elem.setAttribute(copyTo, attr.value);
+            } else if (
+              elem.tagName === "FIGURE" &&
+              !this._getAllNodesWithTag(elem, ["img", "picture"]).length
+            ) {
+              //if the item is a <figure> that does not contain an image or picture, create one and place it inside the figure
+              //see the nytimes-3 testcase for an example
+              var img = this._doc.createElement("img");
+              img.setAttribute(copyTo, attr.value);
+              elem.appendChild(img);
+            }
+          }
+        }
+      }
+    );
+  },
+
+  _getTextDensity(e, tags) {
+    var textLength = this._getInnerText(e, true).length;
+    if (textLength === 0) {
+      return 0;
+    }
+    var childrenLength = 0;
+    var children = this._getAllNodesWithTag(e, tags);
+    this._forEachNode(
+      children,
+      child => (childrenLength += this._getInnerText(child, true).length)
+    );
+    return childrenLength / textLength;
+  },
+
+  /**
+   * Clean an element of all tags of type "tag" if they look fishy.
+   * "Fishy" is an algorithm based on content length, classnames, link density, number of images & embeds, etc.
+   *
+   * @return void
+   **/
+  _cleanConditionally(e, tag) {
+    if (!this._flagIsActive(this.FLAG_CLEAN_CONDITIONALLY)) {
+      return;
+    }
+
+    // Gather counts for other typical elements embedded within.
+    // Traverse backwards so we can remove nodes at the same time
+    // without effecting the traversal.
+    //
+    // TODO: Consider taking into account original contentScore here.
+    this._removeNodes(this._getAllNodesWithTag(e, [tag]), function (node) {
+      // First check if this node IS data table, in which case don't remove it.
+      var isDataTable = function (t) {
+        return t._readabilityDataTable;
+      };
+
+      var isList = tag === "ul" || tag === "ol";
+      if (!isList) {
+        var listLength = 0;
+        var listNodes = this._getAllNodesWithTag(node, ["ul", "ol"]);
+        this._forEachNode(
+          listNodes,
+          list => (listLength += this._getInnerText(list).length)
+        );
+        isList = listLength / this._getInnerText(node).length > 0.9;
+      }
+
+      if (tag === "table" && isDataTable(node)) {
+        return false;
+      }
+
+      // Next check if we're inside a data table, in which case don't remove it as well.
+      if (this._hasAncestorTag(node, "table", -1, isDataTable)) {
+        return false;
+      }
+
+      if (this._hasAncestorTag(node, "code")) {
+        return false;
+      }
+
+      // keep element if it has a data tables
+      if (
+        [...node.getElementsByTagName("table")].some(
+          tbl => tbl._readabilityDataTable
+        )
+      ) {
+        return false;
+      }
+
+      var weight = this._getClassWeight(node);
+
+      this.log("Cleaning Conditionally", node);
+
+      var contentScore = 0;
+
+      if (weight + contentScore < 0) {
+        return true;
+      }
+
+      if (this._getCharCount(node, ",") < 10) {
+        // If there are not very many commas, and the number of
+        // non-paragraph elements is more than paragraphs or other
+        // ominous signs, remove the element.
+        var p = node.getElementsByTagName("p").length;
+        var img = node.getElementsByTagName("img").length;
+        var li = node.getElementsByTagName("li").length - 100;
+        var input = node.getElementsByTagName("input").length;
+        var headingDensity = this._getTextDensity(node, [
+          "h1",
+          "h2",
+          "h3",
+          "h4",
+          "h5",
+          "h6",
+        ]);
+
+        var embedCount = 0;
+        var embeds = this._getAllNodesWithTag(node, [
+          "object",
+          "embed",
+          "iframe",
+        ]);
+
+        for (var i = 0; i < embeds.length; i++) {
+          // If this embed has attribute that matches video regex, don't delete it.
+          for (var j = 0; j < embeds[i].attributes.length; j++) {
+            if (this._allowedVideoRegex.test(embeds[i].attributes[j].value)) {
+              return false;
+            }
+          }
+
+          // For embed with <object> tag, check inner HTML as well.
+          if (
+            embeds[i].tagName === "object" &&
+            this._allowedVideoRegex.test(embeds[i].innerHTML)
+          ) {
+            return false;
+          }
+
+          embedCount++;
+        }
+
+        var innerText = this._getInnerText(node);
+
+        // toss any node whose inner text contains nothing but suspicious words
+        if (
+          this.REGEXPS.adWords.test(innerText) ||
+          this.REGEXPS.loadingWords.test(innerText)
+        ) {
+          return true;
+        }
+
+        var contentLength = innerText.length;
+        var linkDensity = this._getLinkDensity(node);
+        var textishTags = ["SPAN", "LI", "TD"].concat(
+          Array.from(this.DIV_TO_P_ELEMS)
+        );
+        var textDensity = this._getTextDensity(node, textishTags);
+        var isFigureChild = this._hasAncestorTag(node, "figure");
+
+        // apply shadiness checks, then check for exceptions
+        const shouldRemoveNode = () => {
+          const errs = [];
+          if (!isFigureChild && img > 1 && p / img < 0.5) {
+            errs.push(`Bad p to img ratio (img=${img}, p=${p})`);
+          }
+          if (!isList && li > p) {
+            errs.push(`Too many li's outside of a list. (li=${li} > p=${p})`);
+          }
+          if (input > Math.floor(p / 3)) {
+            errs.push(`Too many inputs per p. (input=${input}, p=${p})`);
+          }
+          if (
+            !isList &&
+            !isFigureChild &&
+            headingDensity < 0.9 &&
+            contentLength < 25 &&
+            (img === 0 || img > 2) &&
+            linkDensity > 0
+          ) {
+            errs.push(
+              `Suspiciously short. (headingDensity=${headingDensity}, img=${img}, linkDensity=${linkDensity})`
+            );
+          }
+          if (
+            !isList &&
+            weight < 25 &&
+            linkDensity > 0.2 + this._linkDensityModifier
+          ) {
+            errs.push(
+              `Low weight and a little linky. (linkDensity=${linkDensity})`
+            );
+          }
+          if (weight >= 25 && linkDensity > 0.5 + this._linkDensityModifier) {
+            errs.push(
+              `High weight and mostly links. (linkDensity=${linkDensity})`
+            );
+          }
+          if ((embedCount === 1 && contentLength < 75) || embedCount > 1) {
+            errs.push(
+              `Suspicious embed. (embedCount=${embedCount}, contentLength=${contentLength})`
+            );
+          }
+          if (img === 0 && textDensity === 0) {
+            errs.push(
+              `No useful content. (img=${img}, textDensity=${textDensity})`
+            );
+          }
+
+          if (errs.length) {
+            this.log("Checks failed", errs);
+            return true;
+          }
+
+          return false;
+        };
+
+        var haveToRemove = shouldRemoveNode();
+
+        // Allow simple lists of images to remain in pages
+        if (isList && haveToRemove) {
+          for (var x = 0; x < node.children.length; x++) {
+            let child = node.children[x];
+            // Don't filter in lists with li's that contain more than one child
+            if (child.children.length > 1) {
+              return haveToRemove;
+            }
+          }
+          let li_count = node.getElementsByTagName("li").length;
+          // Only allow the list to remain if every li contains an image
+          if (img == li_count) {
+            return false;
+          }
+        }
+        return haveToRemove;
+      }
+      return false;
+    });
+  },
+
+  /**
+   * Clean out elements that match the specified conditions
+   *
+   * @param Element
+   * @param Function determines whether a node should be removed
+   * @return void
+   **/
+  _cleanMatchedNodes(e, filter) {
+    var endOfSearchMarkerNode = this._getNextNode(e, true);
+    var next = this._getNextNode(e);
+    while (next && next != endOfSearchMarkerNode) {
+      if (filter.call(this, next, next.className + " " + next.id)) {
+        next = this._removeAndGetNext(next);
+      } else {
+        next = this._getNextNode(next);
+      }
+    }
+  },
+
+  /**
+   * Clean out spurious headers from an Element.
+   *
+   * @param Element
+   * @return void
+   **/
+  _cleanHeaders(e) {
+    let headingNodes = this._getAllNodesWithTag(e, ["h1", "h2"]);
+    this._removeNodes(headingNodes, function (node) {
+      let shouldRemove = this._getClassWeight(node) < 0;
+      if (shouldRemove) {
+        this.log("Removing header with low class weight:", node);
+      }
+      return shouldRemove;
+    });
+  },
+
+  /**
+   * Check if this node is an H1 or H2 element whose content is mostly
+   * the same as the article title.
+   *
+   * @param Element  the node to check.
+   * @return boolean indicating whether this is a title-like header.
+   */
+  _headerDuplicatesTitle(node) {
+    if (node.tagName != "H1" && node.tagName != "H2") {
+      return false;
+    }
+    var heading = this._getInnerText(node, false);
+    this.log("Evaluating similarity of header:", heading, this._articleTitle);
+    return this._textSimilarity(this._articleTitle, heading) > 0.75;
+  },
+
+  _flagIsActive(flag) {
+    return (this._flags & flag) > 0;
+  },
+
+  _removeFlag(flag) {
+    this._flags = this._flags & ~flag;
+  },
+
+  _isProbablyVisible(node) {
+    // Have to null-check node.style and node.className.includes to deal with SVG and MathML nodes.
+    return (
+      (!node.style || node.style.display != "none") &&
+      (!node.style || node.style.visibility != "hidden") &&
+      !node.hasAttribute("hidden") &&
+      //check for "fallback-image" so that wikimedia math images are displayed
+      (!node.hasAttribute("aria-hidden") ||
+        node.getAttribute("aria-hidden") != "true" ||
+        (node.className &&
+          node.className.includes &&
+          node.className.includes("fallback-image")))
+    );
+  },
+
+  /**
+   * Runs readability.
+   *
+   * Workflow:
+   *  1. Prep the document by removing script tags, css, etc.
+   *  2. Build readability's DOM tree.
+   *  3. Grab the article content from the current dom tree.
+   *  4. Replace the current DOM tree with the new one.
+   *  5. Read peacefully.
+   *
+   * @return void
+   **/
+  parse() {
+    // Avoid parsing too large documents, as per configuration option
+    if (this._maxElemsToParse > 0) {
+      var numTags = this._doc.getElementsByTagName("*").length;
+      if (numTags > this._maxElemsToParse) {
+        throw new Error(
+          "Aborting parsing document; " + numTags + " elements found"
+        );
+      }
+    }
+
+    // Unwrap image from noscript
+    this._unwrapNoscriptImages(this._doc);
+
+    // Extract JSON-LD metadata before removing scripts
+    var jsonLd = this._disableJSONLD ? {} : this._getJSONLD(this._doc);
+
+    // Remove script tags from the document.
+    this._removeScripts(this._doc);
+
+    this._prepDocument();
+
+    var metadata = this._getArticleMetadata(jsonLd);
+    this._metadata = metadata;
+    this._articleTitle = metadata.title;
+
+    var articleContent = this._grabArticle();
+    if (!articleContent) {
+      return null;
+    }
+
+    this.log("Grabbed: " + articleContent.innerHTML);
+
+    this._postProcessContent(articleContent);
+
+    // If we haven't found an excerpt in the article's metadata, use the article's
+    // first paragraph as the excerpt. This is used for displaying a preview of
+    // the article's content.
+    if (!metadata.excerpt) {
+      var paragraphs = articleContent.getElementsByTagName("p");
+      if (paragraphs.length) {
+        metadata.excerpt = paragraphs[0].textContent.trim();
+      }
+    }
+
+    var textContent = articleContent.textContent;
+    return {
+      title: this._articleTitle,
+      byline: metadata.byline || this._articleByline,
+      dir: this._articleDir,
+      lang: this._articleLang,
+      content: this._serializer(articleContent),
+      textContent,
+      length: textContent.length,
+      excerpt: metadata.excerpt,
+      siteName: metadata.siteName || this._articleSiteName,
+      publishedTime: metadata.publishedTime,
+    };
+  },
+};
+
+if (typeof module === "object") {
+  /* eslint-disable-next-line no-redeclare */
+  /* global module */
+  module.exports = Readability;
+}

--- a/app/src/main/assets/adblock-cosmetic.js
+++ b/app/src/main/assets/adblock-cosmetic.js
@@ -17,6 +17,35 @@
 
   var RUN_DELAY_MS = 120;
 
+  // Wire format: length-prefixed records `<len>:<text><len>:<text>...`
+  // (UTF-16 code-unit counts; matches Kotlin String.length on the bridge
+  // side). Robust to any content, no escape work.
+  function encodeWire(items) {
+    var s = '';
+    for (var i = 0; i < items.length; i++) {
+      var t = items[i];
+      s += t.length + ':' + t;
+    }
+    return s;
+  }
+
+  function decodeWire(s) {
+    var items = [];
+    var i = 0;
+    while (i < s.length) {
+      var colon = s.indexOf(':', i);
+      if (colon < 0) return null;
+      var len = parseInt(s.slice(i, colon), 10);
+      if (!isFinite(len) || len < 0) return null;
+      var start = colon + 1;
+      var end = start + len;
+      if (end > s.length) return null;
+      items.push(s.slice(start, end));
+      i = end;
+    }
+    return items;
+  }
+
   function current() {
     return state.config || {};
   }
@@ -259,12 +288,12 @@
       }
     }
 
-    var resultJson;
+    var resultPayload;
     try {
-      resultJson = adblockBridge.lookupGenericSelectors(
-        JSON.stringify(Array.from(classes)),
-        JSON.stringify(Array.from(ids)),
-        JSON.stringify(cfg.exceptions || []),
+      resultPayload = adblockBridge.lookupGenericSelectors(
+        encodeWire(Array.from(classes)),
+        encodeWire(Array.from(ids)),
+        encodeWire(cfg.exceptions || []),
         cfg.bridgeToken
       );
     } catch (e) {
@@ -272,12 +301,7 @@
       return;
     }
 
-    var selectors;
-    try {
-      selectors = JSON.parse(resultJson);
-    } catch (e) {
-      return;
-    }
+    var selectors = decodeWire(resultPayload || '');
     if (!selectors || selectors.length === 0) return;
 
     var style = document.querySelector('style[data-adblock-generic="1"]');

--- a/app/src/main/assets/adblock-cosmetic.js
+++ b/app/src/main/assets/adblock-cosmetic.js
@@ -1,0 +1,352 @@
+(function () {
+  var config = window.__translatorAdblockConfig;
+  if (!config) return;
+
+  if (window.__translatorAdblockRuntime) {
+    window.__translatorAdblockRuntime.configure(config);
+    return;
+  }
+
+  var state = {
+    config: config,
+    jsInjected: false,
+    validatedHideCss: null,
+    pendingRun: false,
+    observer: null,
+  };
+
+  var RUN_DELAY_MS = 120;
+
+  function current() {
+    return state.config || {};
+  }
+
+  function isValidSelector(selector) {
+    try {
+      document.querySelector(selector);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function buildCssText() {
+    var cfg = current();
+    if (state.validatedHideCss === null) {
+      var valid = [];
+      var invalid = 0;
+      var selectors = cfg.hideSelectors || [];
+      for (var i = 0; i < selectors.length; i++) {
+        if (isValidSelector(selectors[i])) valid.push(selectors[i]);
+        else invalid++;
+      }
+      state.validatedHideCss = valid.length
+        ? valid.join(',\n') + ' { display: none !important; min-height: 0 !important; min-width: 0 !important; height: 0 !important; }\n'
+        : '';
+      if (invalid) console.log('[adblock] skipped invalid cosmetic selectors: ' + invalid);
+    }
+    return state.validatedHideCss + (cfg.baseCss || '');
+  }
+
+  function rootNode() {
+    return document.head || document.documentElement || document.body;
+  }
+
+  function applyCss() {
+    var root = rootNode();
+    if (!root) return false;
+    try {
+      var css = buildCssText();
+      if (css) {
+        var existing = document.querySelector('style[data-adblock="1"]');
+        if (!existing || !existing.isConnected || existing.parentNode !== root) {
+          if (existing && !existing.isConnected) existing.remove();
+          var s = document.createElement('style');
+          s.setAttribute('data-adblock', '1');
+          s.textContent = css;
+          root.appendChild(s);
+        } else if (existing.textContent !== css) {
+          existing.textContent = css;
+        }
+      }
+      injectScriptlet(root);
+      return true;
+    } catch (e) {
+      console.warn('[adblock] cosmetic apply failed', e);
+      return true;
+    }
+  }
+
+  function injectScriptlet(root) {
+    var js = current().injectedScript || '';
+    if (!js || state.jsInjected) return;
+    var sc = document.createElement('script');
+    sc.setAttribute('data-adblock', '1');
+    sc.textContent = js;
+    root.appendChild(sc);
+    sc.remove();
+    state.jsInjected = true;
+  }
+
+  function opTask(op) {
+    var arg = op.arg;
+    switch (op.type) {
+      case 'CssSelector':
+        return function (nodes) {
+          if (nodes === null) {
+            try {
+              return Array.prototype.slice.call(document.querySelectorAll(arg));
+            } catch (e) {
+              return [];
+            }
+          }
+          var out = [];
+          for (var i = 0; i < nodes.length; i++) {
+            try {
+              out.push.apply(out, nodes[i].querySelectorAll(arg));
+            } catch (e) {}
+          }
+          return out;
+        };
+      case 'HasText':
+        var re;
+        if (arg && arg.length > 1 && arg.charAt(0) === '/' && arg.lastIndexOf('/') > 0) {
+          var slash = arg.lastIndexOf('/');
+          try {
+            re = new RegExp(arg.slice(1, slash), arg.slice(slash + 1));
+          } catch (e) {}
+        }
+        var literal = arg;
+        return function (nodes) {
+          return nodes.filter(function (n) {
+            var t = n.textContent || '';
+            return re ? re.test(t) : t.indexOf(literal) >= 0;
+          });
+        };
+      case 'MatchesCss':
+      case 'MatchesCssBefore':
+      case 'MatchesCssAfter':
+        var idx = arg.indexOf(':');
+        if (idx < 0) return function () { return []; };
+        var prop = arg.slice(0, idx).trim();
+        var val = arg.slice(idx + 1).trim();
+        var pseudo = op.type === 'MatchesCssBefore' ? '::before'
+          : op.type === 'MatchesCssAfter' ? '::after' : null;
+        return function (nodes) {
+          return nodes.filter(function (n) {
+            try {
+              var cs = window.getComputedStyle(n, pseudo);
+              return cs && cs.getPropertyValue(prop).trim() === val;
+            } catch (e) {
+              return false;
+            }
+          });
+        };
+      case 'Upward':
+        var n = parseInt(arg, 10);
+        if (!isNaN(n) && /^-?\d+$/.test(String(arg))) {
+          return function (nodes) {
+            var out = [];
+            for (var i = 0; i < nodes.length; i++) {
+              var p = nodes[i];
+              for (var k = 0; k < n && p; k++) p = p.parentElement;
+              if (p) out.push(p);
+            }
+            return out;
+          };
+        }
+        return function (nodes) {
+          var out = [];
+          for (var i = 0; i < nodes.length; i++) {
+            try {
+              var anc = nodes[i].parentElement && nodes[i].parentElement.closest(arg);
+              if (anc) out.push(anc);
+            } catch (e) {}
+          }
+          return out;
+        };
+      default:
+        return null;
+    }
+  }
+
+  function compileFilter(filter) {
+    var tasks = [];
+    for (var i = 0; i < filter.selector.length; i++) {
+      var t = opTask(filter.selector[i]);
+      if (!t) return null;
+      tasks.push(t);
+    }
+    return tasks;
+  }
+
+  function runFilter(filter) {
+    var tasks = compileFilter(filter);
+    if (!tasks) return;
+    var nodes = null;
+    for (var i = 0; i < tasks.length; i++) nodes = tasks[i](nodes);
+    if (!nodes || nodes.length === 0) return;
+    var action = filter.action;
+    if (!action) {
+      for (var j = 0; j < nodes.length; j++) nodes[j].setAttribute('data-adblock-hide', '1');
+      return;
+    }
+    switch (action.type) {
+      case 'Style':
+        for (var j2 = 0; j2 < nodes.length; j2++) {
+          try {
+            nodes[j2].style.cssText += ';' + action.arg;
+          } catch (e) {}
+        }
+        return;
+      case 'Remove':
+        for (var j3 = 0; j3 < nodes.length; j3++) {
+          try {
+            nodes[j3].remove();
+          } catch (e) {}
+        }
+        return;
+      case 'RemoveAttr':
+        for (var j4 = 0; j4 < nodes.length; j4++) {
+          try {
+            nodes[j4].removeAttribute(action.arg);
+          } catch (e) {}
+        }
+        return;
+      case 'RemoveClass':
+        for (var j5 = 0; j5 < nodes.length; j5++) {
+          try {
+            nodes[j5].classList.remove(action.arg);
+          } catch (e) {}
+        }
+        return;
+    }
+  }
+
+  function runProcedurals() {
+    var procedurals = current().proceduralFilters || [];
+    if (procedurals.length === 0) return;
+    for (var i = 0; i < procedurals.length; i++) {
+      var f;
+      try {
+        f = JSON.parse(procedurals[i]);
+      } catch (e) {
+        continue;
+      }
+      try {
+        runFilter(f);
+      } catch (e) {}
+    }
+  }
+
+  function applyGeneric() {
+    var cfg = current();
+    if (cfg.generichide) return;
+    var adblockBridge = window[cfg.adblockBridgeName];
+    if (!adblockBridge) return;
+    var classes = new Set();
+    var ids = new Set();
+    var els = document.getElementsByTagName('*');
+    for (var i = 0; i < els.length; i++) {
+      var el = els[i];
+      if (el.id) ids.add(el.id);
+      var cls = el.getAttribute && el.getAttribute('class');
+      if (cls) {
+        var parts = cls.split(/\s+/);
+        for (var j = 0; j < parts.length; j++) {
+          if (parts[j]) classes.add(parts[j]);
+        }
+      }
+    }
+
+    var resultJson;
+    try {
+      resultJson = adblockBridge.lookupGenericSelectors(
+        JSON.stringify(Array.from(classes)),
+        JSON.stringify(Array.from(ids)),
+        JSON.stringify(cfg.exceptions || []),
+        cfg.bridgeToken
+      );
+    } catch (e) {
+      console.warn('[adblock] generic lookup failed', e);
+      return;
+    }
+
+    var selectors;
+    try {
+      selectors = JSON.parse(resultJson);
+    } catch (e) {
+      return;
+    }
+    if (!selectors || selectors.length === 0) return;
+
+    var style = document.querySelector('style[data-adblock-generic="1"]');
+    if (!style) {
+      style = document.createElement('style');
+      style.setAttribute('data-adblock-generic', '1');
+      (rootNode() || document.documentElement).appendChild(style);
+    }
+    style.textContent =
+      selectors.join(',\n') +
+      ' { display: none !important; min-height: 0 !important; min-width: 0 !important; height: 0 !important; }';
+  }
+
+  function runAll() {
+    state.pendingRun = false;
+    applyCss();
+    runProcedurals();
+    applyGeneric();
+  }
+
+  function scheduleRun(delay) {
+    if (state.pendingRun) return;
+    state.pendingRun = true;
+    setTimeout(runAll, delay == null ? RUN_DELAY_MS : delay);
+  }
+
+  function setupObserver() {
+    if (state.observer || !document.documentElement) return;
+    state.observer = new MutationObserver(function () {
+      scheduleRun();
+    });
+    state.observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+      attributeFilter: ['class', 'id', 'style'],
+    });
+  }
+
+  function ready(fn) {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', fn, { once: true });
+    } else {
+      fn();
+    }
+  }
+
+  window.__translatorAdblockRuntime = {
+    configure: function (nextConfig) {
+      state.config = nextConfig || {};
+      state.validatedHideCss = null;
+      applyCss();
+      setupObserver();
+      scheduleRun(0);
+    },
+  };
+
+  if (!applyCss()) {
+    var tries = 0;
+    var iv = setInterval(function () {
+      tries++;
+      if (applyCss() || tries > 50) clearInterval(iv);
+    }, 20);
+  }
+
+  ready(function () {
+    applyCss();
+    setupObserver();
+    scheduleRun(0);
+  });
+})();

--- a/app/src/main/assets/index.json
+++ b/app/src/main/assets/index.json
@@ -10145,7 +10145,7 @@
       "files": [
         {
           "name": "adblock-lists-v1.zip",
-          "sizeBytes": 2124678,
+          "sizeBytes": 2124780,
           "installPath": "adblock/adblock-lists-v1.zip",
           "url": "https://offline-translator.davidv.dev/support/1/adblock/adblock-lists-v1.zip",
           "archiveFormat": "zip",

--- a/app/src/main/assets/index.json
+++ b/app/src/main/assets/index.json
@@ -10145,7 +10145,7 @@
       "files": [
         {
           "name": "adblock-lists-v1.zip",
-          "sizeBytes": 2124780,
+          "sizeBytes": 2124783,
           "installPath": "adblock/adblock-lists-v1.zip",
           "url": "https://offline-translator.davidv.dev/support/1/adblock/adblock-lists-v1.zip",
           "archiveFormat": "zip",

--- a/app/src/main/assets/index.json
+++ b/app/src/main/assets/index.json
@@ -1,10 +1,10 @@
 {
   "formatVersion": 2,
-  "generatedAt": 1776550317,
+  "generatedAt": 1777135794,
   "dictionaryVersion": 1,
   "sources": {
     "languageIndexVersion": 1,
-    "languageIndexUpdatedAt": 1776550317,
+    "languageIndexUpdatedAt": 1777135794,
     "dictionaryIndexVersion": 1,
     "dictionaryIndexUpdatedAt": 1774864382,
     "gcsModelsUrl": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/db/models.json",
@@ -10138,6 +10138,59 @@
       "dependsOn": [
         "tts-espeak-dict-cmn"
       ]
+    },
+    "support-adblock-lists-v1": {
+      "feature": "support",
+      "kind": "adblock",
+      "files": [
+        {
+          "name": "adblock-lists-v1.zip",
+          "sizeBytes": 2124678,
+          "installPath": "adblock/adblock-lists-v1.zip",
+          "url": "https://offline-translator.davidv.dev/support/1/adblock/adblock-lists-v1.zip",
+          "archiveFormat": "zip",
+          "extractTo": ".",
+          "deleteAfterExtract": true,
+          "installMarkerPath": "adblock/.install-info.json",
+          "installMarkerVersion": 1
+        }
+      ],
+      "dependsOn": [],
+      "metadata": {
+        "version": 1,
+        "lists": [
+          {
+            "packId": "support-adblock-adguard-mobile",
+            "listId": "adguard-mobile",
+            "description": "AdGuard Mobile Ads — mobile-specific ad slots and tracker patterns."
+          },
+          {
+            "packId": "support-adblock-easylist",
+            "listId": "easylist",
+            "description": "EasyList — primary advertising filter list."
+          },
+          {
+            "packId": "support-adblock-easyprivacy",
+            "listId": "easyprivacy",
+            "description": "EasyPrivacy — tracking and analytics filter list."
+          },
+          {
+            "packId": "support-adblock-fanboy-annoyance",
+            "listId": "fanboy-annoyance",
+            "description": "Fanboy's Annoyances — cookie banners, social widgets, sticky video."
+          },
+          {
+            "packId": "support-adblock-ublock-filters",
+            "listId": "ublock-filters",
+            "description": "uBlock Origin filters — cosmetic supplement to EasyList."
+          },
+          {
+            "packId": "support-adblock-ublock-unbreak",
+            "listId": "ublock-unbreak",
+            "description": "uBlock Origin unbreak — exceptions to fix sites broken by other lists."
+          }
+        ]
+      }
     }
   }
 }

--- a/app/src/main/assets/reader-mode.js
+++ b/app/src/main/assets/reader-mode.js
@@ -1,0 +1,125 @@
+(function () {
+  function ensureReadability() {
+    if (typeof Readability === 'function') return true;
+    try {
+      (0, eval)(window.__translatorReadabilityScript || '');
+      return typeof Readability === 'function';
+    } catch (e) {
+      console.warn('[reader-mode] failed to load Readability', e);
+      return false;
+    }
+  }
+
+  function escapeHtml(value) {
+    return String(value || '').replace(/[&<>"']/g, function (ch) {
+      return {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[ch];
+    });
+  }
+
+  function sanitizeArticleHtml(html) {
+    var container = document.createElement('template');
+    container.innerHTML = html || '';
+    var blocked = container.content.querySelectorAll(
+      'script, style, iframe, object, embed, form, input, button, textarea, select, link, meta'
+    );
+    for (var i = 0; i < blocked.length; i++) blocked[i].remove();
+
+    var walker = document.createTreeWalker(container.content, NodeFilter.SHOW_ELEMENT);
+    var node;
+    while ((node = walker.nextNode())) {
+      var attrs = Array.prototype.slice.call(node.attributes || []);
+      for (var j = 0; j < attrs.length; j++) {
+        var name = attrs[j].name;
+        var lowerName = name.toLowerCase();
+        var value = attrs[j].value || '';
+        if (lowerName.indexOf('on') === 0 || lowerName === 'srcdoc') {
+          node.removeAttribute(name);
+          continue;
+        }
+        if (
+          (lowerName === 'href' || lowerName === 'src' || lowerName === 'xlink:href') &&
+          /^\s*javascript:/i.test(value)
+        ) {
+          node.removeAttribute(name);
+        }
+      }
+    }
+    return container.innerHTML;
+  }
+
+  function buildReaderDocument(article) {
+    var title = escapeHtml(article.title || document.title || 'Reader mode');
+    var byline = article.byline ? '<p class="reader-byline">' + escapeHtml(article.byline) + '</p>' : '';
+    var siteName = article.siteName ? '<p class="reader-site">' + escapeHtml(article.siteName) + '</p>' : '';
+    var content = sanitizeArticleHtml(article.content);
+    var lang = escapeHtml(article.lang || document.documentElement.lang || '');
+    var dir = escapeHtml(article.dir || document.dir || 'auto');
+    return (
+      '<!doctype html><html lang="' +
+      lang +
+      '" dir="' +
+      dir +
+      '">' +
+      '<head><meta charset="utf-8">' +
+      '<meta name="viewport" content="width=device-width, initial-scale=1">' +
+      '<title>' +
+      title +
+      '</title>' +
+      '<style>' +
+      ':root{color-scheme:light dark}' +
+      'body{margin:0;background:#f6f0e4;color:#211f1a;font:19px/1.68 Georgia,"Times New Roman",serif}' +
+      'main{box-sizing:border-box;max-width:min(760px,calc(100vw - 32px));margin:0 auto;padding:72px 0 40px}' +
+      '.reader-site{margin:0 0 10px;color:#746c5b;font:600 13px/1.2 sans-serif;letter-spacing:.08em;text-transform:uppercase}' +
+      'h1{margin:0 0 10px;color:#171510;font:700 34px/1.14 Georgia,"Times New Roman",serif}' +
+      '.reader-byline{margin:0 0 28px;color:#746c5b;font:15px/1.4 sans-serif}' +
+      'p,li,blockquote{color:inherit}' +
+      'a{color:#7b4a1f}' +
+      'img,video,figure,pre,table{max-width:100%;height:auto}' +
+      'img,video{border-radius:10px}' +
+      'pre{overflow:auto}' +
+      'figcaption{color:#746c5b;font:14px/1.4 sans-serif}' +
+      '@media (prefers-color-scheme:dark){body{background:#191714;color:#eee5d5}h1{color:#fff7e8}.reader-site,.reader-byline,figcaption{color:#a99f8d}a{color:#e0a15c}}' +
+      '</style></head><body><main>' +
+      siteName +
+      '<h1>' +
+      title +
+      '</h1>' +
+      byline +
+      content +
+      '</main></body></html>'
+    );
+  }
+
+  if (!ensureReadability()) return window.__translatorReaderModeProbe ? false : null;
+
+  try {
+    var clone = document.cloneNode(true);
+    var article = new Readability(clone, {
+      classesToPreserve: [
+        'caption',
+        'emoji',
+        'hidden',
+        'invisible',
+        'sr-only',
+        'visually-hidden',
+        'visuallyhidden',
+        'wp-caption',
+        'wp-caption-text',
+        'wp-smiley'
+      ]
+    }).parse();
+    if (!article || !article.content || article.length < 500) {
+      return window.__translatorReaderModeProbe ? false : null;
+    }
+    return window.__translatorReaderModeProbe ? true : buildReaderDocument(article);
+  } catch (e) {
+    console.warn('[reader-mode] failed', e);
+    return window.__translatorReaderModeProbe ? false : null;
+  }
+})();

--- a/app/src/main/assets/translator.js
+++ b/app/src/main/assets/translator.js
@@ -1,0 +1,436 @@
+(function () {
+  if (window.__translator) return;
+
+  const nonce = Math.random().toString(36).slice(2) + Date.now().toString(36);
+  const pending = new Map();
+  let nextId = 1;
+
+  function send(method, payload) {
+    return new Promise((resolve, reject) => {
+      const id = nextId++;
+      pending.set(id, { resolve, reject });
+      try {
+        window.__translatorBridge[method](id, JSON.stringify(payload), nonce);
+      } catch (e) {
+        pending.delete(id);
+        reject(e);
+      }
+    });
+  }
+
+  const BLOCK_TAGS = new Set([
+    'P', 'LI', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
+    'TD', 'TH', 'FIGCAPTION', 'DT', 'DD', 'BLOCKQUOTE',
+    'SUMMARY', 'CAPTION', 'LEGEND',
+  ]);
+  const STRUCTURAL_TAGS = new Set([
+    'DIV', 'SECTION', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER',
+    'NAV', 'MAIN', 'FIGURE', 'DETAILS', 'FORM', 'ADDRESS',
+  ]);
+  const SKIP_TAGS = new Set([
+    'SCRIPT', 'STYLE', 'CODE', 'PRE', 'KBD', 'SAMP', 'VAR',
+    'OBJECT', 'EMBED', 'NOSCRIPT', 'TEMPLATE', 'IFRAME',
+    'TEXTAREA', 'SVG', 'MATH', 'CANVAS',
+  ]);
+
+  const BATCH_MAX = 50;
+  const DRAIN_INTERVAL_MS = 25;
+  const INTERSECTION_MARGIN = '500px 0px';
+
+  const GENERIC_ATTRS = [
+    'title', 'placeholder', 'alt',
+    'aria-label', 'aria-description', 'aria-placeholder',
+    'aria-roledescription', 'aria-valuetext', 'aria-braillelabel',
+  ];
+  const ATTR_SELECTOR = GENERIC_ATTRS.map(a => `[${a}]`).join(',');
+
+  const OBSERVER_OPTS = {
+    childList: true,
+    subtree: true,
+    characterData: true,
+  };
+
+  function isBlockLike(el) {
+    return BLOCK_TAGS.has(el.tagName) || STRUCTURAL_TAGS.has(el.tagName);
+  }
+
+  function isSkippedBySelf(el) {
+    if (SKIP_TAGS.has(el.tagName)) return true;
+    if (el.getAttribute && el.getAttribute('translate') === 'no') return true;
+    if (el.classList && el.classList.contains('notranslate')) return true;
+    if (el.hasAttribute && el.hasAttribute('contenteditable')) return true;
+    return false;
+  }
+
+  function isSkippedByAncestor(el) {
+    for (let n = el; n; n = n.parentElement) {
+      if (n.nodeType !== 1) continue;
+      if (isSkippedBySelf(n)) return true;
+    }
+    return false;
+  }
+
+  function hasTranslatedAncestor(el) {
+    for (let n = el; n; n = n.parentElement) {
+      if (n.nodeType !== 1) continue;
+      if (n.hasAttribute && n.hasAttribute('data-xlated')) return true;
+    }
+    return false;
+  }
+
+  function hasMeaningfulText(el) {
+    const t = el.textContent;
+    return !!t && t.trim().length > 0;
+  }
+
+  function hasBlockLikeDescendant(el) {
+    for (const child of el.children) {
+      if (isBlockLike(child)) return true;
+      if (hasBlockLikeDescendant(child)) return true;
+    }
+    return false;
+  }
+
+  function isLeafUnit(el) {
+    if (!isBlockLike(el)) return false;
+    if (hasBlockLikeDescendant(el)) return false;
+    return hasMeaningfulText(el);
+  }
+
+  function collectUnits(root, units) {
+    const children = root.children;
+    for (let i = 0; i < children.length; i++) {
+      walk(children[i], units);
+    }
+  }
+
+  function walk(el, units) {
+    if (isSkippedBySelf(el)) return;
+    if (el.hasAttribute('data-xlated')) return;
+    if (el.shadowRoot) collectUnits(el.shadowRoot, units);
+
+    if (isLeafUnit(el)) {
+      units.push(el);
+    } else {
+      collectUnits(el, units);
+    }
+  }
+
+  const queued = new Set();
+
+  const io = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) enqueue(e.target);
+      }
+    },
+    { rootMargin: INTERSECTION_MARGIN },
+  );
+
+  function enqueue(el) {
+    if (queued.has(el)) return;
+    if (!el.isConnected) return;
+    if (el.hasAttribute('data-xlated')) {
+      io.unobserve(el);
+      return;
+    }
+    queued.add(el);
+    scheduleDrain();
+  }
+
+  function observeUnits(units) {
+    for (const u of units) io.observe(u);
+  }
+
+  let drainScheduled = false;
+  let lastDrain = 0;
+
+  function scheduleDrain() {
+    if (drainScheduled) return;
+    drainScheduled = true;
+    requestAnimationFrame(maybeDrain);
+  }
+
+  function maybeDrain() {
+    drainScheduled = false;
+    if (queued.size === 0 && attrQueued.size === 0) return;
+    const now = performance.now();
+    const wait = lastDrain + DRAIN_INTERVAL_MS - now;
+    if (wait > 0) {
+      setTimeout(scheduleDrain, wait);
+      return;
+    }
+    lastDrain = now;
+    if (queued.size > 0) {
+      const batch = Array.from(queued);
+      queued.clear();
+      for (const el of batch) io.unobserve(el);
+      processUnits(batch);
+    }
+    if (attrQueued.size > 0) {
+      drainAttrQueue();
+    }
+  }
+
+  let observer = null;
+
+  function pauseObserver() {
+    if (observer) observer.disconnect();
+  }
+
+  function resumeObserver() {
+    if (observer) observer.observe(document.body, OBSERVER_OPTS);
+  }
+
+  function writeBack(units, translated, snapshots) {
+    pauseObserver();
+    try {
+      for (let i = 0; i < units.length; i++) {
+        const el = units[i];
+        const out = translated[i];
+        if (out == null) continue;
+        if (!el.isConnected) continue;
+        if (el.textContent !== snapshots[i]) continue;
+        el.innerHTML = out;
+        el.setAttribute('data-xlated', '1');
+      }
+    } finally {
+      resumeObserver();
+    }
+  }
+
+  const attrQueued = new Map();
+
+  const attrIo = new IntersectionObserver(
+    (entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) enqueueAttr(e.target);
+      }
+    },
+    { rootMargin: INTERSECTION_MARGIN },
+  );
+
+  function translatableAttrsOf(el) {
+    const result = [];
+    for (const a of GENERIC_ATTRS) {
+      if (el.hasAttribute(a)) result.push(a);
+    }
+    if (el.tagName === 'INPUT') {
+      const t = (el.getAttribute('type') || '').toLowerCase();
+      if ((t === 'button' || t === 'reset') && el.hasAttribute('value')) {
+        result.push('value');
+      }
+    } else if (el.tagName === 'OPTION' || el.tagName === 'OPTGROUP' || el.tagName === 'TRACK') {
+      if (el.hasAttribute('label')) result.push('label');
+    }
+    return result;
+  }
+
+  function enqueueAttr(el) {
+    if (attrQueued.has(el)) return;
+    if (!el.isConnected) return;
+    if (el.hasAttribute('data-xlated-attr')) {
+      attrIo.unobserve(el);
+      return;
+    }
+    const attrs = translatableAttrsOf(el);
+    if (attrs.length === 0) {
+      attrIo.unobserve(el);
+      return;
+    }
+    const snapshot = new Map();
+    for (const a of attrs) snapshot.set(a, el.getAttribute(a));
+    attrQueued.set(el, snapshot);
+    scheduleDrain();
+  }
+
+  function observeAttrCandidates(root) {
+    const scope =
+      root.nodeType === 1 && root.matches && root.matches(ATTR_SELECTOR)
+        ? [root]
+        : [];
+    if (root.querySelectorAll) {
+      for (const el of root.querySelectorAll(ATTR_SELECTOR)) scope.push(el);
+      for (const el of root.querySelectorAll('input[type=button],input[type=reset],option,optgroup,track')) {
+        if (translatableAttrsOf(el).length > 0) scope.push(el);
+      }
+    }
+    for (const el of scope) {
+      if (isSkippedByAncestor(el)) continue;
+      if (hasTranslatedAncestor(el)) continue;
+      attrIo.observe(el);
+    }
+  }
+
+  function translateMetaAttributes() {
+    if (!document.head) return;
+    const metas = Array.from(
+      document.head.querySelectorAll('meta[name="description"],meta[name="keywords"]'),
+    ).filter(m => m.hasAttribute('content') && !m.hasAttribute('data-xlated-attr'));
+    if (metas.length === 0) return;
+    const texts = metas.map(m => m.getAttribute('content'));
+    send('translateTexts', texts)
+      .then((translated) => {
+        for (let i = 0; i < metas.length; i++) {
+          const out = translated[i];
+          if (out == null) continue;
+          const m = metas[i];
+          if (!m.isConnected) continue;
+          if (m.getAttribute('content') !== texts[i]) continue;
+          m.setAttribute('content', out);
+          m.setAttribute('data-xlated-attr', '1');
+        }
+      })
+      .catch((e) => console.warn('[translator] meta batch failed', e));
+  }
+
+  async function drainAttrQueue() {
+    if (attrQueued.size === 0) return;
+    const entries = Array.from(attrQueued.entries());
+    attrQueued.clear();
+    for (const [el] of entries) attrIo.unobserve(el);
+
+    const records = [];
+    for (const [el, snapshot] of entries) {
+      if (!el.isConnected) continue;
+      for (const [attr, text] of snapshot) {
+        if (el.getAttribute(attr) !== text) continue;
+        if (!text || text.trim().length === 0) continue;
+        records.push({ el, attr, text });
+      }
+    }
+    if (records.length === 0) return;
+
+    for (let i = 0; i < records.length; i += BATCH_MAX) {
+      const batch = records.slice(i, i + BATCH_MAX);
+      const texts = batch.map(r => r.text);
+      let translated;
+      try {
+        translated = await send('translateTexts', texts);
+      } catch (e) {
+        console.warn('[translator] attr batch failed', e);
+        continue;
+      }
+      pauseObserver();
+      try {
+        for (let j = 0; j < batch.length; j++) {
+          const r = batch[j];
+          const out = translated[j];
+          if (out == null) continue;
+          if (!r.el.isConnected) continue;
+          if (r.el.getAttribute(r.attr) !== r.text) continue;
+          r.el.setAttribute(r.attr, out);
+          r.el.setAttribute('data-xlated-attr', '1');
+        }
+      } finally {
+        resumeObserver();
+      }
+    }
+  }
+
+  async function processUnits(units) {
+    for (let i = 0; i < units.length; i += BATCH_MAX) {
+      const batchUnits = units.slice(i, i + BATCH_MAX);
+      const batchFragments = batchUnits.map(u => u.innerHTML);
+      const batchSnapshots = batchUnits.map(u => u.textContent);
+      let translated;
+      try {
+        translated = await send('translateHtmlFragments', batchFragments);
+      } catch (e) {
+        console.warn('[translator] batch failed', e);
+        continue;
+      }
+      writeBack(batchUnits, translated, batchSnapshots);
+    }
+  }
+
+  function handleMutations(muts) {
+    const touched = new Set();
+    for (const m of muts) {
+      if (m.type === 'childList') {
+        for (const node of m.addedNodes) {
+          if (node.nodeType === 1) touched.add(node);
+        }
+      } else if (m.type === 'characterData') {
+        const p = m.target.parentElement;
+        if (p) touched.add(p);
+      }
+    }
+    if (touched.size === 0) return;
+    const newUnits = [];
+    for (const node of touched) {
+      if (!node.isConnected) continue;
+      if (isSkippedByAncestor(node)) continue;
+      if (hasTranslatedAncestor(node)) continue;
+      if (isLeafUnit(node)) {
+        newUnits.push(node);
+      } else {
+        collectUnits(node, newUnits);
+      }
+      observeAttrCandidates(node);
+    }
+    observeUnits(newUnits);
+  }
+
+  function scan() {
+    if (isSkippedByAncestor(document.documentElement)) return;
+    const units = [];
+    collectUnits(document.body, units);
+    observeUnits(units);
+    observeAttrCandidates(document.body);
+    translateMetaAttributes();
+
+    if (!observer) {
+      observer = new MutationObserver(handleMutations);
+      observer.observe(document.body, OBSERVER_OPTS);
+    }
+  }
+
+  window.__translator = {
+    nonce,
+    resolve(id, results, callerNonce) {
+      if (callerNonce !== nonce) return;
+      const entry = pending.get(id);
+      if (!entry) return;
+      pending.delete(id);
+      let parsed;
+      try {
+        parsed = typeof results === 'string' ? JSON.parse(results) : results;
+      } catch (e) {
+        parsed = results;
+      }
+      entry.resolve(parsed);
+    },
+    translateHtmlFragments: fragments => send('translateHtmlFragments', fragments),
+    translateTexts: texts => send('translateTexts', texts),
+    scan,
+  };
+
+  function hookSpaNavigation() {
+    const origPush = history.pushState;
+    const origReplace = history.replaceState;
+    const emit = () => window.dispatchEvent(new Event('__translator:urlchange'));
+    history.pushState = function () {
+      origPush.apply(this, arguments);
+      emit();
+    };
+    history.replaceState = function () {
+      origReplace.apply(this, arguments);
+      emit();
+    };
+    window.addEventListener('popstate', emit);
+    window.addEventListener('__translator:urlchange', () => scan());
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      scan();
+      hookSpaNavigation();
+    }, { once: true });
+  } else {
+    scan();
+    hookSpaNavigation();
+  }
+
+  console.log('[translator] content script ready');
+})();

--- a/app/src/main/assets/translator.js
+++ b/app/src/main/assets/translator.js
@@ -2,6 +2,10 @@
   if (window.__translator) return;
 
   const nonce = Math.random().toString(36).slice(2) + Date.now().toString(36);
+  const bridgeName = typeof __translatorBridgeName === 'string' ? __translatorBridgeName : null;
+  const bridgeToken = typeof __translatorBridgeToken === 'string' ? __translatorBridgeToken : null;
+  const bridge = bridgeName ? window[bridgeName] : null;
+  if (!bridge || !bridgeToken) return;
   const pending = new Map();
   let nextId = 1;
 
@@ -10,7 +14,7 @@
       const id = nextId++;
       pending.set(id, { resolve, reject });
       try {
-        window.__translatorBridge[method](id, JSON.stringify(payload), nonce);
+        bridge[method](id, JSON.stringify(payload), bridgeToken, nonce);
       } catch (e) {
         pending.delete(id);
         reject(e);
@@ -388,7 +392,6 @@
   }
 
   window.__translator = {
-    nonce,
     resolve(id, results, callerNonce) {
       if (callerNonce !== nonce) return;
       const entry = pending.get(id);
@@ -402,9 +405,6 @@
       }
       entry.resolve(parsed);
     },
-    translateHtmlFragments: fragments => send('translateHtmlFragments', fragments),
-    translateTexts: texts => send('translateTexts', texts),
-    scan,
   };
 
   function hookSpaNavigation() {

--- a/app/src/main/assets/translator.js
+++ b/app/src/main/assets/translator.js
@@ -9,12 +9,42 @@
   const pending = new Map();
   let nextId = 1;
 
+  // Wire format: length-prefixed records. `<len>:<text><len>:<text>...`
+  // where `len` is the UTF-16 code-unit count of the text (matches JS
+  // String.length and Kotlin String.length). Robust to any content,
+  // cheaper than JSON because no per-char escaping.
+  function encodeWire(items) {
+    let s = '';
+    for (let i = 0; i < items.length; i++) {
+      const t = items[i];
+      s += t.length + ':' + t;
+    }
+    return s;
+  }
+
+  function decodeWire(s) {
+    const items = [];
+    let i = 0;
+    while (i < s.length) {
+      const colon = s.indexOf(':', i);
+      if (colon < 0) return null;
+      const len = parseInt(s.slice(i, colon), 10);
+      if (!Number.isFinite(len) || len < 0) return null;
+      const start = colon + 1;
+      const end = start + len;
+      if (end > s.length) return null;
+      items.push(s.slice(start, end));
+      i = end;
+    }
+    return items;
+  }
+
   function send(method, payload) {
     return new Promise((resolve, reject) => {
       const id = nextId++;
       pending.set(id, { resolve, reject });
       try {
-        bridge[method](id, JSON.stringify(payload), bridgeToken, nonce);
+        bridge[method](id, encodeWire(payload), bridgeToken, nonce);
       } catch (e) {
         pending.delete(id);
         reject(e);
@@ -88,37 +118,34 @@
     return !!t && t.trim().length > 0;
   }
 
-  function hasBlockLikeDescendant(el) {
-    for (const child of el.children) {
-      if (isBlockLike(child)) return true;
-      if (hasBlockLikeDescendant(child)) return true;
-    }
-    return false;
-  }
-
-  function isLeafUnit(el) {
-    if (!isBlockLike(el)) return false;
-    if (hasBlockLikeDescendant(el)) return false;
-    return hasMeaningfulText(el);
-  }
-
   function collectUnits(root, units) {
-    const children = root.children;
-    for (let i = 0; i < children.length; i++) {
-      walk(children[i], units);
+    const kids = root.children;
+    for (let i = 0; i < kids.length; i++) {
+      walk(kids[i], units);
     }
   }
 
+  // Single bottom-up pass: returns whether this subtree contains any
+  // block-like element so the caller can decide if it should itself be a
+  // leaf unit. Pushes leaf units into `target` as it goes. Inside skipped
+  // subtrees `target` is null — we still recurse to report block-like-ness
+  // (preserving the original semantic where skipped descendants prevent an
+  // ancestor from becoming a leaf), but we don't collect anything.
   function walk(el, units) {
-    if (isSkippedBySelf(el)) return;
-    if (el.hasAttribute('data-xlated')) return;
-    if (el.shadowRoot) collectUnits(el.shadowRoot, units);
-
-    if (isLeafUnit(el)) {
-      units.push(el);
-    } else {
-      collectUnits(el, units);
+    if (el.hasAttribute('data-xlated')) return true;
+    const skipped = isSkippedBySelf(el);
+    const target = skipped ? null : units;
+    if (!skipped && el.shadowRoot) collectUnits(el.shadowRoot, units);
+    let childHasBlockLike = false;
+    const kids = el.children;
+    for (let i = 0; i < kids.length; i++) {
+      if (walk(kids[i], target)) childHasBlockLike = true;
     }
+    const myselfBlockLike = isBlockLike(el);
+    if (target && myselfBlockLike && !childHasBlockLike && hasMeaningfulText(el)) {
+      target.push(el);
+    }
+    return myselfBlockLike || childHasBlockLike;
   }
 
   const queued = new Set();
@@ -367,11 +394,7 @@
       if (!node.isConnected) continue;
       if (isSkippedByAncestor(node)) continue;
       if (hasTranslatedAncestor(node)) continue;
-      if (isLeafUnit(node)) {
-        newUnits.push(node);
-      } else {
-        collectUnits(node, newUnits);
-      }
+      walk(node, newUnits);
       observeAttrCandidates(node);
     }
     observeUnits(newUnits);
@@ -397,12 +420,8 @@
       const entry = pending.get(id);
       if (!entry) return;
       pending.delete(id);
-      let parsed;
-      try {
-        parsed = typeof results === 'string' ? JSON.parse(results) : results;
-      } catch (e) {
-        parsed = results;
-      }
+      const parsed =
+        typeof results === 'string' ? (decodeWire(results) || []) : results;
       entry.resolve(parsed);
     },
   };

--- a/app/src/main/assets/translator.js
+++ b/app/src/main/assets/translator.js
@@ -51,6 +51,7 @@
   };
 
   function isBlockLike(el) {
+    if (el.getAttribute && el.getAttribute('role') === 'heading') return true;
     return BLOCK_TAGS.has(el.tagName) || STRUCTURAL_TAGS.has(el.tagName);
   }
 

--- a/app/src/main/bindings/Cargo.lock
+++ b/app/src/main/bindings/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "adblock"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc4a2c7fe914856e08e7c8d8f3dadac82425a0339163548f810450bf42c7adc"
+dependencies = [
+ "addr",
+ "arrayvec",
+ "base64",
+ "bitflags 2.11.1",
+ "flatbuffers",
+ "idna",
+ "itertools 0.13.0",
+ "memchr 2.8.0",
+ "percent-encoding",
+ "precomputed-hash",
+ "regex 1.12.3",
+ "rustc-hash 1.1.0",
+ "seahash",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "addr"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93b8a41dbe230ad5087cc721f8d41611de654542180586b315d9f4cf6b72bef"
+dependencies = [
+ "psl",
+ "psl-types",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +94,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "askama"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +165,7 @@ dependencies = [
 [[package]]
 name = "bergamot-sys"
 version = "0.1.0"
+source = "git+https://github.com/DavidVentura/bergamot-sys#bf379fdb9036eee64faf4662cae7e9375d9e1ef9"
 dependencies = [
  "cmake",
 ]
@@ -127,15 +175,6 @@ name = "bimap"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
-name = "binary-heap-plus"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4551d8382e911ecc0d0f0ffb602777988669be09447d536ff4388d1def11296"
-dependencies = [
- "compare 0.1.0",
-]
 
 [[package]]
 name = "bindgen"
@@ -204,27 +243,14 @@ dependencies = [
 name = "bindings"
 version = "0.1.0"
 dependencies = [
+ "adblock",
  "android_logger",
  "log",
+ "serde_json",
  "thiserror 2.0.18",
  "translator",
  "uniffi",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -237,6 +263,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -309,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -373,18 +402,6 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "compare"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
-
-[[package]]
-name = "compare"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120133d4db2ec47efe2e26502ee984747630c67f51974fca0b6c1340cf2368d3"
 
 [[package]]
 name = "core_maths"
@@ -544,6 +561,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +585,15 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs-err"
@@ -1062,6 +1098,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1397,17 +1454,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered_iter"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dcb2710cda23a8dacbb3fc39f18c883e639e1b6df19b0b10abbdd6919100fe"
-dependencies = [
- "bit-set",
- "bit-vec",
- "vec_map",
-]
-
-[[package]]
 name = "ort"
 version = "2.0.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1597,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1620,21 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.205"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194b4aac978e4e46f782a95ecdb06bc69919c935e783984e5f5b817545881beb"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "py_literal"
@@ -1705,14 +1772,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
-name = "rustfst"
-version = "1.3.0"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795b9ecc1a217d0357f9c3d109598ea1572da566292cb5e0195b2eb1f16014c7"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustfst"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3096239ad3664245480c50bf34a6ed45af5f40c0f6258d4b28a4c8082813a519"
 dependencies = [
  "anyhow",
  "bimap",
- "binary-heap-plus",
  "bitflags 2.11.1",
  "generic-array 1.3.5",
  "itertools 0.14.0",
@@ -1722,7 +1797,6 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde",
- "stable_bst",
  "superslice",
 ]
 
@@ -1777,6 +1851,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
@@ -1871,16 +1951,6 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
-
-[[package]]
-name = "stable_bst"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1df971c9978cdb75a38e82697472b6a001a9ac9488899da0981c9b35db96ad"
-dependencies = [
- "compare 0.0.6",
- "ordered_iter",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -2132,6 +2202,7 @@ dependencies = [
 [[package]]
 name = "translator"
 version = "0.1.0"
+source = "git+https://github.com/DavidVentura/translator-rs.git#fd9cd0b6c2747282ad57c5b62558156b5205ce71"
 dependencies = [
  "bergamot-sys",
  "cld2",
@@ -2300,6 +2371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,12 +2405,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/app/src/main/bindings/Cargo.lock
+++ b/app/src/main/bindings/Cargo.lock
@@ -118,7 +118,6 @@ dependencies = [
 [[package]]
 name = "bergamot-sys"
 version = "0.1.0"
-source = "git+https://github.com/DavidVentura/bergamot-sys#c6a3fde4e39645d93958fe935c75a4189b4b90bc"
 dependencies = [
  "cmake",
 ]
@@ -2133,7 +2132,6 @@ dependencies = [
 [[package]]
 name = "translator"
 version = "0.1.0"
-source = "git+https://github.com/DavidVentura/translator-rs.git#62702f59e6fee79f6abaf60e1e16f073ad259c02"
 dependencies = [
  "bergamot-sys",
  "cld2",

--- a/app/src/main/bindings/Cargo.toml
+++ b/app/src/main/bindings/Cargo.toml
@@ -18,6 +18,8 @@ path = "src/lib.rs"
 [dependencies]
 translator = { git = "https://github.com/DavidVentura/translator-rs.git", default-features = false, features = ["uniffi", "transliterate"] }
 # translator = { path = "/home/david/git/translator-rs", default-features = false, features = ["uniffi", "transliterate"] }
+adblock = { version = "0.12.2", default-features = false, features = ["full-regex-handling", "embedded-domain-resolver"] }
+serde_json = "1"
 uniffi = "0.29"
 thiserror = "2"
 log = "0.4"

--- a/app/src/main/bindings/src/adblock.rs
+++ b/app/src/main/bindings/src/adblock.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use adblock::Engine as InnerEngine;
+use adblock::cosmetic_filter_cache::ProceduralOrActionFilter;
+use adblock::lists::ParseOptions;
+use adblock::request::Request;
+
+#[derive(Debug, thiserror::Error, uniffi::Error)]
+pub enum AdblockException {
+    #[error("deserialization failed: {reason}")]
+    Deserialize { reason: String },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, uniffi::Enum)]
+pub enum AdblockRequestType {
+    Document,
+    Subdocument,
+    Stylesheet,
+    Script,
+    Image,
+    Font,
+    Media,
+    Object,
+    Xhr,
+    Fetch,
+    WebSocket,
+    Ping,
+    Other,
+}
+
+impl AdblockRequestType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            AdblockRequestType::Document => "document",
+            AdblockRequestType::Subdocument => "subdocument",
+            AdblockRequestType::Stylesheet => "stylesheet",
+            AdblockRequestType::Script => "script",
+            AdblockRequestType::Image => "image",
+            AdblockRequestType::Font => "font",
+            AdblockRequestType::Media => "media",
+            AdblockRequestType::Object => "object",
+            AdblockRequestType::Xhr => "xmlhttprequest",
+            AdblockRequestType::Fetch => "xmlhttprequest",
+            AdblockRequestType::WebSocket => "websocket",
+            AdblockRequestType::Ping => "ping",
+            AdblockRequestType::Other => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AdblockVerdict {
+    pub matched: bool,
+    pub exception: bool,
+    pub important: bool,
+    pub redirect: Option<String>,
+}
+
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct AdblockCosmetic {
+    pub hide_selectors: Vec<String>,
+    pub style_rules: Vec<String>,
+    pub procedural_filters: Vec<String>,
+    pub exceptions: Vec<String>,
+    pub injected_script: String,
+    pub generichide: bool,
+}
+
+impl AdblockVerdict {
+    fn allow() -> Self {
+        Self {
+            matched: false,
+            exception: false,
+            important: false,
+            redirect: None,
+        }
+    }
+}
+
+#[derive(uniffi::Object)]
+pub struct AdblockEngine {
+    inner: InnerEngine,
+}
+
+#[uniffi::export]
+impl AdblockEngine {
+    #[uniffi::constructor]
+    pub fn from_rules(rules_text: String) -> Arc<Self> {
+        let inner = InnerEngine::from_rules(rules_text.lines(), ParseOptions::default());
+        Arc::new(Self { inner })
+    }
+
+    #[uniffi::constructor]
+    pub fn deserialize(bytes: Vec<u8>) -> Result<Arc<Self>, AdblockException> {
+        let mut inner = InnerEngine::default();
+        inner
+            .deserialize(&bytes)
+            .map_err(|e| AdblockException::Deserialize {
+                reason: format!("{e:?}"),
+            })?;
+        Ok(Arc::new(Self { inner }))
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        self.inner.serialize()
+    }
+
+    pub fn check_request(
+        &self,
+        url: String,
+        source_url: String,
+        request_type: AdblockRequestType,
+    ) -> AdblockVerdict {
+        let request = match Request::new(&url, &source_url, request_type.as_str()) {
+            Ok(r) => r,
+            Err(_) => return AdblockVerdict::allow(),
+        };
+        let result = self.inner.check_network_request(&request);
+        AdblockVerdict {
+            matched: result.matched,
+            exception: result.exception.is_some(),
+            important: result.important,
+            redirect: result.redirect,
+        }
+    }
+
+    pub fn hidden_class_id_selectors(
+        &self,
+        classes: Vec<String>,
+        ids: Vec<String>,
+        exceptions: Vec<String>,
+    ) -> Vec<String> {
+        let exception_set: std::collections::HashSet<String> = exceptions.into_iter().collect();
+        self.inner
+            .hidden_class_id_selectors(classes.iter(), ids.iter(), &exception_set)
+    }
+
+    pub fn cosmetic_resources(&self, url: String) -> AdblockCosmetic {
+        let r = self.inner.url_cosmetic_resources(&url);
+        let mut hide_selectors: Vec<String> = r.hide_selectors.into_iter().collect();
+        let mut style_rules: Vec<String> = Vec::new();
+        let mut procedural_filters: Vec<String> = Vec::new();
+
+        for proc_json in &r.procedural_actions {
+            let Ok(filter) = serde_json::from_str::<ProceduralOrActionFilter>(proc_json) else {
+                continue;
+            };
+            if let Some((selector, style)) = filter.as_css() {
+                if style == "display: none !important" {
+                    hide_selectors.push(selector);
+                } else {
+                    style_rules.push(format!("{selector} {{ {style} }}"));
+                }
+            } else {
+                procedural_filters.push(proc_json.clone());
+            }
+        }
+
+        AdblockCosmetic {
+            hide_selectors,
+            style_rules,
+            procedural_filters,
+            exceptions: r.exceptions.into_iter().collect(),
+            injected_script: r.injected_script,
+            generichide: r.generichide,
+        }
+    }
+}

--- a/app/src/main/bindings/src/lib.rs
+++ b/app/src/main/bindings/src/lib.rs
@@ -1,15 +1,13 @@
 uniffi::setup_scaffolding!();
 
+pub mod adblock;
 pub mod bergamot;
 pub mod transliterate;
 pub mod uniffi_catalog;
 
 #[cfg(target_os = "android")]
 #[unsafe(no_mangle)]
-pub extern "C" fn JNI_OnLoad(
-    _vm: *mut std::ffi::c_void,
-    _reserved: *mut std::ffi::c_void,
-) -> i32 {
+pub extern "C" fn JNI_OnLoad(_vm: *mut std::ffi::c_void, _reserved: *mut std::ffi::c_void) -> i32 {
     android_logger::init_once(
         android_logger::Config::default()
             .with_max_level(log::LevelFilter::Debug)

--- a/app/src/main/bindings/src/uniffi_catalog.rs
+++ b/app/src/main/bindings/src/uniffi_catalog.rs
@@ -59,6 +59,25 @@ pub struct DictionaryWordRecord {
     pub redirects: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, uniffi::Record)]
+pub struct CatalogFileRecord {
+    pub name: String,
+    pub size_bytes: u64,
+    pub install_path: String,
+    pub url: String,
+}
+
+impl From<translator::catalog::AssetFileV2> for CatalogFileRecord {
+    fn from(file: translator::catalog::AssetFileV2) -> Self {
+        Self {
+            name: file.name,
+            size_bytes: file.size_bytes,
+            install_path: file.install_path,
+            url: file.url,
+        }
+    }
+}
+
 #[cfg(feature = "dictionary")]
 fn map_dictionary_word(word: translator::tarkka::WordWithTaggedEntries) -> DictionaryWordRecord {
     DictionaryWordRecord {
@@ -156,6 +175,15 @@ impl CatalogHandle {
         self.snapshot()
             .catalog
             .dictionary_info(&translator::DictionaryCode::from(dictionary_code))
+    }
+
+    fn support_files_by_kind(&self, support_kind: String) -> Vec<CatalogFileRecord> {
+        self.snapshot()
+            .catalog
+            .support_files_by_kind(&support_kind)
+            .into_iter()
+            .map(Into::into)
+            .collect()
     }
 
     fn lookup_dictionary(
@@ -338,8 +366,19 @@ impl CatalogHandle {
             .plan_download(&language_code, feature, selected_tts_pack_id.as_deref())
     }
 
+    fn plan_support_download_by_kind(
+        &self,
+        support_kind: String,
+    ) -> Option<translator::DownloadPlan> {
+        self.session.plan_support_download_by_kind(&support_kind)
+    }
+
     fn prepare_delete(&self, language_code: String, feature: Feature) -> translator::DeletePlan {
         self.session.prepare_delete(&language_code, feature)
+    }
+
+    fn prepare_delete_support_by_kind(&self, support_kind: String) -> translator::DeletePlan {
+        self.session.prepare_delete_support_by_kind(&support_kind)
     }
 
     fn prepare_delete_superseded_tts(
@@ -353,6 +392,10 @@ impl CatalogHandle {
 
     fn size_bytes(&self, language_code: String, feature: Feature) -> u64 {
         self.session.size_bytes(&language_code, feature)
+    }
+
+    fn support_size_bytes_by_kind(&self, support_kind: String) -> u64 {
+        self.session.support_size_bytes_by_kind(&support_kind)
     }
 
     fn default_tts_pack_id(&self, language_code: String) -> Option<String> {

--- a/app/src/main/bindings/src/uniffi_catalog.rs
+++ b/app/src/main/bindings/src/uniffi_catalog.rs
@@ -222,6 +222,17 @@ impl CatalogHandle {
             .map_err(CatalogError::from)
     }
 
+    fn translate_html_fragments(
+        &self,
+        from_code: String,
+        to_code: String,
+        fragments: Vec<String>,
+    ) -> Result<Vec<String>, CatalogError> {
+        self.session
+            .translate_html_fragments(&from_code, &to_code, &fragments)
+            .map_err(CatalogError::from)
+    }
+
     fn translate_mixed_texts(
         &self,
         inputs: Vec<String>,

--- a/app/src/main/java/dev/davidv/translator/CatalogModels.kt
+++ b/app/src/main/java/dev/davidv/translator/CatalogModels.kt
@@ -124,6 +124,13 @@ data class LanguageAvailabilityEntry(
   val availability: LangAvailability,
 )
 
+data class CatalogFileEntry(
+  val name: String,
+  val sizeBytes: Long,
+  val installPath: String,
+  val url: String,
+)
+
 class LanguageCatalog private constructor(
   private val handle: CatalogHandle,
   val formatVersion: Int,
@@ -193,6 +200,16 @@ class LanguageCatalog private constructor(
   fun dictionaryInfo(dictionaryCode: String): DictionaryInfo? =
     handle.dictionaryInfo(dictionaryCode)?.let {
       DictionaryInfo(date = it.date, filename = it.filename, size = it.size.toLong(), type = it.typeName, wordCount = it.wordCount.toLong())
+    }
+
+  fun supportFilesByKind(kind: String): List<CatalogFileEntry> =
+    handle.supportFilesByKind(kind).map { file ->
+      CatalogFileEntry(
+        name = file.name,
+        sizeBytes = file.sizeBytes.toLong(),
+        installPath = file.installPath,
+        url = file.url,
+      )
     }
 
   @Throws(CatalogException::class)
@@ -309,10 +326,14 @@ class LanguageCatalog private constructor(
     selectedTtsPackId: String? = null,
   ): DownloadPlan? = handle.planDownload(languageCode, feature, selectedTtsPackId)
 
+  fun planSupportDownloadByKind(kind: String): DownloadPlan? = handle.planSupportDownloadByKind(kind)
+
   fun prepareDelete(
     languageCode: String,
     feature: Feature,
   ): DeletePlan = handle.prepareDelete(languageCode, feature)
+
+  fun prepareDeleteSupportByKind(kind: String): DeletePlan = handle.prepareDeleteSupportByKind(kind)
 
   fun prepareDeleteSupersededTts(
     languageCode: String,
@@ -325,6 +346,14 @@ class LanguageCatalog private constructor(
     languageCode: String,
     feature: Feature,
   ): Long = handle.sizeBytes(languageCode, feature).toLong()
+
+  fun supportSizeBytesByKind(kind: String): Long = handle.supportSizeBytesByKind(kind).toLong()
+
+  fun supportInstalledByKind(kind: String): Boolean {
+    val sizeBytes = supportSizeBytesByKind(kind)
+    val plan = planSupportDownloadByKind(kind) ?: return false
+    return sizeBytes > 0 && plan.tasks.isEmpty()
+  }
 
   fun availableTtsVoices(languageCode: String): List<TtsVoiceOption> =
     handle.availableTtsVoices(languageCode).map { voice ->

--- a/app/src/main/java/dev/davidv/translator/CatalogModels.kt
+++ b/app/src/main/java/dev/davidv/translator/CatalogModels.kt
@@ -242,6 +242,13 @@ class LanguageCatalog private constructor(
       availableLanguages.map { it.code },
     )
 
+  @Throws(CatalogException::class)
+  fun translateHtmlFragments(
+    from: Language,
+    to: Language,
+    fragments: List<String>,
+  ): List<String> = handle.translateHtmlFragments(from.code, to.code, fragments)
+
   fun translateStructuredFragments(
     fragments: List<StyledFragment>,
     forcedSourceLanguage: Language?,

--- a/app/src/main/java/dev/davidv/translator/DownloadEvent.kt
+++ b/app/src/main/java/dev/davidv/translator/DownloadEvent.kt
@@ -30,6 +30,10 @@ sealed class DownloadEvent {
     val language: Language,
   ) : DownloadEvent()
 
+  data class NewSupportAvailable(
+    val kind: String,
+  ) : DownloadEvent()
+
   data object CatalogDownloaded : DownloadEvent()
 
   data class DownloadError(

--- a/app/src/main/java/dev/davidv/translator/DownloadService.kt
+++ b/app/src/main/java/dev/davidv/translator/DownloadService.kt
@@ -559,7 +559,14 @@ class DownloadService : Service() {
     val job =
       serviceScope.launch {
         try {
-          val catalog = getCatalog() ?: return@launch
+          val catalog =
+            getCatalog() ?: run {
+              updateAdblockDownloadState {
+                it.copy(isDownloading = false, error = "Catalog unavailable")
+              }
+              _downloadEvents.emit(DownloadEvent.DownloadError("Catalog unavailable"))
+              return@launch
+            }
           val downloadPlan =
             catalog.planSupportDownloadByKind(ADBLOCK_KIND) ?: run {
               Log.w("DownloadService", "No adblock support pack in catalog")

--- a/app/src/main/java/dev/davidv/translator/DownloadService.kt
+++ b/app/src/main/java/dev/davidv/translator/DownloadService.kt
@@ -109,12 +109,16 @@ class DownloadService : Service() {
   private val _ttsDownloadStates = MutableStateFlow<Map<Language, DownloadState>>(emptyMap())
   val ttsDownloadStates: StateFlow<Map<Language, DownloadState>> = _ttsDownloadStates
 
+  private val _adblockDownloadState = MutableStateFlow(DownloadState())
+  val adblockDownloadState: StateFlow<DownloadState> = _adblockDownloadState
+
   private val _downloadEvents = MutableSharedFlow<DownloadEvent>()
   val downloadEvents: SharedFlow<DownloadEvent> = _downloadEvents.asSharedFlow()
 
   private val downloadJobs = mutableMapOf<Language, Job>()
   private val dictionaryDownloadJobs = mutableMapOf<Language, Job>()
   private val ttsDownloadJobs = mutableMapOf<Language, Job>()
+  private var adblockDownloadJob: Job? = null
   private val baseDirPath: String
     get() = filePathManager.currentBaseDir().absolutePath
 
@@ -196,6 +200,22 @@ class DownloadService : Service() {
       context.startService(intent)
     }
 
+    fun startAdblockDownload(context: Context) {
+      val intent =
+        Intent(context, DownloadService::class.java).apply {
+          action = "START_ADBLOCK_DOWNLOAD"
+        }
+      context.startService(intent)
+    }
+
+    fun cancelAdblockDownload(context: Context) {
+      val intent =
+        Intent(context, DownloadService::class.java).apply {
+          action = "CANCEL_ADBLOCK_DOWNLOAD"
+        }
+      context.startService(intent)
+    }
+
     fun fetchCatalog(context: Context) {
       val intent =
         Intent(context, DownloadService::class.java).apply {
@@ -254,6 +274,14 @@ class DownloadService : Service() {
         val catalog = getCatalog() ?: return START_NOT_STICKY
         val language = catalog.languageByCode(languageCode) ?: return START_NOT_STICKY
         cancelTtsDownload(language)
+      }
+
+      "START_ADBLOCK_DOWNLOAD" -> {
+        startAdblockDownload()
+      }
+
+      "CANCEL_ADBLOCK_DOWNLOAD" -> {
+        cancelAdblockDownload()
       }
 
       "FETCH_CATALOG" -> {
@@ -519,6 +547,87 @@ class DownloadService : Service() {
     Log.i("DownloadService", "Cancelled TTS download for ${language.displayName}")
   }
 
+  private fun startAdblockDownload() {
+    if (_adblockDownloadState.value.isDownloading) return
+    updateAdblockDownloadState {
+      DownloadState(
+        isDownloading = true,
+        isCompleted = false,
+        downloaded = 1,
+      )
+    }
+    val job =
+      serviceScope.launch {
+        try {
+          val catalog = getCatalog() ?: return@launch
+          val downloadPlan =
+            catalog.planSupportDownloadByKind(ADBLOCK_KIND) ?: run {
+              Log.w("DownloadService", "No adblock support pack in catalog")
+              updateAdblockDownloadState {
+                it.copy(isDownloading = false, error = "No adblock support pack in catalog")
+              }
+              return@launch
+            }
+          var success = true
+          if (downloadPlan.tasks.isNotEmpty()) {
+            updateAdblockDownloadState {
+              it.copy(
+                isDownloading = true,
+                downloaded = 1,
+                totalSize = downloadPlan.totalSize.toLong(),
+              )
+            }
+            Log.i("DownloadService", "Starting adblock download")
+            for (task in downloadPlan.tasks) {
+              if (!downloadPackFile(task, ::incrementAdblockDownloadBytes)) {
+                success = false
+              }
+            }
+          }
+
+          updateAdblockDownloadState {
+            DownloadState(
+              isDownloading = false,
+              isCompleted = success,
+            )
+          }
+
+          if (success) {
+            filePathManager.reloadCatalog()
+            (application as? TranslatorApplication)?.adblockManager?.reload()
+            Log.i("DownloadService", "Adblock download complete")
+            _downloadEvents.emit(DownloadEvent.NewSupportAvailable(ADBLOCK_KIND))
+          } else {
+            updateAdblockDownloadState {
+              it.copy(isDownloading = false, error = "Adblock download failed")
+            }
+            _downloadEvents.emit(DownloadEvent.DownloadError("Adblock download failed"))
+          }
+        } catch (e: Exception) {
+          Log.e("DownloadService", "Adblock download failed", e)
+          updateAdblockDownloadState {
+            it.copy(isDownloading = false, error = e.message)
+          }
+          _downloadEvents.emit(DownloadEvent.DownloadError("Adblock download failed"))
+        } finally {
+          adblockDownloadJob = null
+        }
+      }
+
+    adblockDownloadJob = job
+  }
+
+  private fun cancelAdblockDownload() {
+    adblockDownloadJob?.cancel()
+    adblockDownloadJob = null
+
+    updateAdblockDownloadState {
+      it.copy(isDownloading = false, isCancelled = true, error = null)
+    }
+
+    Log.i("DownloadService", "Cancelled adblock download")
+  }
+
   private fun cancelLanguageDownload(language: Language) {
     downloadJobs[language]?.cancel()
     downloadJobs.remove(language)
@@ -623,11 +732,37 @@ class DownloadService : Service() {
     }
   }
 
+  private fun updateAdblockDownloadState(update: (DownloadState) -> DownloadState) {
+    synchronized(this) {
+      _adblockDownloadState.value = update(_adblockDownloadState.value)
+    }
+  }
+
+  private fun incrementAdblockDownloadBytes(incrementalBytes: Long) {
+    updateAdblockDownloadState {
+      it.copy(downloaded = it.downloaded + incrementalBytes)
+    }
+  }
+
   private suspend fun downloadPackFile(
     task: DownloadTask,
     targetLanguage: Language,
     incrementDictionary: Boolean = false,
     incrementTts: Boolean = false,
+  ): Boolean =
+    downloadPackFile(task) { incrementalProgress ->
+      if (incrementDictionary) {
+        incrementDictionaryDownloadBytes(targetLanguage, incrementalProgress)
+      } else if (incrementTts) {
+        incrementTtsDownloadBytes(targetLanguage, incrementalProgress)
+      } else {
+        incrementDownloadBytes(targetLanguage, incrementalProgress)
+      }
+    }
+
+  private suspend fun downloadPackFile(
+    task: DownloadTask,
+    onProgress: (Long) -> Unit,
   ): Boolean {
     val outputFile = filePathManager.resolveInstallPath(task.installPath)
     val url = task.url
@@ -643,15 +778,8 @@ class DownloadService : Service() {
             extractTo = filePathManager.resolveInstallPath(extractTo),
             deleteAfterExtract = task.deleteAfterExtract,
             installMarkerPath = installMarkerPath,
-          ) { incrementalProgress ->
-            if (incrementDictionary) {
-              incrementDictionaryDownloadBytes(targetLanguage, incrementalProgress)
-            } else if (incrementTts) {
-              incrementTtsDownloadBytes(targetLanguage, incrementalProgress)
-            } else {
-              incrementDownloadBytes(targetLanguage, incrementalProgress)
-            }
-          }.also { extracted ->
+            onProgress = onProgress,
+          ).also { extracted ->
             if (extracted && installMarkerPath != null && installMarkerVersion != null) {
               filePathManager.writeInstallMarker(installMarkerPath, installMarkerVersion)
             }
@@ -661,15 +789,8 @@ class DownloadService : Service() {
             url,
             outputFile,
             decompress = task.decompress,
-          ) { incrementalProgress ->
-            if (incrementDictionary) {
-              incrementDictionaryDownloadBytes(targetLanguage, incrementalProgress)
-            } else if (incrementTts) {
-              incrementTtsDownloadBytes(targetLanguage, incrementalProgress)
-            } else {
-              incrementDownloadBytes(targetLanguage, incrementalProgress)
-            }
-          }
+            onProgress = onProgress,
+          )
         }
       Log.i("DownloadService", "Downloaded ${task.packId}:${task.installPath} from $url = $success")
       success
@@ -905,3 +1026,5 @@ data class DownloadState(
   val totalSize: Long = 1,
   val error: String? = null,
 )
+
+private const val ADBLOCK_KIND = "adblock"

--- a/app/src/main/java/dev/davidv/translator/FilePathManager.kt
+++ b/app/src/main/java/dev/davidv/translator/FilePathManager.kt
@@ -47,6 +47,8 @@ class FilePathManager(
 
   fun getDictionariesDir(): File = File(baseDir, "dictionaries")
 
+  fun getAdblockDir(): File = File(baseDir, "adblock")
+
   fun resolveInstallPath(relativePath: String): File = File(baseDir, relativePath)
 
   fun getDictionaryFile(language: Language): File = File(getDictionariesDir(), "${language.dictionaryCode}.dict")

--- a/app/src/main/java/dev/davidv/translator/LanguageStateManager.kt
+++ b/app/src/main/java/dev/davidv/translator/LanguageStateManager.kt
@@ -117,6 +117,12 @@ class LanguageStateManager(
               refreshLanguageAvailability()
             }
 
+            is DownloadEvent.NewSupportAvailable -> {
+              setCatalog(withContext(Dispatchers.IO) { filePathManager.reloadCatalog() })
+              _catalogRefreshToken.value++
+              refreshLanguageAvailability()
+            }
+
             is DownloadEvent.CatalogDownloaded -> {
               setCatalog(withContext(Dispatchers.IO) { filePathManager.reloadCatalog() })
               _catalogRefreshToken.value++
@@ -177,6 +183,13 @@ class LanguageStateManager(
     filePathManager.applyDeletePlan(catalog.prepareDelete(language.code, Feature.TTS))
     refreshLanguageAvailability()
     Log.i("LanguageStateManager", "Removed TTS for language: ${language.displayName}")
+  }
+
+  fun deleteSupportByKind(kind: String) {
+    val catalog = catalogState.value ?: filePathManager.loadCatalog() ?: return
+    filePathManager.applyDeletePlan(catalog.prepareDeleteSupportByKind(kind))
+    refreshLanguageAvailability()
+    Log.i("LanguageStateManager", "Removed support files for kind: $kind")
   }
 
   fun canSwapLanguages(

--- a/app/src/main/java/dev/davidv/translator/MainActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : ComponentActivity() {
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
     handleIntent(intent)
+    if (isFinishing) return
 
     val app = application as TranslatorApplication
 
@@ -129,6 +130,16 @@ class MainActivity : ComponentActivity() {
           }
 
         if (text != null) {
+          val url = firstUrlInText(text)
+          if (url != null) {
+            val browserIntent =
+              Intent(this, dev.davidv.translator.browser.BrowserActivity::class.java).apply {
+                putExtra(dev.davidv.translator.browser.BrowserActivity.EXTRA_URL, url)
+              }
+            startActivity(browserIntent)
+            finish()
+            return
+          }
           textToTranslate = text
         } else if (imageUri != null) {
           sharedImageUri = imageUri
@@ -136,5 +147,12 @@ class MainActivity : ComponentActivity() {
         }
       }
     }
+  }
+
+  private fun firstUrlInText(text: String): String? {
+    for (token in text.trim().split(Regex("\\s+"))) {
+      if (token.startsWith("http://") || token.startsWith("https://")) return token
+    }
+    return null
   }
 }

--- a/app/src/main/java/dev/davidv/translator/TranslationService.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslationService.kt
@@ -45,6 +45,22 @@ class TranslationService(
     catalog.warmTranslationModels(from, to)
   }
 
+  suspend fun translateHtmlFragments(
+    from: Language,
+    to: Language,
+    fragments: List<String>,
+  ): List<String> =
+    withContext(Dispatchers.IO) {
+      if (fragments.isEmpty() || from == to) return@withContext fragments
+      val catalog = filePathManager.loadCatalog() ?: return@withContext fragments
+      try {
+        catalog.translateHtmlFragments(from, to, fragments)
+      } catch (e: CatalogException) {
+        Log.w("TranslationService", "translateHtmlFragments failed", e)
+        fragments
+      }
+    }
+
   suspend fun translateMixedTexts(
     inputs: List<String>,
     forcedSourceLanguage: Language?,

--- a/app/src/main/java/dev/davidv/translator/TranslatorApplication.kt
+++ b/app/src/main/java/dev/davidv/translator/TranslatorApplication.kt
@@ -19,6 +19,7 @@ package dev.davidv.translator
 
 import android.app.Application
 import android.util.Log
+import dev.davidv.translator.adblock.AdblockManager
 
 class TranslatorApplication : Application() {
   lateinit var settingsManager: SettingsManager
@@ -29,6 +30,7 @@ class TranslatorApplication : Application() {
   lateinit var speechService: SpeechService
   lateinit var languageDetector: LanguageDetector
   lateinit var translationCoordinator: TranslationCoordinator
+  lateinit var adblockManager: AdblockManager
   val languagesFlow = kotlinx.coroutines.flow.MutableStateFlow<List<Language>>(emptyList())
   var languageCatalog: LanguageCatalog? = null
     private set
@@ -48,6 +50,7 @@ class TranslatorApplication : Application() {
     languageDetector = LanguageDetector { code -> languageCatalog?.languageByCode(code) }
     translationCoordinator =
       TranslationCoordinator(translationService, speechService, languageDetector, imageProcessor, settingsManager)
+    adblockManager = AdblockManager(filePathManager)
 
     if (settingsManager.settings.value.tapToTranslateEnabled) {
       TapToTranslateNotification.show(this)

--- a/app/src/main/java/dev/davidv/translator/adblock/AdblockManager.kt
+++ b/app/src/main/java/dev/davidv/translator/adblock/AdblockManager.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator.adblock
+
+import android.util.Log
+import dev.davidv.translator.FilePathManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import uniffi.bindings.AdblockCosmetic
+import uniffi.bindings.AdblockEngine
+import uniffi.bindings.AdblockRequestType
+import uniffi.bindings.AdblockVerdict
+import java.io.File
+
+class AdblockManager(
+  private val filePathManager: FilePathManager,
+) {
+  companion object {
+    private const val TAG = "AdblockManager"
+    private const val CACHE_FILE = "engine.bin"
+  }
+
+  private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+  @Volatile
+  private var engine: AdblockEngine? = null
+
+  private val _ready = MutableStateFlow(false)
+  val ready: StateFlow<Boolean> = _ready.asStateFlow()
+
+  init {
+    scope.launch { tryLoad() }
+  }
+
+  fun reload() {
+    scope.launch {
+      clearEngineCache()
+      tryLoad()
+    }
+  }
+
+  private fun clearEngineCache() {
+    val cacheFile = File(filePathManager.getAdblockDir(), CACHE_FILE)
+    if (cacheFile.exists()) cacheFile.delete()
+  }
+
+  private suspend fun tryLoad() =
+    withContext(Dispatchers.IO) {
+      val dir = filePathManager.getAdblockDir()
+      val cacheFile = File(dir, CACHE_FILE)
+      val ruleFiles = listRuleFiles(dir)
+      Log.i(
+        TAG,
+        "adblock dir=${dir.absolutePath} engine.exists=${cacheFile.exists()} rules=${ruleFiles.map { it.name }}",
+      )
+
+      val loaded =
+        loadFromCache(cacheFile)
+          ?: loadFromRules(ruleFiles, cacheFile)
+
+      if (loaded != null) {
+        engine = loaded
+        _ready.value = true
+        Log.i(TAG, "adblock engine loaded")
+      } else {
+        engine = null
+        _ready.value = false
+        Log.i(TAG, "no adblock rules in ${dir.absolutePath}; pass-through")
+      }
+    }
+
+  private fun listRuleFiles(dir: File): List<File> =
+    dir.listFiles { f -> f.isFile && f.name.endsWith(".txt") }?.sortedBy { it.name } ?: emptyList()
+
+  private fun loadFromCache(cacheFile: File): AdblockEngine? {
+    if (!cacheFile.exists()) return null
+    return try {
+      val t0 = System.currentTimeMillis()
+      val bytes = cacheFile.readBytes()
+      val readMs = System.currentTimeMillis() - t0
+      val t1 = System.currentTimeMillis()
+      val eng = AdblockEngine.deserialize(bytes)
+      val deserMs = System.currentTimeMillis() - t1
+      Log.i(TAG, "cache load: ${bytes.size} bytes read ${readMs}ms, deserialize ${deserMs}ms")
+      eng
+    } catch (t: Throwable) {
+      Log.w(TAG, "cache load failed; will re-parse rules", t)
+      cacheFile.delete()
+      null
+    }
+  }
+
+  private fun loadFromRules(
+    ruleFiles: List<File>,
+    cacheFile: File,
+  ): AdblockEngine? {
+    if (ruleFiles.isEmpty()) return null
+    return try {
+      val tRead = System.currentTimeMillis()
+      val text =
+        buildString {
+          for (file in ruleFiles) {
+            append(file.readText())
+            if (!endsWith('\n')) append('\n')
+          }
+        }
+      val readMs = System.currentTimeMillis() - tRead
+      val ruleCount = text.count { it == '\n' }
+      val tParse = System.currentTimeMillis()
+      val eng = AdblockEngine.fromRules(text)
+      val parseMs = System.currentTimeMillis() - tParse
+      val tSer = System.currentTimeMillis()
+      val serialized =
+        runCatching {
+          val bytes = eng.serialize()
+          cacheFile.parentFile?.mkdirs()
+          cacheFile.writeBytes(bytes)
+          bytes.size
+        }.onFailure { Log.w(TAG, "engine cache write failed", it) }
+          .getOrDefault(-1)
+      val serMs = System.currentTimeMillis() - tSer
+      Log.i(
+        TAG,
+        "rule parse: ${ruleFiles.size} files, ~$ruleCount lines, read ${readMs}ms, " +
+          "compile ${parseMs}ms, serialize+write ${serMs}ms (cache=${serialized}B)",
+      )
+      eng
+    } catch (t: Throwable) {
+      Log.w(TAG, "rule parse failed", t)
+      null
+    }
+  }
+
+  fun checkRequest(
+    url: String,
+    sourceUrl: String,
+    requestType: AdblockRequestType,
+  ): AdblockVerdict? = engine?.checkRequest(url, sourceUrl, requestType)
+
+  fun cosmeticResources(url: String): AdblockCosmetic? = engine?.cosmeticResources(url)
+
+  fun hiddenClassIdSelectors(
+    classes: List<String>,
+    ids: List<String>,
+    exceptions: List<String>,
+  ): List<String> = engine?.hiddenClassIdSelectors(classes, ids, exceptions) ?: emptyList()
+}

--- a/app/src/main/java/dev/davidv/translator/adblock/RequestTypeMapper.kt
+++ b/app/src/main/java/dev/davidv/translator/adblock/RequestTypeMapper.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator.adblock
+
+import android.webkit.WebResourceRequest
+import uniffi.bindings.AdblockRequestType
+
+private val IMAGE_EXTS = setOf("png", "jpg", "jpeg", "gif", "webp", "svg", "ico", "bmp", "avif")
+private val FONT_EXTS = setOf("woff", "woff2", "ttf", "otf", "eot")
+private val MEDIA_EXTS = setOf("mp4", "webm", "mp3", "ogg", "wav", "m4a", "m4v", "mov", "flac")
+
+fun mapRequestType(request: WebResourceRequest): AdblockRequestType {
+  if (request.isForMainFrame) return AdblockRequestType.DOCUMENT
+
+  val headers = caseInsensitive(request.requestHeaders)
+  val accept = headers["accept"]?.lowercase() ?: ""
+  val secFetchDest = headers["sec-fetch-dest"]?.lowercase()
+  val xRequestedWith = headers["x-requested-with"]
+
+  if (xRequestedWith == "XMLHttpRequest") return AdblockRequestType.XHR
+
+  when (secFetchDest) {
+    "document" -> return AdblockRequestType.DOCUMENT
+    "iframe", "frame" -> return AdblockRequestType.SUBDOCUMENT
+    "script" -> return AdblockRequestType.SCRIPT
+    "style" -> return AdblockRequestType.STYLESHEET
+    "image" -> return AdblockRequestType.IMAGE
+    "font" -> return AdblockRequestType.FONT
+    "video", "audio", "track" -> return AdblockRequestType.MEDIA
+    "object", "embed" -> return AdblockRequestType.OBJECT
+    "manifest" -> return AdblockRequestType.OTHER
+    "empty" -> return AdblockRequestType.FETCH
+    "report" -> return AdblockRequestType.PING
+  }
+
+  if (accept.contains("text/css")) return AdblockRequestType.STYLESHEET
+  if (accept.contains("javascript")) return AdblockRequestType.SCRIPT
+  if (accept.contains("image/")) return AdblockRequestType.IMAGE
+  if (accept.contains("font/")) return AdblockRequestType.FONT
+
+  val ext = extensionOf(request.url.toString())
+  return when {
+    ext == "css" -> AdblockRequestType.STYLESHEET
+    ext == "js" || ext == "mjs" -> AdblockRequestType.SCRIPT
+    ext in IMAGE_EXTS -> AdblockRequestType.IMAGE
+    ext in FONT_EXTS -> AdblockRequestType.FONT
+    ext in MEDIA_EXTS -> AdblockRequestType.MEDIA
+    else -> AdblockRequestType.OTHER
+  }
+}
+
+private fun caseInsensitive(headers: Map<String, String>?): Map<String, String> {
+  if (headers.isNullOrEmpty()) return emptyMap()
+  val out = HashMap<String, String>(headers.size)
+  for ((k, v) in headers) out[k.lowercase()] = v
+  return out
+}
+
+fun refererOf(request: WebResourceRequest): String? = caseInsensitive(request.requestHeaders)["referer"]
+
+private fun extensionOf(url: String): String? {
+  val q = url.indexOfAny(charArrayOf('?', '#')).let { if (it < 0) url.length else it }
+  val path = url.substring(0, q)
+  val slash = path.lastIndexOf('/')
+  val name = if (slash >= 0) path.substring(slash + 1) else path
+  val dot = name.lastIndexOf('.')
+  if (dot < 0 || dot == name.length - 1) return null
+  return name.substring(dot + 1).lowercase()
+}

--- a/app/src/main/java/dev/davidv/translator/browser/AdblockJsBridge.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/AdblockJsBridge.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator.browser
+
+import android.webkit.JavascriptInterface
+import dev.davidv.translator.adblock.AdblockManager
+import org.json.JSONArray
+
+class AdblockJsBridge(
+  private val adblockManager: AdblockManager,
+) {
+  @JavascriptInterface
+  fun lookupGenericSelectors(
+    classesJson: String,
+    idsJson: String,
+    exceptionsJson: String,
+  ): String {
+    val classes = parseStringArray(classesJson)
+    val ids = parseStringArray(idsJson)
+    val exceptions = parseStringArray(exceptionsJson)
+    val selectors = adblockManager.hiddenClassIdSelectors(classes, ids, exceptions)
+    val arr = JSONArray()
+    selectors.forEach { arr.put(it) }
+    return arr.toString()
+  }
+
+  private fun parseStringArray(json: String): List<String> {
+    val arr = JSONArray(json)
+    return List(arr.length()) { arr.getString(it) }
+  }
+}

--- a/app/src/main/java/dev/davidv/translator/browser/AdblockJsBridge.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/AdblockJsBridge.kt
@@ -19,7 +19,6 @@ package dev.davidv.translator.browser
 
 import android.webkit.JavascriptInterface
 import dev.davidv.translator.adblock.AdblockManager
-import org.json.JSONArray
 
 class AdblockJsBridge(
   private val adblockManager: AdblockManager,
@@ -27,30 +26,56 @@ class AdblockJsBridge(
 ) {
   companion object {
     private const val MAX_VALUES = 5000
-    private const val MAX_JSON_CHARS = 200_000
+    private const val MAX_PAYLOAD_CHARS = 200_000
+    private const val MAX_ITEM_CHARS = 4_000
   }
 
   @JavascriptInterface
   fun lookupGenericSelectors(
-    classesJson: String,
-    idsJson: String,
-    exceptionsJson: String,
+    classesPayload: String,
+    idsPayload: String,
+    exceptionsPayload: String,
     token: String,
   ): String {
-    if (token != bridgeToken) return "[]"
-    val classes = parseStringArray(classesJson) ?: return "[]"
-    val ids = parseStringArray(idsJson) ?: return "[]"
-    val exceptions = parseStringArray(exceptionsJson) ?: return "[]"
+    if (token != bridgeToken) return ""
+    val classes = decodeWire(classesPayload) ?: return ""
+    val ids = decodeWire(idsPayload) ?: return ""
+    val exceptions = decodeWire(exceptionsPayload) ?: return ""
     val selectors = adblockManager.hiddenClassIdSelectors(classes, ids, exceptions)
-    val arr = JSONArray()
-    selectors.forEach { arr.put(it) }
-    return arr.toString()
+    return encodeWire(selectors)
   }
 
-  private fun parseStringArray(json: String): List<String>? {
-    if (json.length > MAX_JSON_CHARS) return null
-    val arr = runCatching { JSONArray(json) }.getOrNull() ?: return null
-    if (arr.length() > MAX_VALUES) return null
-    return List(arr.length()) { i -> arr.optString(i, "") }
+  // Wire format: length-prefixed records `<len>:<text><len>:<text>...`
+  // (UTF-16 code-unit counts; matches JS String.length).
+  private fun decodeWire(payload: String): List<String>? {
+    if (payload.isEmpty()) return emptyList()
+    if (payload.length > MAX_PAYLOAD_CHARS) return null
+    val items = ArrayList<String>()
+    var i = 0
+    val n = payload.length
+    while (i < n) {
+      val colon = payload.indexOf(':', i)
+      if (colon < 0) return null
+      val len =
+        try {
+          payload.substring(i, colon).toInt()
+        } catch (_: NumberFormatException) {
+          return null
+        }
+      if (len < 0 || len > MAX_ITEM_CHARS) return null
+      val start = colon + 1
+      val end = start + len
+      if (end > n) return null
+      items.add(payload.substring(start, end))
+      if (items.size > MAX_VALUES) return null
+      i = end
+    }
+    return items
+  }
+
+  private fun encodeWire(values: List<String>): String {
+    val sb = StringBuilder()
+    for (v in values) sb.append(v.length).append(':').append(v)
+    return sb.toString()
   }
 }

--- a/app/src/main/java/dev/davidv/translator/browser/AdblockJsBridge.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/AdblockJsBridge.kt
@@ -23,24 +23,34 @@ import org.json.JSONArray
 
 class AdblockJsBridge(
   private val adblockManager: AdblockManager,
+  private val bridgeToken: String,
 ) {
+  companion object {
+    private const val MAX_VALUES = 5000
+    private const val MAX_JSON_CHARS = 200_000
+  }
+
   @JavascriptInterface
   fun lookupGenericSelectors(
     classesJson: String,
     idsJson: String,
     exceptionsJson: String,
+    token: String,
   ): String {
-    val classes = parseStringArray(classesJson)
-    val ids = parseStringArray(idsJson)
-    val exceptions = parseStringArray(exceptionsJson)
+    if (token != bridgeToken) return "[]"
+    val classes = parseStringArray(classesJson) ?: return "[]"
+    val ids = parseStringArray(idsJson) ?: return "[]"
+    val exceptions = parseStringArray(exceptionsJson) ?: return "[]"
     val selectors = adblockManager.hiddenClassIdSelectors(classes, ids, exceptions)
     val arr = JSONArray()
     selectors.forEach { arr.put(it) }
     return arr.toString()
   }
 
-  private fun parseStringArray(json: String): List<String> {
-    val arr = JSONArray(json)
-    return List(arr.length()) { arr.getString(it) }
+  private fun parseStringArray(json: String): List<String>? {
+    if (json.length > MAX_JSON_CHARS) return null
+    val arr = runCatching { JSONArray(json) }.getOrNull() ?: return null
+    if (arr.length() > MAX_VALUES) return null
+    return List(arr.length()) { i -> arr.optString(i, "") }
   }
 }

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
+import android.view.ContextThemeWrapper
 import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -35,6 +36,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
@@ -47,6 +49,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -72,6 +75,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import org.json.JSONTokener
+import java.util.UUID
 
 class BrowserActivity : ComponentActivity() {
   companion object {
@@ -174,6 +178,7 @@ private fun BrowserScreen(
   val languageState by viewModel.languageState.collectAsStateWithLifecycle()
   val languageMetadata by viewModel.languageMetadata.collectAsStateWithLifecycle()
   val url by viewModel.url.collectAsStateWithLifecycle()
+  val darkTheme = isSystemInDarkTheme()
 
   if (to == null) return
 
@@ -211,6 +216,7 @@ private fun BrowserScreen(
       contentScript = contentScript,
       translationService = translationService,
       adblockManager = adblockManager,
+      darkTheme = darkTheme,
       onScrollDelta = { y, dy ->
         if (y < TOPBAR_TOP_SHOW_PX) {
           topBarVisible = true
@@ -268,7 +274,7 @@ private fun BrowserScreen(
         LanguageSelectionRow(
           from = from!!,
           to = to!!,
-          canSwap = true,
+          canSwap = viewModel.canSwapLanguages(from!!, to!!),
           languageState = languageState,
           languageMetadata = languageMetadata,
           onMessage = viewModel::onMessage,
@@ -323,6 +329,7 @@ private fun BrowserWebView(
   contentScript: String,
   translationService: TranslationService,
   adblockManager: AdblockManager,
+  darkTheme: Boolean,
   onScrollDelta: (y: Int, dy: Int) -> Unit,
   onWebViewReady: (WebView) -> Unit,
   onPageStarted: () -> Unit,
@@ -331,91 +338,116 @@ private fun BrowserWebView(
   val scope = androidx.compose.runtime.rememberCoroutineScope()
   val bridgeRef = remember { arrayOfNulls<TranslatorJsBridge>(1) }
   val currentPageUrlRef = remember { java.util.concurrent.atomic.AtomicReference<String?>(null) }
+  val bridgeToken = remember { UUID.randomUUID().toString() }
+  val translatorBridgeName = remember { "__translatorBridge_${bridgeToken.filter { it != '-' }}" }
+  val adblockBridgeName = remember { "__adblockBridge_${bridgeToken.filter { it != '-' }}" }
 
-  AndroidView(
-    modifier = Modifier.fillMaxSize(),
-    factory = { ctx ->
-      val webView =
-        WebView(ctx).apply {
-          layoutParams =
-            ViewGroup.LayoutParams(
-              ViewGroup.LayoutParams.MATCH_PARENT,
-              ViewGroup.LayoutParams.MATCH_PARENT,
-            )
-          settings.javaScriptEnabled = true
-          settings.domStorageEnabled = true
+  key(darkTheme) {
+    AndroidView(
+      modifier = Modifier.fillMaxSize(),
+      factory = { ctx ->
+        val webViewContext =
+          ContextThemeWrapper(
+            ctx,
+            if (darkTheme) {
+              R.style.Theme_Translator_WebView_Dark
+            } else {
+              R.style.Theme_Translator_WebView_Light
+            },
+          )
+        val webView =
+          WebView(webViewContext).apply {
+            layoutParams =
+              ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+              )
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+          }
+
+        webView.setOnScrollChangeListener { _, _, y, _, oldY ->
+          onScrollDelta(y, y - oldY)
         }
 
-      webView.setOnScrollChangeListener { _, _, y, _, oldY ->
-        onScrollDelta(y, y - oldY)
-      }
+        val bridge =
+          TranslatorJsBridge(
+            scope = scope,
+            webView = webView,
+            translationService = translationService,
+            bridgeToken = bridgeToken,
+            sourceLanguage = sourceLang,
+            targetLanguage = targetLang,
+          )
+        bridgeRef[0] = bridge
+        webView.addJavascriptInterface(bridge, translatorBridgeName)
+        webView.addJavascriptInterface(AdblockJsBridge(adblockManager, bridgeToken), adblockBridgeName)
 
-      val bridge =
-        TranslatorJsBridge(
-          scope = scope,
-          webView = webView,
-          translationService = translationService,
-          sourceLanguage = sourceLang,
-          targetLanguage = targetLang,
-        )
-      bridgeRef[0] = bridge
-      webView.addJavascriptInterface(bridge, "__translatorBridge")
-      webView.addJavascriptInterface(AdblockJsBridge(adblockManager), "__adblockBridge")
+        webView.webViewClient =
+          object : WebViewClient() {
+            override fun onPageStarted(
+              view: WebView?,
+              url: String?,
+              favicon: Bitmap?,
+            ) {
+              Log.i("AdblockManager", "onPageStarted view=$view url=$url")
+              onPageStarted()
+              currentPageUrlRef.set(url)
+              if (view != null && url != null) {
+                applyCosmeticFiltersAsync(
+                  scope,
+                  view,
+                  adblockManager,
+                  url,
+                  adblockBridgeName,
+                  bridgeToken,
+                )
+              }
+            }
 
-      webView.webViewClient =
-        object : WebViewClient() {
-          override fun onPageStarted(
-            view: WebView?,
-            url: String?,
-            favicon: Bitmap?,
-          ) {
-            Log.i("AdblockManager", "onPageStarted view=$view url=$url")
-            onPageStarted()
-            currentPageUrlRef.set(url)
-            if (view != null && url != null) {
-              applyCosmeticFiltersAsync(scope, view, adblockManager, url)
+            override fun onPageFinished(
+              view: WebView?,
+              url: String?,
+            ) {
+              view?.evaluateJavascript(
+                buildTranslatorContentJs(contentScript, translatorBridgeName, bridgeToken),
+                null,
+              )
+              if (view != null) onPageFinished(view)
+            }
+
+            override fun shouldInterceptRequest(
+              view: WebView?,
+              request: WebResourceRequest?,
+            ): WebResourceResponse? {
+              if (request == null) return null
+              val topUrl = currentPageUrlRef.get() ?: return null
+              val sourceUrl =
+                if (request.isForMainFrame) topUrl else refererOf(request) ?: topUrl
+              val verdict =
+                adblockManager.checkRequest(
+                  url = request.url.toString(),
+                  sourceUrl = sourceUrl,
+                  requestType = mapRequestType(request),
+                ) ?: return null
+              if (!verdict.matched || verdict.exception) return null
+              return WebResourceResponse("text/plain", "utf-8", ByteArray(0).inputStream())
             }
           }
 
-          override fun onPageFinished(
-            view: WebView?,
-            url: String?,
-          ) {
-            view?.evaluateJavascript(contentScript, null)
-            if (view != null) onPageFinished(view)
-          }
-
-          override fun shouldInterceptRequest(
-            view: WebView?,
-            request: WebResourceRequest?,
-          ): WebResourceResponse? {
-            if (request == null) return null
-            val topUrl = currentPageUrlRef.get() ?: return null
-            val sourceUrl =
-              if (request.isForMainFrame) topUrl else refererOf(request) ?: topUrl
-            val verdict =
-              adblockManager.checkRequest(
-                url = request.url.toString(),
-                sourceUrl = sourceUrl,
-                requestType = mapRequestType(request),
-              ) ?: return null
-            if (!verdict.matched || verdict.exception) return null
-            return WebResourceResponse("text/plain", "utf-8", ByteArray(0).inputStream())
-          }
-        }
-
-      onWebViewReady(webView)
-      webView.loadUrl(url)
-      webView
-    },
-    update = { webView ->
-      val b = bridgeRef[0] ?: return@AndroidView
-      val langsChanged = b.sourceLanguage != sourceLang || b.targetLanguage != targetLang
-      b.sourceLanguage = sourceLang
-      b.targetLanguage = targetLang
-      if (langsChanged) webView.reload()
-    },
-  )
+        onWebViewReady(webView)
+        webView.loadUrl(url)
+        webView
+      },
+      update = { webView ->
+        val b = bridgeRef[0] ?: return@AndroidView
+        val langsChanged = b.sourceLanguage != sourceLang || b.targetLanguage != targetLang
+        b.sourceLanguage = sourceLang
+        b.targetLanguage = targetLang
+        if (langsChanged) webView.reload()
+      },
+    )
+  }
 }
 
 private fun buildReaderModeJs(
@@ -430,6 +462,17 @@ private fun buildReaderModeJs(
     "(0, eval)($readerModeLiteral);"
 }
 
+private fun buildTranslatorContentJs(
+  contentScript: String,
+  bridgeName: String,
+  bridgeToken: String,
+): String =
+  "(function(){\n" +
+    "var __translatorBridgeName = ${JSONObject.quote(bridgeName)};\n" +
+    "var __translatorBridgeToken = ${JSONObject.quote(bridgeToken)};\n" +
+    contentScript +
+    "\n})();"
+
 private fun decodeJavascriptString(value: String): String? {
   if (value == "null") return null
   return runCatching { JSONTokener(value).nextValue() as? String }.getOrNull()
@@ -440,6 +483,8 @@ private fun applyCosmeticFiltersAsync(
   webView: WebView,
   adblockManager: AdblockManager,
   url: String,
+  adblockBridgeName: String,
+  bridgeToken: String,
 ) {
   Log.i("AdblockManager", "onPageStarted url=$url scheduling lookup")
   scope.launch {
@@ -466,6 +511,8 @@ private fun applyCosmeticFiltersAsync(
         cosmetic.exceptions,
         cosmetic.generichide,
         cosmetic.injectedScript,
+        adblockBridgeName,
+        bridgeToken,
       )
     if (js.isEmpty()) {
       Log.i("AdblockManager", "url=$url empty cosmetic, skipping")
@@ -482,6 +529,8 @@ private fun buildCosmeticJs(
   exceptions: List<String>,
   generichide: Boolean,
   injectedScript: String,
+  adblockBridgeName: String,
+  bridgeToken: String,
 ): String {
   if (hideSelectors.isEmpty() && styleRules.isEmpty() &&
     proceduralFilters.isEmpty() && injectedScript.isBlank() && generichide
@@ -504,6 +553,8 @@ private fun buildCosmeticJs(
   val exceptionsLiteral =
     org.json.JSONArray().apply { exceptions.forEach { put(it) } }.toString()
   val scriptLiteral = JSONObject.quote(injectedScript)
+  val adblockBridgeNameLiteral = JSONObject.quote(adblockBridgeName)
+  val bridgeTokenLiteral = JSONObject.quote(bridgeToken)
   val generichideLiteral = if (generichide) "true" else "false"
   return """
     (function(){
@@ -513,6 +564,8 @@ private fun buildCosmeticJs(
       var procedurals = $proceduralLiteral;
       var exceptions = $exceptionsLiteral;
       var generichide = $generichideLiteral;
+      var adblockBridgeName = $adblockBridgeNameLiteral;
+      var bridgeToken = $bridgeTokenLiteral;
 
       var jsInjected = false;
       var validatedHideCss = null;
@@ -729,7 +782,8 @@ private fun buildCosmeticJs(
 
       function applyGeneric() {
         if (generichide) return;
-        if (!window.__adblockBridge) return;
+        var adblockBridge = window[adblockBridgeName];
+        if (!adblockBridge) return;
         var classes = new Set();
         var ids = new Set();
         var els = document.getElementsByTagName('*');
@@ -749,7 +803,7 @@ private fun buildCosmeticJs(
         var exArr = JSON.stringify(exceptions || []);
         var resultJson;
         try {
-          resultJson = window.__adblockBridge.lookupGenericSelectors(classArr, idArr, exArr);
+          resultJson = adblockBridge.lookupGenericSelectors(classArr, idArr, exArr, bridgeToken);
         } catch (e) {
           console.warn('[adblock] generic lookup failed', e);
           return;

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
@@ -424,6 +424,12 @@ private fun BrowserWebView(
               onPageStarted()
               currentPageUrlRef.set(url)
               val pageSerial = currentPageSerialRef.incrementAndGet()
+              // Inject the translator content script as early as possible.
+              // The script self-defers its DOM scan until DOMContentLoaded
+              view?.evaluateJavascript(
+                buildTranslatorContentJs(contentScript, translatorBridgeName, bridgeToken),
+                null,
+              )
               if (view != null && url != null) {
                 applyCosmeticFiltersAsync(
                   scope,
@@ -443,10 +449,6 @@ private fun BrowserWebView(
               view: WebView?,
               url: String?,
             ) {
-              view?.evaluateJavascript(
-                buildTranslatorContentJs(contentScript, translatorBridgeName, bridgeToken),
-                null,
-              )
               val pageSerial = currentPageSerialRef.get()
               if (view != null && url != null) {
                 applyCosmeticFiltersAsync(

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -343,11 +344,32 @@ private fun BrowserWebView(
 ) {
   val scope = androidx.compose.runtime.rememberCoroutineScope()
   val bridgeRef = remember { arrayOfNulls<TranslatorJsBridge>(1) }
+  val webViewRef = remember { arrayOfNulls<WebView>(1) }
   val currentPageUrlRef = remember { java.util.concurrent.atomic.AtomicReference<String?>(null) }
   val currentPageSerialRef = remember { java.util.concurrent.atomic.AtomicInteger(0) }
+  val adblockReady by adblockManager.ready.collectAsStateWithLifecycle()
   val bridgeToken = remember { UUID.randomUUID().toString() }
   val translatorBridgeName = remember { "__translatorBridge_${bridgeToken.filter { it != '-' }}" }
   val adblockBridgeName = remember { "__adblockBridge_${bridgeToken.filter { it != '-' }}" }
+
+  LaunchedEffect(adblockReady) {
+    if (!adblockReady) return@LaunchedEffect
+    val webView = webViewRef[0] ?: return@LaunchedEffect
+    val pageSerial = currentPageSerialRef.get()
+    if (pageSerial == 0) return@LaunchedEffect
+    val currentUrl = webView.url ?: currentPageUrlRef.get() ?: return@LaunchedEffect
+    applyCosmeticFiltersAsync(
+      scope,
+      webView,
+      adblockManager,
+      currentUrl,
+      pageSerial,
+      currentPageSerialRef,
+      adblockBridgeName,
+      bridgeToken,
+      adblockCosmeticScript,
+    )
+  }
 
   key(darkTheme) {
     AndroidView(
@@ -387,6 +409,7 @@ private fun BrowserWebView(
             targetLanguage = targetLang,
           )
         bridgeRef[0] = bridge
+        webViewRef[0] = webView
         webView.addJavascriptInterface(bridge, translatorBridgeName)
         webView.addJavascriptInterface(AdblockJsBridge(adblockManager, bridgeToken), adblockBridgeName)
 

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
@@ -23,8 +23,11 @@ import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
 import android.view.ViewGroup
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
@@ -49,15 +52,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.davidv.translator.Language
+import dev.davidv.translator.R
 import dev.davidv.translator.TranslationService
 import dev.davidv.translator.TranslatorApplication
+import dev.davidv.translator.adblock.AdblockManager
+import dev.davidv.translator.adblock.mapRequestType
+import dev.davidv.translator.adblock.refererOf
 import dev.davidv.translator.ui.components.LanguageSelectionRow
 import dev.davidv.translator.ui.theme.TranslatorTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import org.json.JSONTokener
 
 class BrowserActivity : ComponentActivity() {
   companion object {
@@ -94,6 +108,8 @@ class BrowserActivity : ComponentActivity() {
       )[BrowserViewModel::class.java]
 
     val contentScript = assets.open("translator.js").bufferedReader().use { it.readText() }
+    val readabilityScript = assets.open("Readability.js").bufferedReader().use { it.readText() }
+    val readerModeScript = assets.open("reader-mode.js").bufferedReader().use { it.readText() }
 
     setContent {
       TranslatorTheme {
@@ -104,7 +120,10 @@ class BrowserActivity : ComponentActivity() {
           BrowserScreen(
             viewModel = viewModel,
             contentScript = contentScript,
+            readabilityScript = readabilityScript,
+            readerModeScript = readerModeScript,
             translationService = app.translationService,
+            adblockManager = app.adblockManager,
             onFinish = { finish() },
           )
         }
@@ -134,6 +153,8 @@ class BrowserActivity : ComponentActivity() {
 }
 
 private const val TOPBAR_SCROLL_THRESHOLD_PX = 8
+private const val TOPBAR_HIDE_SCROLL_DISTANCE_PX = 56
+private const val TOPBAR_SHOW_SCROLL_DISTANCE_PX = 72
 private const val TOPBAR_TOP_SHOW_PX = 50
 
 @SuppressLint("SetJavaScriptEnabled")
@@ -141,9 +162,13 @@ private const val TOPBAR_TOP_SHOW_PX = 50
 private fun BrowserScreen(
   viewModel: BrowserViewModel,
   contentScript: String,
+  readabilityScript: String,
+  readerModeScript: String,
   translationService: TranslationService,
+  adblockManager: AdblockManager,
   onFinish: () -> Unit,
 ) {
+  val context = LocalContext.current
   val from by viewModel.from.collectAsStateWithLifecycle()
   val to by viewModel.to.collectAsStateWithLifecycle()
   val languageState by viewModel.languageState.collectAsStateWithLifecycle()
@@ -163,6 +188,10 @@ private fun BrowserScreen(
   }
 
   var topBarVisible by remember { mutableStateOf(true) }
+  var topBarScrollAccumulator by remember { mutableStateOf(0) }
+  var readerModeEnabled by remember { mutableStateOf(false) }
+  var readerModeAvailable by remember { mutableStateOf(false) }
+  var loadingReaderMode by remember { mutableStateOf(false) }
   val webViewRef = remember { arrayOfNulls<WebView>(1) }
 
   BackHandler {
@@ -181,16 +210,50 @@ private fun BrowserScreen(
       targetLang = to!!,
       contentScript = contentScript,
       translationService = translationService,
+      adblockManager = adblockManager,
       onScrollDelta = { y, dy ->
-        topBarVisible =
+        if (y < TOPBAR_TOP_SHOW_PX) {
+          topBarVisible = true
+          topBarScrollAccumulator = 0
+        } else if (kotlin.math.abs(dy) > TOPBAR_SCROLL_THRESHOLD_PX) {
+          val continuedSameDirection =
+            (topBarScrollAccumulator >= 0 && dy > 0) ||
+              (topBarScrollAccumulator <= 0 && dy < 0)
+          topBarScrollAccumulator =
+            if (continuedSameDirection) {
+              topBarScrollAccumulator + dy
+            } else {
+              dy
+            }
+
           when {
-            y < TOPBAR_TOP_SHOW_PX -> true
-            dy > TOPBAR_SCROLL_THRESHOLD_PX -> false
-            dy < -TOPBAR_SCROLL_THRESHOLD_PX -> true
-            else -> topBarVisible
+            topBarVisible && topBarScrollAccumulator >= TOPBAR_HIDE_SCROLL_DISTANCE_PX -> {
+              topBarVisible = false
+              topBarScrollAccumulator = 0
+            }
+            !topBarVisible && topBarScrollAccumulator <= -TOPBAR_SHOW_SCROLL_DISTANCE_PX -> {
+              topBarVisible = true
+              topBarScrollAccumulator = 0
+            }
           }
+        }
       },
       onWebViewReady = { webViewRef[0] = it },
+      onPageStarted = {
+        if (!loadingReaderMode) {
+          readerModeEnabled = false
+          readerModeAvailable = false
+        }
+      },
+      onPageFinished = { webView ->
+        loadingReaderMode = false
+        if (!readerModeEnabled) {
+          val js = buildReaderModeJs(readabilityScript, readerModeScript, probeOnly = true)
+          webView.evaluateJavascript(js) { result ->
+            readerModeAvailable = result == "true"
+          }
+        }
+      },
     )
 
     AnimatedVisibility(
@@ -209,8 +272,42 @@ private fun BrowserScreen(
           languageState = languageState,
           languageMetadata = languageMetadata,
           onMessage = viewModel::onMessage,
-          onSettings = null,
-          drawable = Pair("", 0),
+          drawable =
+            Pair(
+              if (readerModeEnabled) "Exit reader mode" else "Reader mode",
+              R.drawable.chrome_reader_mode,
+            ),
+          onSettings =
+            if (readerModeEnabled || readerModeAvailable) {
+              {
+                val webView = webViewRef[0]
+                if (webView != null) {
+                  if (readerModeEnabled) {
+                    if (webView.canGoBack()) {
+                      webView.goBack()
+                    } else {
+                      webView.reload()
+                    }
+                  } else {
+                    val js = buildReaderModeJs(readabilityScript, readerModeScript, probeOnly = false)
+                    webView.evaluateJavascript(js) { result ->
+                      val readerHtml = decodeJavascriptString(result)
+                      if (readerHtml == null) {
+                        readerModeAvailable = false
+                        Toast.makeText(context, "Reader mode unavailable for this page", Toast.LENGTH_SHORT).show()
+                      } else {
+                        loadingReaderMode = true
+                        readerModeEnabled = true
+                        val baseUrl = webView.url
+                        webView.loadDataWithBaseURL(baseUrl, readerHtml, "text/html", "UTF-8", baseUrl)
+                      }
+                    }
+                  }
+                }
+              }
+            } else {
+              null
+            },
         )
       }
     }
@@ -225,11 +322,15 @@ private fun BrowserWebView(
   targetLang: Language,
   contentScript: String,
   translationService: TranslationService,
+  adblockManager: AdblockManager,
   onScrollDelta: (y: Int, dy: Int) -> Unit,
   onWebViewReady: (WebView) -> Unit,
+  onPageStarted: () -> Unit,
+  onPageFinished: (WebView) -> Unit,
 ) {
   val scope = androidx.compose.runtime.rememberCoroutineScope()
   val bridgeRef = remember { arrayOfNulls<TranslatorJsBridge>(1) }
+  val currentPageUrlRef = remember { java.util.concurrent.atomic.AtomicReference<String?>(null) }
 
   AndroidView(
     modifier = Modifier.fillMaxSize(),
@@ -259,6 +360,7 @@ private fun BrowserWebView(
         )
       bridgeRef[0] = bridge
       webView.addJavascriptInterface(bridge, "__translatorBridge")
+      webView.addJavascriptInterface(AdblockJsBridge(adblockManager), "__adblockBridge")
 
       webView.webViewClient =
         object : WebViewClient() {
@@ -267,7 +369,38 @@ private fun BrowserWebView(
             url: String?,
             favicon: Bitmap?,
           ) {
+            Log.i("AdblockManager", "onPageStarted view=$view url=$url")
+            onPageStarted()
+            currentPageUrlRef.set(url)
+            if (view != null && url != null) {
+              applyCosmeticFiltersAsync(scope, view, adblockManager, url)
+            }
+          }
+
+          override fun onPageFinished(
+            view: WebView?,
+            url: String?,
+          ) {
             view?.evaluateJavascript(contentScript, null)
+            if (view != null) onPageFinished(view)
+          }
+
+          override fun shouldInterceptRequest(
+            view: WebView?,
+            request: WebResourceRequest?,
+          ): WebResourceResponse? {
+            if (request == null) return null
+            val topUrl = currentPageUrlRef.get() ?: return null
+            val sourceUrl =
+              if (request.isForMainFrame) topUrl else refererOf(request) ?: topUrl
+            val verdict =
+              adblockManager.checkRequest(
+                url = request.url.toString(),
+                sourceUrl = sourceUrl,
+                requestType = mapRequestType(request),
+              ) ?: return null
+            if (!verdict.matched || verdict.exception) return null
+            return WebResourceResponse("text/plain", "utf-8", ByteArray(0).inputStream())
           }
         }
 
@@ -283,4 +416,369 @@ private fun BrowserWebView(
       if (langsChanged) webView.reload()
     },
   )
+}
+
+private fun buildReaderModeJs(
+  readabilityScript: String,
+  readerModeScript: String,
+  probeOnly: Boolean,
+): String {
+  val readabilityLiteral = JSONObject.quote(readabilityScript)
+  val readerModeLiteral = JSONObject.quote(readerModeScript)
+  return "window.__translatorReadabilityScript = $readabilityLiteral;\n" +
+    "window.__translatorReaderModeProbe = $probeOnly;\n" +
+    "(0, eval)($readerModeLiteral);"
+}
+
+private fun decodeJavascriptString(value: String): String? {
+  if (value == "null") return null
+  return runCatching { JSONTokener(value).nextValue() as? String }.getOrNull()
+}
+
+private fun applyCosmeticFiltersAsync(
+  scope: CoroutineScope,
+  webView: WebView,
+  adblockManager: AdblockManager,
+  url: String,
+) {
+  Log.i("AdblockManager", "onPageStarted url=$url scheduling lookup")
+  scope.launch {
+    val tFetch = System.currentTimeMillis()
+    val cosmetic = withContext(Dispatchers.IO) { adblockManager.cosmeticResources(url) }
+    val fetchMs = System.currentTimeMillis() - tFetch
+    if (cosmetic == null) {
+      Log.i("AdblockManager", "url=$url cosmetic=null (engine not loaded?) fetch=${fetchMs}ms")
+      return@launch
+    }
+    val sdaPresent = cosmetic.hideSelectors.any { it == ".sdaContainer" }
+    Log.i(
+      "AdblockManager",
+      "url=$url hide=${cosmetic.hideSelectors.size} style=${cosmetic.styleRules.size} " +
+        "procedural=${cosmetic.proceduralFilters.size} script=${cosmetic.injectedScript.length}B " +
+        "exc=${cosmetic.exceptions.size} generichide=${cosmetic.generichide} " +
+        "hasSdaContainer=$sdaPresent fetch=${fetchMs}ms",
+    )
+    val js =
+      buildCosmeticJs(
+        cosmetic.hideSelectors,
+        cosmetic.styleRules,
+        cosmetic.proceduralFilters,
+        cosmetic.exceptions,
+        cosmetic.generichide,
+        cosmetic.injectedScript,
+      )
+    if (js.isEmpty()) {
+      Log.i("AdblockManager", "url=$url empty cosmetic, skipping")
+      return@launch
+    }
+    webView.evaluateJavascript(js, null)
+  }
+}
+
+private fun buildCosmeticJs(
+  hideSelectors: List<String>,
+  styleRules: List<String>,
+  proceduralFilters: List<String>,
+  exceptions: List<String>,
+  generichide: Boolean,
+  injectedScript: String,
+): String {
+  if (hideSelectors.isEmpty() && styleRules.isEmpty() &&
+    proceduralFilters.isEmpty() && injectedScript.isBlank() && generichide
+  ) {
+    return ""
+  }
+  val cssParts = mutableListOf<String>()
+  cssParts.add(
+    "[data-adblock-hide] { display: none !important; min-height: 0 !important; min-width: 0 !important; height: 0 !important; }",
+  )
+  if (styleRules.isNotEmpty()) {
+    cssParts.addAll(styleRules)
+  }
+  val css = cssParts.joinToString("\n")
+  val hideSelectorsLiteral =
+    org.json.JSONArray().apply { hideSelectors.forEach { put(it) } }.toString()
+  val cssLiteral = JSONObject.quote(css)
+  val proceduralLiteral =
+    org.json.JSONArray().apply { proceduralFilters.forEach { put(it) } }.toString()
+  val exceptionsLiteral =
+    org.json.JSONArray().apply { exceptions.forEach { put(it) } }.toString()
+  val scriptLiteral = JSONObject.quote(injectedScript)
+  val generichideLiteral = if (generichide) "true" else "false"
+  return """
+    (function(){
+      var baseCss = $cssLiteral;
+      var hideSelectors = $hideSelectorsLiteral;
+      var js = $scriptLiteral;
+      var procedurals = $proceduralLiteral;
+      var exceptions = $exceptionsLiteral;
+      var generichide = $generichideLiteral;
+
+      var jsInjected = false;
+      var validatedHideCss = null;
+
+      function isValidSelector(selector) {
+        try {
+          document.querySelector(selector);
+          return true;
+        } catch (e) {
+          return false;
+        }
+      }
+
+      function buildCssText() {
+        if (validatedHideCss === null) {
+          var valid = [];
+          var invalid = 0;
+          for (var i = 0; i < hideSelectors.length; i++) {
+            if (isValidSelector(hideSelectors[i])) valid.push(hideSelectors[i]);
+            else invalid++;
+          }
+          validatedHideCss = valid.length
+            ? valid.join(',\n') + ' { display: none !important; min-height: 0 !important; min-width: 0 !important; height: 0 !important; }\n'
+            : '';
+          if (invalid) console.log('[adblock] skipped invalid cosmetic selectors: ' + invalid);
+        }
+        return validatedHideCss + baseCss;
+      }
+
+      function applyCss() {
+        var root = document.head || document.documentElement || document.body;
+        if (!root) return false;
+        try {
+          var css = buildCssText();
+          if (css) {
+            var existing = document.querySelector('style[data-adblock="1"]');
+            if (!existing || !existing.isConnected || existing.parentNode !== root) {
+              if (existing && !existing.isConnected) existing.remove();
+              var s = document.createElement('style');
+              s.setAttribute('data-adblock','1');
+              s.textContent = css;
+              root.appendChild(s);
+            } else if (existing.textContent !== css) {
+              existing.textContent = css;
+            }
+          }
+          if (js && !jsInjected) {
+            var sc = document.createElement('script');
+            sc.setAttribute('data-adblock','1');
+            sc.textContent = js;
+            root.appendChild(sc);
+            sc.remove();
+            jsInjected = true;
+          }
+          return true;
+        } catch (e) {
+          console.warn('[adblock] cosmetic apply failed', e);
+          return true;
+        }
+      }
+
+      function guardCss() {
+        try {
+          var target = document.documentElement;
+          if (!target) return;
+          var mo = new MutationObserver(function(){
+            var existing = document.querySelector('style[data-adblock="1"]');
+            if (!existing || !existing.isConnected) applyCss();
+          });
+          mo.observe(target, { childList: true, subtree: true });
+        } catch (e) {}
+      }
+
+      // ---- procedural filter pipeline (uBO-style) ----
+      function opTask(op) {
+        var arg = op.arg;
+        switch (op.type) {
+          case 'CssSelector':
+            return function(nodes) {
+              if (nodes === null) {
+                try { return Array.prototype.slice.call(document.querySelectorAll(arg)); }
+                catch (e) { return []; }
+              }
+              var out = [];
+              for (var i = 0; i < nodes.length; i++) {
+                try { out.push.apply(out, nodes[i].querySelectorAll(arg)); } catch (e) {}
+              }
+              return out;
+            };
+          case 'HasText':
+            var re;
+            if (arg && arg.length > 1 && arg.charAt(0) === '/' &&
+                arg.lastIndexOf('/') > 0) {
+              var slash = arg.lastIndexOf('/');
+              try { re = new RegExp(arg.slice(1, slash), arg.slice(slash + 1)); } catch (e) {}
+            }
+            var literal = arg;
+            return function(nodes) {
+              return nodes.filter(function(n){
+                var t = (n.textContent || '');
+                return re ? re.test(t) : t.indexOf(literal) >= 0;
+              });
+            };
+          case 'MatchesCss':
+          case 'MatchesCssBefore':
+          case 'MatchesCssAfter':
+            // arg shape: "prop: value" possibly more complex
+            var idx = arg.indexOf(':');
+            if (idx < 0) return function(nodes){ return []; };
+            var prop = arg.slice(0, idx).trim();
+            var val = arg.slice(idx + 1).trim();
+            var pseudo = op.type === 'MatchesCssBefore' ? '::before'
+                       : op.type === 'MatchesCssAfter' ? '::after' : null;
+            return function(nodes) {
+              return nodes.filter(function(n){
+                try {
+                  var cs = window.getComputedStyle(n, pseudo);
+                  return cs && cs.getPropertyValue(prop).trim() === val;
+                } catch (e) { return false; }
+              });
+            };
+          case 'Upward':
+            // arg: integer N, or selector
+            var n = parseInt(arg, 10);
+            if (!isNaN(n) && /^-?\d+$/.test(String(arg))) {
+              return function(nodes) {
+                var out = [];
+                for (var i = 0; i < nodes.length; i++) {
+                  var p = nodes[i];
+                  for (var k = 0; k < n && p; k++) p = p.parentElement;
+                  if (p) out.push(p);
+                }
+                return out;
+              };
+            }
+            return function(nodes) {
+              var out = [];
+              for (var i = 0; i < nodes.length; i++) {
+                try {
+                  var anc = nodes[i].parentElement && nodes[i].parentElement.closest(arg);
+                  if (anc) out.push(anc);
+                } catch (e) {}
+              }
+              return out;
+            };
+          default:
+            return null; // unsupported -> drop entire filter
+        }
+      }
+
+      function compileFilter(filter) {
+        var tasks = [];
+        for (var i = 0; i < filter.selector.length; i++) {
+          var t = opTask(filter.selector[i]);
+          if (!t) return null;
+          tasks.push(t);
+        }
+        return tasks;
+      }
+
+      function runFilter(filter) {
+        var tasks = compileFilter(filter);
+        if (!tasks) return;
+        var nodes = null;
+        for (var i = 0; i < tasks.length; i++) nodes = tasks[i](nodes);
+        if (!nodes || nodes.length === 0) return;
+        var action = filter.action;
+        if (!action) {
+          for (var j = 0; j < nodes.length; j++) nodes[j].setAttribute('data-adblock-hide', '1');
+          return;
+        }
+        switch (action.type) {
+          case 'Style':
+            for (var j2 = 0; j2 < nodes.length; j2++) {
+              try { nodes[j2].style.cssText += ';' + action.arg; } catch (e) {}
+            }
+            return;
+          case 'Remove':
+            for (var j3 = 0; j3 < nodes.length; j3++) {
+              try { nodes[j3].remove(); } catch (e) {}
+            }
+            return;
+          case 'RemoveAttr':
+            for (var j4 = 0; j4 < nodes.length; j4++) {
+              try { nodes[j4].removeAttribute(action.arg); } catch (e) {}
+            }
+            return;
+          case 'RemoveClass':
+            for (var j5 = 0; j5 < nodes.length; j5++) {
+              try { nodes[j5].classList.remove(action.arg); } catch (e) {}
+            }
+            return;
+        }
+      }
+
+      function runProcedurals() {
+        if (!procedurals || procedurals.length === 0) return;
+        var hits = 0;
+        for (var i = 0; i < procedurals.length; i++) {
+          var f;
+          try { f = JSON.parse(procedurals[i]); } catch (e) { continue; }
+          try { runFilter(f); hits++; } catch (e) {}
+        }
+      }
+
+
+      function ready(fn) {
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', fn, { once: true });
+        } else {
+          fn();
+        }
+      }
+
+      function applyGeneric() {
+        if (generichide) return;
+        if (!window.__adblockBridge) return;
+        var classes = new Set();
+        var ids = new Set();
+        var els = document.getElementsByTagName('*');
+        for (var i = 0; i < els.length; i++) {
+          var el = els[i];
+          if (el.id) ids.add(el.id);
+          var cls = el.getAttribute && el.getAttribute('class');
+          if (cls) {
+            var parts = cls.split(/\s+/);
+            for (var j = 0; j < parts.length; j++) {
+              if (parts[j]) classes.add(parts[j]);
+            }
+          }
+        }
+        var classArr = JSON.stringify(Array.from(classes));
+        var idArr = JSON.stringify(Array.from(ids));
+        var exArr = JSON.stringify(exceptions || []);
+        var resultJson;
+        try {
+          resultJson = window.__adblockBridge.lookupGenericSelectors(classArr, idArr, exArr);
+        } catch (e) {
+          console.warn('[adblock] generic lookup failed', e);
+          return;
+        }
+        var selectors;
+        try { selectors = JSON.parse(resultJson); } catch (e) { return; }
+        if (!selectors || selectors.length === 0) return;
+        var style = document.createElement('style');
+        style.setAttribute('data-adblock-generic', '1');
+        style.textContent =
+          selectors.join(',\n') +
+          ' { display: none !important; min-height: 0 !important; min-width: 0 !important; height: 0 !important; }';
+        (document.head || document.documentElement).appendChild(style);
+        console.log('[adblock] generic selectors applied: ' + selectors.length);
+      }
+
+      if (!applyCss()) {
+        var tries = 0;
+        var iv = setInterval(function(){
+          tries++;
+          if (applyCss() || tries > 50) clearInterval(iv);
+        }, 20);
+      }
+      ready(function(){
+        applyCss(); // re-assert in case the framework rebuilt <head>
+        guardCss();
+        runProcedurals();
+        applyGeneric();
+      });
+    })();
+    """.trimIndent()
 }

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator.browser
+
+import android.annotation.SuppressLint
+import android.content.Intent
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.util.Log
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.davidv.translator.Language
+import dev.davidv.translator.TranslationService
+import dev.davidv.translator.TranslatorApplication
+import dev.davidv.translator.ui.components.LanguageSelectionRow
+import dev.davidv.translator.ui.theme.TranslatorTheme
+
+class BrowserActivity : ComponentActivity() {
+  companion object {
+    const val EXTRA_URL = "url"
+    const val EXTRA_SOURCE_LANG = "source_lang"
+    const val EXTRA_TARGET_LANG = "target_lang"
+    private const val DEFAULT_HOME = "about:blank"
+    private const val TAG = "BrowserActivity"
+  }
+
+  private lateinit var viewModel: BrowserViewModel
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
+    val app = application as TranslatorApplication
+
+    val initialUrl = extractUrl(intent) ?: DEFAULT_HOME
+    val sourceCode = intent.getStringExtra(EXTRA_SOURCE_LANG)
+    val targetCode = intent.getStringExtra(EXTRA_TARGET_LANG)
+
+    viewModel =
+      ViewModelProvider(
+        this,
+        BrowserViewModelFactory(
+          settingsManager = app.settingsManager,
+          filePathManager = app.filePathManager,
+          languageMetadataManager = app.languageMetadataManager,
+          translationService = app.translationService,
+          initialUrl = initialUrl,
+          initialSourceCode = sourceCode,
+          initialTargetCode = targetCode,
+        ),
+      )[BrowserViewModel::class.java]
+
+    val contentScript = assets.open("translator.js").bufferedReader().use { it.readText() }
+
+    setContent {
+      TranslatorTheme {
+        Surface(
+          color = MaterialTheme.colorScheme.background,
+          modifier = Modifier.fillMaxSize().windowInsetsPadding(WindowInsets.safeDrawing),
+        ) {
+          BrowserScreen(
+            viewModel = viewModel,
+            contentScript = contentScript,
+            translationService = app.translationService,
+            onFinish = { finish() },
+          )
+        }
+      }
+    }
+  }
+
+  private fun extractUrl(intent: Intent?): String? {
+    if (intent == null) return null
+    val fromExtra = intent.getStringExtra(EXTRA_URL)
+    if (!fromExtra.isNullOrBlank()) return fromExtra
+    if (intent.action == Intent.ACTION_SEND) {
+      val shared = intent.getStringExtra(Intent.EXTRA_TEXT)?.trim()
+      if (!shared.isNullOrBlank()) return firstUrlInText(shared)
+    }
+    intent.data?.let { return it.toString() }
+    return null
+  }
+
+  private fun firstUrlInText(text: String): String {
+    for (token in text.split(Regex("\\s+"))) {
+      if (token.startsWith("http://") || token.startsWith("https://")) return token
+    }
+    Log.d(TAG, "ACTION_SEND had no URL; using full text as query target: $text")
+    return text
+  }
+}
+
+private const val TOPBAR_SCROLL_THRESHOLD_PX = 8
+private const val TOPBAR_TOP_SHOW_PX = 50
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun BrowserScreen(
+  viewModel: BrowserViewModel,
+  contentScript: String,
+  translationService: TranslationService,
+  onFinish: () -> Unit,
+) {
+  val from by viewModel.from.collectAsStateWithLifecycle()
+  val to by viewModel.to.collectAsStateWithLifecycle()
+  val languageState by viewModel.languageState.collectAsStateWithLifecycle()
+  val languageMetadata by viewModel.languageMetadata.collectAsStateWithLifecycle()
+  val url by viewModel.url.collectAsStateWithLifecycle()
+
+  if (to == null) return
+
+  if (from == null) {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+      Text(
+        text = "No source language available. Install one from the main screen first, or set a default source language in settings.",
+        color = MaterialTheme.colorScheme.onBackground,
+      )
+    }
+    return
+  }
+
+  var topBarVisible by remember { mutableStateOf(true) }
+  val webViewRef = remember { arrayOfNulls<WebView>(1) }
+
+  BackHandler {
+    val wv = webViewRef[0]
+    if (wv != null && wv.canGoBack()) {
+      wv.goBack()
+    } else {
+      onFinish()
+    }
+  }
+
+  Box(modifier = Modifier.fillMaxSize()) {
+    BrowserWebView(
+      url = url,
+      sourceLang = from!!,
+      targetLang = to!!,
+      contentScript = contentScript,
+      translationService = translationService,
+      onScrollDelta = { y, dy ->
+        topBarVisible =
+          when {
+            y < TOPBAR_TOP_SHOW_PX -> true
+            dy > TOPBAR_SCROLL_THRESHOLD_PX -> false
+            dy < -TOPBAR_SCROLL_THRESHOLD_PX -> true
+            else -> topBarVisible
+          }
+      },
+      onWebViewReady = { webViewRef[0] = it },
+    )
+
+    AnimatedVisibility(
+      visible = topBarVisible,
+      enter = slideInVertically { -it },
+      exit = slideOutVertically { -it },
+      modifier = Modifier.align(Alignment.TopCenter),
+    ) {
+      Surface(
+        color = MaterialTheme.colorScheme.background,
+      ) {
+        LanguageSelectionRow(
+          from = from!!,
+          to = to!!,
+          canSwap = true,
+          languageState = languageState,
+          languageMetadata = languageMetadata,
+          onMessage = viewModel::onMessage,
+          onSettings = null,
+          drawable = Pair("", 0),
+        )
+      }
+    }
+  }
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun BrowserWebView(
+  url: String,
+  sourceLang: Language,
+  targetLang: Language,
+  contentScript: String,
+  translationService: TranslationService,
+  onScrollDelta: (y: Int, dy: Int) -> Unit,
+  onWebViewReady: (WebView) -> Unit,
+) {
+  val scope = androidx.compose.runtime.rememberCoroutineScope()
+  val bridgeRef = remember { arrayOfNulls<TranslatorJsBridge>(1) }
+
+  AndroidView(
+    modifier = Modifier.fillMaxSize(),
+    factory = { ctx ->
+      val webView =
+        WebView(ctx).apply {
+          layoutParams =
+            ViewGroup.LayoutParams(
+              ViewGroup.LayoutParams.MATCH_PARENT,
+              ViewGroup.LayoutParams.MATCH_PARENT,
+            )
+          settings.javaScriptEnabled = true
+          settings.domStorageEnabled = true
+        }
+
+      webView.setOnScrollChangeListener { _, _, y, _, oldY ->
+        onScrollDelta(y, y - oldY)
+      }
+
+      val bridge =
+        TranslatorJsBridge(
+          scope = scope,
+          webView = webView,
+          translationService = translationService,
+          sourceLanguage = sourceLang,
+          targetLanguage = targetLang,
+        )
+      bridgeRef[0] = bridge
+      webView.addJavascriptInterface(bridge, "__translatorBridge")
+
+      webView.webViewClient =
+        object : WebViewClient() {
+          override fun onPageStarted(
+            view: WebView?,
+            url: String?,
+            favicon: Bitmap?,
+          ) {
+            view?.evaluateJavascript(contentScript, null)
+          }
+        }
+
+      onWebViewReady(webView)
+      webView.loadUrl(url)
+      webView
+    },
+    update = { webView ->
+      val b = bridgeRef[0] ?: return@AndroidView
+      val langsChanged = b.sourceLanguage != sourceLang || b.targetLanguage != targetLang
+      b.sourceLanguage = sourceLang
+      b.targetLanguage = targetLang
+      if (langsChanged) webView.reload()
+    },
+  )
+}

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
@@ -114,6 +114,8 @@ class BrowserActivity : ComponentActivity() {
     val contentScript = assets.open("translator.js").bufferedReader().use { it.readText() }
     val readabilityScript = assets.open("Readability.js").bufferedReader().use { it.readText() }
     val readerModeScript = assets.open("reader-mode.js").bufferedReader().use { it.readText() }
+    val adblockCosmeticScript =
+      assets.open("adblock-cosmetic.js").bufferedReader().use { it.readText() }
 
     setContent {
       TranslatorTheme {
@@ -126,6 +128,7 @@ class BrowserActivity : ComponentActivity() {
             contentScript = contentScript,
             readabilityScript = readabilityScript,
             readerModeScript = readerModeScript,
+            adblockCosmeticScript = adblockCosmeticScript,
             translationService = app.translationService,
             adblockManager = app.adblockManager,
             onFinish = { finish() },
@@ -168,6 +171,7 @@ private fun BrowserScreen(
   contentScript: String,
   readabilityScript: String,
   readerModeScript: String,
+  adblockCosmeticScript: String,
   translationService: TranslationService,
   adblockManager: AdblockManager,
   onFinish: () -> Unit,
@@ -214,6 +218,7 @@ private fun BrowserScreen(
       sourceLang = from!!,
       targetLang = to!!,
       contentScript = contentScript,
+      adblockCosmeticScript = adblockCosmeticScript,
       translationService = translationService,
       adblockManager = adblockManager,
       darkTheme = darkTheme,
@@ -327,6 +332,7 @@ private fun BrowserWebView(
   sourceLang: Language,
   targetLang: Language,
   contentScript: String,
+  adblockCosmeticScript: String,
   translationService: TranslationService,
   adblockManager: AdblockManager,
   darkTheme: Boolean,
@@ -338,6 +344,7 @@ private fun BrowserWebView(
   val scope = androidx.compose.runtime.rememberCoroutineScope()
   val bridgeRef = remember { arrayOfNulls<TranslatorJsBridge>(1) }
   val currentPageUrlRef = remember { java.util.concurrent.atomic.AtomicReference<String?>(null) }
+  val currentPageSerialRef = remember { java.util.concurrent.atomic.AtomicInteger(0) }
   val bridgeToken = remember { UUID.randomUUID().toString() }
   val translatorBridgeName = remember { "__translatorBridge_${bridgeToken.filter { it != '-' }}" }
   val adblockBridgeName = remember { "__adblockBridge_${bridgeToken.filter { it != '-' }}" }
@@ -393,14 +400,18 @@ private fun BrowserWebView(
               Log.i("AdblockManager", "onPageStarted view=$view url=$url")
               onPageStarted()
               currentPageUrlRef.set(url)
+              val pageSerial = currentPageSerialRef.incrementAndGet()
               if (view != null && url != null) {
                 applyCosmeticFiltersAsync(
                   scope,
                   view,
                   adblockManager,
                   url,
+                  pageSerial,
+                  currentPageSerialRef,
                   adblockBridgeName,
                   bridgeToken,
+                  adblockCosmeticScript,
                 )
               }
             }
@@ -413,6 +424,20 @@ private fun BrowserWebView(
                 buildTranslatorContentJs(contentScript, translatorBridgeName, bridgeToken),
                 null,
               )
+              val pageSerial = currentPageSerialRef.get()
+              if (view != null && url != null) {
+                applyCosmeticFiltersAsync(
+                  scope,
+                  view,
+                  adblockManager,
+                  url,
+                  pageSerial,
+                  currentPageSerialRef,
+                  adblockBridgeName,
+                  bridgeToken,
+                  adblockCosmeticScript,
+                )
+              }
               if (view != null) onPageFinished(view)
             }
 
@@ -483,10 +508,13 @@ private fun applyCosmeticFiltersAsync(
   webView: WebView,
   adblockManager: AdblockManager,
   url: String,
+  pageSerial: Int,
+  currentPageSerialRef: java.util.concurrent.atomic.AtomicInteger,
   adblockBridgeName: String,
   bridgeToken: String,
+  adblockCosmeticScript: String,
 ) {
-  Log.i("AdblockManager", "onPageStarted url=$url scheduling lookup")
+  Log.i("AdblockManager", "url=$url scheduling cosmetic lookup")
   scope.launch {
     val tFetch = System.currentTimeMillis()
     val cosmetic = withContext(Dispatchers.IO) { adblockManager.cosmeticResources(url) }
@@ -513,12 +541,19 @@ private fun applyCosmeticFiltersAsync(
         cosmetic.injectedScript,
         adblockBridgeName,
         bridgeToken,
+        adblockCosmeticScript,
       )
     if (js.isEmpty()) {
       Log.i("AdblockManager", "url=$url empty cosmetic, skipping")
       return@launch
     }
-    webView.evaluateJavascript(js, null)
+    withContext(Dispatchers.Main) {
+      if (currentPageSerialRef.get() != pageSerial) {
+        Log.i("AdblockManager", "url=$url stale cosmetic result, skipping")
+        return@withContext
+      }
+      webView.evaluateJavascript(js, null)
+    }
   }
 }
 
@@ -531,6 +566,7 @@ private fun buildCosmeticJs(
   injectedScript: String,
   adblockBridgeName: String,
   bridgeToken: String,
+  adblockCosmeticScript: String,
 ): String {
   if (hideSelectors.isEmpty() && styleRules.isEmpty() &&
     proceduralFilters.isEmpty() && injectedScript.isBlank() && generichide
@@ -544,295 +580,19 @@ private fun buildCosmeticJs(
   if (styleRules.isNotEmpty()) {
     cssParts.addAll(styleRules)
   }
-  val css = cssParts.joinToString("\n")
-  val hideSelectorsLiteral =
-    org.json.JSONArray().apply { hideSelectors.forEach { put(it) } }.toString()
-  val cssLiteral = JSONObject.quote(css)
-  val proceduralLiteral =
-    org.json.JSONArray().apply { proceduralFilters.forEach { put(it) } }.toString()
-  val exceptionsLiteral =
-    org.json.JSONArray().apply { exceptions.forEach { put(it) } }.toString()
-  val scriptLiteral = JSONObject.quote(injectedScript)
-  val adblockBridgeNameLiteral = JSONObject.quote(adblockBridgeName)
-  val bridgeTokenLiteral = JSONObject.quote(bridgeToken)
-  val generichideLiteral = if (generichide) "true" else "false"
-  return """
-    (function(){
-      var baseCss = $cssLiteral;
-      var hideSelectors = $hideSelectorsLiteral;
-      var js = $scriptLiteral;
-      var procedurals = $proceduralLiteral;
-      var exceptions = $exceptionsLiteral;
-      var generichide = $generichideLiteral;
-      var adblockBridgeName = $adblockBridgeNameLiteral;
-      var bridgeToken = $bridgeTokenLiteral;
-
-      var jsInjected = false;
-      var validatedHideCss = null;
-
-      function isValidSelector(selector) {
-        try {
-          document.querySelector(selector);
-          return true;
-        } catch (e) {
-          return false;
-        }
-      }
-
-      function buildCssText() {
-        if (validatedHideCss === null) {
-          var valid = [];
-          var invalid = 0;
-          for (var i = 0; i < hideSelectors.length; i++) {
-            if (isValidSelector(hideSelectors[i])) valid.push(hideSelectors[i]);
-            else invalid++;
-          }
-          validatedHideCss = valid.length
-            ? valid.join(',\n') + ' { display: none !important; min-height: 0 !important; min-width: 0 !important; height: 0 !important; }\n'
-            : '';
-          if (invalid) console.log('[adblock] skipped invalid cosmetic selectors: ' + invalid);
-        }
-        return validatedHideCss + baseCss;
-      }
-
-      function applyCss() {
-        var root = document.head || document.documentElement || document.body;
-        if (!root) return false;
-        try {
-          var css = buildCssText();
-          if (css) {
-            var existing = document.querySelector('style[data-adblock="1"]');
-            if (!existing || !existing.isConnected || existing.parentNode !== root) {
-              if (existing && !existing.isConnected) existing.remove();
-              var s = document.createElement('style');
-              s.setAttribute('data-adblock','1');
-              s.textContent = css;
-              root.appendChild(s);
-            } else if (existing.textContent !== css) {
-              existing.textContent = css;
-            }
-          }
-          if (js && !jsInjected) {
-            var sc = document.createElement('script');
-            sc.setAttribute('data-adblock','1');
-            sc.textContent = js;
-            root.appendChild(sc);
-            sc.remove();
-            jsInjected = true;
-          }
-          return true;
-        } catch (e) {
-          console.warn('[adblock] cosmetic apply failed', e);
-          return true;
-        }
-      }
-
-      function guardCss() {
-        try {
-          var target = document.documentElement;
-          if (!target) return;
-          var mo = new MutationObserver(function(){
-            var existing = document.querySelector('style[data-adblock="1"]');
-            if (!existing || !existing.isConnected) applyCss();
-          });
-          mo.observe(target, { childList: true, subtree: true });
-        } catch (e) {}
-      }
-
-      // ---- procedural filter pipeline (uBO-style) ----
-      function opTask(op) {
-        var arg = op.arg;
-        switch (op.type) {
-          case 'CssSelector':
-            return function(nodes) {
-              if (nodes === null) {
-                try { return Array.prototype.slice.call(document.querySelectorAll(arg)); }
-                catch (e) { return []; }
-              }
-              var out = [];
-              for (var i = 0; i < nodes.length; i++) {
-                try { out.push.apply(out, nodes[i].querySelectorAll(arg)); } catch (e) {}
-              }
-              return out;
-            };
-          case 'HasText':
-            var re;
-            if (arg && arg.length > 1 && arg.charAt(0) === '/' &&
-                arg.lastIndexOf('/') > 0) {
-              var slash = arg.lastIndexOf('/');
-              try { re = new RegExp(arg.slice(1, slash), arg.slice(slash + 1)); } catch (e) {}
-            }
-            var literal = arg;
-            return function(nodes) {
-              return nodes.filter(function(n){
-                var t = (n.textContent || '');
-                return re ? re.test(t) : t.indexOf(literal) >= 0;
-              });
-            };
-          case 'MatchesCss':
-          case 'MatchesCssBefore':
-          case 'MatchesCssAfter':
-            // arg shape: "prop: value" possibly more complex
-            var idx = arg.indexOf(':');
-            if (idx < 0) return function(nodes){ return []; };
-            var prop = arg.slice(0, idx).trim();
-            var val = arg.slice(idx + 1).trim();
-            var pseudo = op.type === 'MatchesCssBefore' ? '::before'
-                       : op.type === 'MatchesCssAfter' ? '::after' : null;
-            return function(nodes) {
-              return nodes.filter(function(n){
-                try {
-                  var cs = window.getComputedStyle(n, pseudo);
-                  return cs && cs.getPropertyValue(prop).trim() === val;
-                } catch (e) { return false; }
-              });
-            };
-          case 'Upward':
-            // arg: integer N, or selector
-            var n = parseInt(arg, 10);
-            if (!isNaN(n) && /^-?\d+$/.test(String(arg))) {
-              return function(nodes) {
-                var out = [];
-                for (var i = 0; i < nodes.length; i++) {
-                  var p = nodes[i];
-                  for (var k = 0; k < n && p; k++) p = p.parentElement;
-                  if (p) out.push(p);
-                }
-                return out;
-              };
-            }
-            return function(nodes) {
-              var out = [];
-              for (var i = 0; i < nodes.length; i++) {
-                try {
-                  var anc = nodes[i].parentElement && nodes[i].parentElement.closest(arg);
-                  if (anc) out.push(anc);
-                } catch (e) {}
-              }
-              return out;
-            };
-          default:
-            return null; // unsupported -> drop entire filter
-        }
-      }
-
-      function compileFilter(filter) {
-        var tasks = [];
-        for (var i = 0; i < filter.selector.length; i++) {
-          var t = opTask(filter.selector[i]);
-          if (!t) return null;
-          tasks.push(t);
-        }
-        return tasks;
-      }
-
-      function runFilter(filter) {
-        var tasks = compileFilter(filter);
-        if (!tasks) return;
-        var nodes = null;
-        for (var i = 0; i < tasks.length; i++) nodes = tasks[i](nodes);
-        if (!nodes || nodes.length === 0) return;
-        var action = filter.action;
-        if (!action) {
-          for (var j = 0; j < nodes.length; j++) nodes[j].setAttribute('data-adblock-hide', '1');
-          return;
-        }
-        switch (action.type) {
-          case 'Style':
-            for (var j2 = 0; j2 < nodes.length; j2++) {
-              try { nodes[j2].style.cssText += ';' + action.arg; } catch (e) {}
-            }
-            return;
-          case 'Remove':
-            for (var j3 = 0; j3 < nodes.length; j3++) {
-              try { nodes[j3].remove(); } catch (e) {}
-            }
-            return;
-          case 'RemoveAttr':
-            for (var j4 = 0; j4 < nodes.length; j4++) {
-              try { nodes[j4].removeAttribute(action.arg); } catch (e) {}
-            }
-            return;
-          case 'RemoveClass':
-            for (var j5 = 0; j5 < nodes.length; j5++) {
-              try { nodes[j5].classList.remove(action.arg); } catch (e) {}
-            }
-            return;
-        }
-      }
-
-      function runProcedurals() {
-        if (!procedurals || procedurals.length === 0) return;
-        var hits = 0;
-        for (var i = 0; i < procedurals.length; i++) {
-          var f;
-          try { f = JSON.parse(procedurals[i]); } catch (e) { continue; }
-          try { runFilter(f); hits++; } catch (e) {}
-        }
-      }
-
-
-      function ready(fn) {
-        if (document.readyState === 'loading') {
-          document.addEventListener('DOMContentLoaded', fn, { once: true });
-        } else {
-          fn();
-        }
-      }
-
-      function applyGeneric() {
-        if (generichide) return;
-        var adblockBridge = window[adblockBridgeName];
-        if (!adblockBridge) return;
-        var classes = new Set();
-        var ids = new Set();
-        var els = document.getElementsByTagName('*');
-        for (var i = 0; i < els.length; i++) {
-          var el = els[i];
-          if (el.id) ids.add(el.id);
-          var cls = el.getAttribute && el.getAttribute('class');
-          if (cls) {
-            var parts = cls.split(/\s+/);
-            for (var j = 0; j < parts.length; j++) {
-              if (parts[j]) classes.add(parts[j]);
-            }
-          }
-        }
-        var classArr = JSON.stringify(Array.from(classes));
-        var idArr = JSON.stringify(Array.from(ids));
-        var exArr = JSON.stringify(exceptions || []);
-        var resultJson;
-        try {
-          resultJson = adblockBridge.lookupGenericSelectors(classArr, idArr, exArr, bridgeToken);
-        } catch (e) {
-          console.warn('[adblock] generic lookup failed', e);
-          return;
-        }
-        var selectors;
-        try { selectors = JSON.parse(resultJson); } catch (e) { return; }
-        if (!selectors || selectors.length === 0) return;
-        var style = document.createElement('style');
-        style.setAttribute('data-adblock-generic', '1');
-        style.textContent =
-          selectors.join(',\n') +
-          ' { display: none !important; min-height: 0 !important; min-width: 0 !important; height: 0 !important; }';
-        (document.head || document.documentElement).appendChild(style);
-        console.log('[adblock] generic selectors applied: ' + selectors.length);
-      }
-
-      if (!applyCss()) {
-        var tries = 0;
-        var iv = setInterval(function(){
-          tries++;
-          if (applyCss() || tries > 50) clearInterval(iv);
-        }, 20);
-      }
-      ready(function(){
-        applyCss(); // re-assert in case the framework rebuilt <head>
-        guardCss();
-        runProcedurals();
-        applyGeneric();
-      });
-    })();
-    """.trimIndent()
+  val config =
+    JSONObject()
+      .put("baseCss", cssParts.joinToString("\n"))
+      .put("hideSelectors", org.json.JSONArray().apply { hideSelectors.forEach { put(it) } })
+      .put(
+        "proceduralFilters",
+        org.json.JSONArray().apply { proceduralFilters.forEach { put(it) } },
+      )
+      .put("exceptions", org.json.JSONArray().apply { exceptions.forEach { put(it) } })
+      .put("generichide", generichide)
+      .put("injectedScript", injectedScript)
+      .put("adblockBridgeName", adblockBridgeName)
+      .put("bridgeToken", bridgeToken)
+      .toString()
+  return "window.__translatorAdblockConfig = $config;\n$adblockCosmeticScript"
 }

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserViewModel.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserViewModel.kt
@@ -99,7 +99,7 @@ class BrowserViewModel(
       is TranslatorMessage.SwapLanguages -> {
         val prevFrom = _from.value
         val prevTo = _to.value
-        if (prevFrom != null && prevTo != null) {
+        if (prevFrom != null && prevTo != null && canSwapLanguages(prevFrom, prevTo)) {
           _from.value = prevTo
           _to.value = prevFrom
         }
@@ -123,6 +123,11 @@ class BrowserViewModel(
       }
     _url.value = normalized
   }
+
+  fun canSwapLanguages(
+    from: Language,
+    to: Language,
+  ): Boolean = languageStateManager.canSwapLanguages(from, to)
 }
 
 class BrowserViewModelFactory(

--- a/app/src/main/java/dev/davidv/translator/browser/BrowserViewModel.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserViewModel.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator.browser
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import dev.davidv.translator.FilePathManager
+import dev.davidv.translator.Language
+import dev.davidv.translator.LanguageAvailabilityState
+import dev.davidv.translator.LanguageMetadata
+import dev.davidv.translator.LanguageMetadataManager
+import dev.davidv.translator.LanguageStateManager
+import dev.davidv.translator.SettingsManager
+import dev.davidv.translator.TranslationService
+import dev.davidv.translator.TranslatorMessage
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+class BrowserViewModel(
+  settingsManager: SettingsManager,
+  filePathManager: FilePathManager,
+  languageMetadataManager: LanguageMetadataManager,
+  private val translationService: TranslationService,
+  initialUrl: String,
+  initialSourceCode: String?,
+  initialTargetCode: String?,
+) : ViewModel() {
+  val languageStateManager = LanguageStateManager(viewModelScope, filePathManager)
+
+  val languageState: StateFlow<LanguageAvailabilityState> = languageStateManager.languageState
+  val languageMetadata: StateFlow<Map<Language, LanguageMetadata>> = languageMetadataManager.metadata
+
+  private val _from = MutableStateFlow<Language?>(null)
+  val from: StateFlow<Language?> = _from.asStateFlow()
+
+  private val _to = MutableStateFlow<Language?>(null)
+  val to: StateFlow<Language?> = _to.asStateFlow()
+
+  private val _url = MutableStateFlow(initialUrl)
+  val url: StateFlow<String> = _url.asStateFlow()
+
+  init {
+    viewModelScope.launch {
+      combine(languageStateManager.catalog, languageStateManager.languageState) { catalog, state ->
+        catalog to state
+      }.collect { (catalog, state) ->
+        if (catalog == null) return@collect
+        val settings = settingsManager.settings.value
+        if (_to.value == null) {
+          val tgtCode = initialTargetCode ?: settings.defaultTargetLanguageCode
+          _to.value = catalog.languageByCode(tgtCode) ?: catalog.english
+        }
+        if (_from.value == null) {
+          val srcCode = initialSourceCode ?: settings.defaultSourceLanguageCode
+          val byCode = srcCode?.let { catalog.languageByCode(it) }
+          _from.value = byCode ?: firstAvailableSourceLanguage(state, _to.value)
+        }
+        val fromLang = _from.value
+        val toLang = _to.value
+        if (fromLang != null && toLang != null && fromLang != toLang) {
+          translationService.preloadModel(fromLang, toLang)
+        }
+      }
+    }
+  }
+
+  private fun firstAvailableSourceLanguage(
+    state: LanguageAvailabilityState,
+    target: Language?,
+  ): Language? =
+    state.allLanguages().firstOrNull { lang ->
+      lang != target &&
+        (lang.isEnglish || state.availabilityFor(lang)?.hasToEnglish == true)
+    }
+
+  fun onMessage(message: TranslatorMessage) {
+    when (message) {
+      is TranslatorMessage.FromLang -> _from.value = message.language
+      is TranslatorMessage.ToLang -> _to.value = message.language
+      is TranslatorMessage.SwapLanguages -> {
+        val prevFrom = _from.value
+        val prevTo = _to.value
+        if (prevFrom != null && prevTo != null) {
+          _from.value = prevTo
+          _to.value = prevFrom
+        }
+      }
+      else -> {}
+    }
+    val fromLang = _from.value
+    val toLang = _to.value
+    if (fromLang != null && toLang != null && fromLang != toLang) {
+      viewModelScope.launch { translationService.preloadModel(fromLang, toLang) }
+    }
+  }
+
+  fun loadUrl(value: String) {
+    val normalized =
+      when {
+        value.startsWith("http://") || value.startsWith("https://") -> value
+        value == "about:blank" -> value
+        value.isBlank() -> return
+        else -> "https://$value"
+      }
+    _url.value = normalized
+  }
+}
+
+class BrowserViewModelFactory(
+  private val settingsManager: SettingsManager,
+  private val filePathManager: FilePathManager,
+  private val languageMetadataManager: LanguageMetadataManager,
+  private val translationService: TranslationService,
+  private val initialUrl: String,
+  private val initialSourceCode: String?,
+  private val initialTargetCode: String?,
+) : ViewModelProvider.Factory {
+  override fun <T : ViewModel> create(modelClass: Class<T>): T {
+    @Suppress("UNCHECKED_CAST")
+    return BrowserViewModel(
+      settingsManager = settingsManager,
+      filePathManager = filePathManager,
+      languageMetadataManager = languageMetadataManager,
+      translationService = translationService,
+      initialUrl = initialUrl,
+      initialSourceCode = initialSourceCode,
+      initialTargetCode = initialTargetCode,
+    ) as T
+  }
+}

--- a/app/src/main/java/dev/davidv/translator/browser/TranslatorJsBridge.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/TranslatorJsBridge.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.json.JSONArray
 import org.json.JSONObject
 
 class TranslatorJsBridge(
@@ -46,13 +45,13 @@ class TranslatorJsBridge(
   @JavascriptInterface
   fun translateHtmlFragments(
     requestId: Int,
-    fragmentsJson: String,
+    fragmentsPayload: String,
     token: String,
     nonce: String,
   ) {
     if (token != bridgeToken) return
     scope.launch {
-      val fragments = decodeStringArray(fragmentsJson)
+      val fragments = decodeWire(fragmentsPayload)
       if (fragments == null) {
         resolveOnJs(requestId, emptyList(), nonce)
         return@launch
@@ -71,13 +70,13 @@ class TranslatorJsBridge(
   @JavascriptInterface
   fun translateTexts(
     requestId: Int,
-    textsJson: String,
+    textsPayload: String,
     token: String,
     nonce: String,
   ) {
     if (token != bridgeToken) return
     scope.launch {
-      val texts = decodeStringArray(textsJson)
+      val texts = decodeWire(textsPayload)
       if (texts == null) {
         resolveOnJs(requestId, emptyList(), nonce)
         return@launch
@@ -115,7 +114,7 @@ class TranslatorJsBridge(
     translated: List<String>,
     nonce: String,
   ) {
-    val payload = encodeStringArray(translated)
+    val payload = JSONObject.quote(encodeWire(translated))
     val jsNonce = JSONObject.quote(nonce)
     withContext(Dispatchers.Main) {
       webView.evaluateJavascript(
@@ -125,26 +124,41 @@ class TranslatorJsBridge(
     }
   }
 
-  private fun decodeStringArray(json: String): List<String>? {
-    if (json.length > MAX_TOTAL_CHARS + 4096) return null
-    val arr = runCatching { JSONArray(json) }.getOrNull() ?: return null
-    if (arr.length() > MAX_BATCH_ITEMS) return null
-    val values = ArrayList<String>(arr.length())
-    var totalChars = 0
-    for (i in 0 until arr.length()) {
-      if (arr.isNull(i)) return null
-      val value = arr.getString(i)
-      if (value.length > MAX_ITEM_CHARS) return null
-      totalChars += value.length
-      if (totalChars > MAX_TOTAL_CHARS) return null
-      values += value
+  // Wire format: length-prefixed records `<len>:<text><len>:<text>...`
+  // where `len` is the UTF-16 code-unit count (matches String.length on
+  // both sides). Robust to any content; cheaper than JSON because no
+  // per-char escape work.
+  private fun decodeWire(payload: String): List<String>? {
+    if (payload.isEmpty()) return emptyList()
+    if (payload.length > MAX_TOTAL_CHARS + MAX_BATCH_ITEMS * 8) return null
+    val items = ArrayList<String>()
+    var i = 0
+    val n = payload.length
+    while (i < n) {
+      val colon = payload.indexOf(':', i)
+      if (colon < 0) return null
+      val len =
+        try {
+          payload.substring(i, colon).toInt()
+        } catch (_: NumberFormatException) {
+          return null
+        }
+      if (len < 0 || len > MAX_ITEM_CHARS) return null
+      val start = colon + 1
+      val end = start + len
+      if (end > n) return null
+      items.add(payload.substring(start, end))
+      if (items.size > MAX_BATCH_ITEMS) return null
+      i = end
     }
-    return values
+    return items
   }
 
-  private fun encodeStringArray(values: List<String>): String {
-    val arr = JSONArray()
-    values.forEach { arr.put(it) }
-    return arr.toString()
+  private fun encodeWire(values: List<String>): String {
+    val sb = StringBuilder()
+    for (v in values) {
+      sb.append(v.length).append(':').append(v)
+    }
+    return sb.toString()
   }
 }

--- a/app/src/main/java/dev/davidv/translator/browser/TranslatorJsBridge.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/TranslatorJsBridge.kt
@@ -33,17 +33,30 @@ class TranslatorJsBridge(
   private val scope: CoroutineScope,
   private val webView: WebView,
   private val translationService: TranslationService,
+  private val bridgeToken: String,
   @Volatile var sourceLanguage: Language,
   @Volatile var targetLanguage: Language,
 ) {
+  companion object {
+    private const val MAX_BATCH_ITEMS = 50
+    private const val MAX_TOTAL_CHARS = 100_000
+    private const val MAX_ITEM_CHARS = 20_000
+  }
+
   @JavascriptInterface
   fun translateHtmlFragments(
     requestId: Int,
     fragmentsJson: String,
+    token: String,
     nonce: String,
   ) {
+    if (token != bridgeToken) return
     scope.launch {
       val fragments = decodeStringArray(fragmentsJson)
+      if (fragments == null) {
+        resolveOnJs(requestId, emptyList(), nonce)
+        return@launch
+      }
       val translated =
         try {
           translationService.translateHtmlFragments(sourceLanguage, targetLanguage, fragments)
@@ -59,10 +72,16 @@ class TranslatorJsBridge(
   fun translateTexts(
     requestId: Int,
     textsJson: String,
+    token: String,
     nonce: String,
   ) {
+    if (token != bridgeToken) return
     scope.launch {
       val texts = decodeStringArray(textsJson)
+      if (texts == null) {
+        resolveOnJs(requestId, emptyList(), nonce)
+        return@launch
+      }
       val translated =
         try {
           val result =
@@ -106,9 +125,21 @@ class TranslatorJsBridge(
     }
   }
 
-  private fun decodeStringArray(json: String): List<String> {
-    val arr = JSONArray(json)
-    return List(arr.length()) { arr.getString(it) }
+  private fun decodeStringArray(json: String): List<String>? {
+    if (json.length > MAX_TOTAL_CHARS + 4096) return null
+    val arr = runCatching { JSONArray(json) }.getOrNull() ?: return null
+    if (arr.length() > MAX_BATCH_ITEMS) return null
+    val values = ArrayList<String>(arr.length())
+    var totalChars = 0
+    for (i in 0 until arr.length()) {
+      if (arr.isNull(i)) return null
+      val value = arr.getString(i)
+      if (value.length > MAX_ITEM_CHARS) return null
+      totalChars += value.length
+      if (totalChars > MAX_TOTAL_CHARS) return null
+      values += value
+    }
+    return values
   }
 
   private fun encodeStringArray(values: List<String>): String {

--- a/app/src/main/java/dev/davidv/translator/browser/TranslatorJsBridge.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/TranslatorJsBridge.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator.browser
+
+import android.util.Log
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import dev.davidv.translator.Language
+import dev.davidv.translator.TranslationService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+class TranslatorJsBridge(
+  private val scope: CoroutineScope,
+  private val webView: WebView,
+  private val translationService: TranslationService,
+  @Volatile var sourceLanguage: Language,
+  @Volatile var targetLanguage: Language,
+) {
+  @JavascriptInterface
+  fun translateHtmlFragments(
+    requestId: Int,
+    fragmentsJson: String,
+    nonce: String,
+  ) {
+    scope.launch {
+      val fragments = decodeStringArray(fragmentsJson)
+      val translated =
+        try {
+          translationService.translateHtmlFragments(sourceLanguage, targetLanguage, fragments)
+        } catch (t: Throwable) {
+          Log.w("TranslatorJsBridge", "translateHtmlFragments failed", t)
+          fragments
+        }
+      resolveOnJs(requestId, translated, nonce)
+    }
+  }
+
+  @JavascriptInterface
+  fun translateTexts(
+    requestId: Int,
+    textsJson: String,
+    nonce: String,
+  ) {
+    scope.launch {
+      val texts = decodeStringArray(textsJson)
+      val translated =
+        try {
+          val result =
+            translationService.translateMixedTexts(
+              texts,
+              sourceLanguage,
+              targetLanguage,
+              listOf(sourceLanguage, targetLanguage),
+            )
+          mapMixedTextsToInputOrder(texts, result)
+        } catch (t: Throwable) {
+          Log.w("TranslatorJsBridge", "translateTexts failed", t)
+          texts
+        }
+      resolveOnJs(requestId, translated, nonce)
+    }
+  }
+
+  private fun mapMixedTextsToInputOrder(
+    inputs: List<String>,
+    result: dev.davidv.translator.BatchTextTranslationOutput,
+  ): List<String> =
+    when (result) {
+      is dev.davidv.translator.BatchTextTranslationOutput.Translated ->
+        inputs.map { result.results[it] ?: it }
+      is dev.davidv.translator.BatchTextTranslationOutput.NothingToTranslate -> inputs
+    }
+
+  private suspend fun resolveOnJs(
+    requestId: Int,
+    translated: List<String>,
+    nonce: String,
+  ) {
+    val payload = encodeStringArray(translated)
+    val jsNonce = JSONObject.quote(nonce)
+    withContext(Dispatchers.Main) {
+      webView.evaluateJavascript(
+        "window.__translator && window.__translator.resolve($requestId, $payload, $jsNonce);",
+        null,
+      )
+    }
+  }
+
+  private fun decodeStringArray(json: String): List<String> {
+    val arr = JSONArray(json)
+    return List(arr.length()) { arr.getString(it) }
+  }
+
+  private fun encodeStringArray(values: List<String>): String {
+    val arr = JSONArray()
+    values.forEach { arr.put(it) }
+    return arr.toString()
+  }
+}

--- a/app/src/main/java/dev/davidv/translator/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/SettingsScreen.kt
@@ -24,23 +24,29 @@ import android.os.Build
 import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -63,6 +69,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dev.davidv.translator.AppSettings
 import dev.davidv.translator.BackgroundMode
+import dev.davidv.translator.DownloadService
+import dev.davidv.translator.DownloadState
 import dev.davidv.translator.Language
 import dev.davidv.translator.LanguageCatalog
 import dev.davidv.translator.LanguageMetadataManager
@@ -132,8 +140,11 @@ fun SettingsScreen(
   languageMetadataManager: dev.davidv.translator.LanguageMetadataManager,
   availableLanguages: List<Language>,
   catalog: LanguageCatalog?,
+  adblockDownloadState: DownloadState,
+  adblockInstalled: Boolean,
   onSettingsChange: (AppSettings) -> Unit,
   onManageLanguages: () -> Unit,
+  onDeleteAdblockSupport: () -> Unit,
 ) {
   val context = LocalContext.current
   var showPermissionDialog by remember { mutableStateOf(false) }
@@ -348,6 +359,36 @@ fun SettingsScreen(
               },
             )
           }
+        }
+      }
+
+      // Web Translator Section
+      Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors =
+          CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
+          ),
+      ) {
+        Column(
+          modifier = Modifier.padding(16.dp),
+          verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+          Text(
+            text = "Web Translator",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+          )
+
+          WebTranslatorAssetRow(
+            label = "Adblock support",
+            secondaryLabel = catalog?.supportSizeBytesByKind("adblock")?.let(::formatSize),
+            installed = adblockInstalled,
+            downloadState = adblockDownloadState,
+            onDownload = { DownloadService.startAdblockDownload(context) },
+            onDelete = onDeleteAdblockSupport,
+            onCancel = { DownloadService.cancelAdblockDownload(context) },
+          )
         }
       }
 
@@ -924,6 +965,129 @@ fun SettingsScreen(
   }
 }
 
+@Composable
+private fun WebTranslatorAssetRow(
+  label: String,
+  secondaryLabel: String?,
+  installed: Boolean,
+  downloadState: DownloadState,
+  onDownload: () -> Unit,
+  onDelete: () -> Unit,
+  onCancel: () -> Unit,
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    horizontalArrangement = Arrangement.SpaceBetween,
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(
+      modifier = Modifier.weight(1f),
+      verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+      Text(
+        text = label,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+      )
+      secondaryLabel?.let { size ->
+        Text(
+          text = size,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+
+    SupportActionButton(
+      downloadState = downloadState,
+      installed = installed,
+      onDownload = onDownload,
+      onDelete = onDelete,
+      onCancel = onCancel,
+    )
+  }
+}
+
+@Composable
+private fun SupportActionButton(
+  downloadState: DownloadState,
+  installed: Boolean,
+  onDownload: () -> Unit,
+  onDelete: () -> Unit,
+  onCancel: () -> Unit,
+) {
+  if (downloadState.isDownloading) {
+    Box(
+      contentAlignment = Alignment.Center,
+      modifier = Modifier.size(40.dp),
+    ) {
+      val targetProgress =
+        if (downloadState.totalSize > 0) {
+          downloadState.downloaded.toFloat() / downloadState.totalSize.toFloat()
+        } else {
+          0f
+        }
+      val animatedProgress by animateFloatAsState(
+        targetValue = targetProgress,
+        animationSpec = tween(durationMillis = 300),
+        label = "adblock-progress",
+      )
+      CircularProgressIndicator(
+        progress = { animatedProgress },
+        modifier = Modifier.size(32.dp),
+      )
+      IconButton(
+        onClick = onCancel,
+        modifier = Modifier.size(32.dp),
+      ) {
+        Icon(
+          painter = painterResource(id = R.drawable.cancel),
+          contentDescription = "Cancel Download",
+        )
+      }
+    }
+    return
+  }
+
+  IconButton(
+    onClick = if (installed) onDelete else onDownload,
+    modifier = Modifier.size(40.dp),
+  ) {
+    Icon(
+      painter =
+        painterResource(
+          id =
+            when {
+              installed -> R.drawable.delete
+              downloadState.isCancelled || downloadState.error != null -> R.drawable.refresh
+              else -> R.drawable.add
+            },
+        ),
+      contentDescription =
+        when {
+          installed -> "Delete"
+          downloadState.isCancelled || downloadState.error != null -> "Retry Download"
+          else -> "Download"
+        },
+    )
+  }
+}
+
+private fun formatSize(sizeBytes: Long): String {
+  val units = listOf("B", "KB", "MB", "GB")
+  var size = sizeBytes.toDouble()
+  var unitIndex = 0
+  while (size >= 1024 && unitIndex < units.lastIndex) {
+    size /= 1024
+    unitIndex++
+  }
+  return if (unitIndex == 0) {
+    "${size.toLong()} ${units[unitIndex]}"
+  } else {
+    "%.1f %s".format(size, units[unitIndex])
+  }
+}
+
 private fun isAssistantRoleHeld(context: android.content.Context): Boolean {
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false
   val roleManager = context.getSystemService(RoleManager::class.java) ?: return false
@@ -991,8 +1155,11 @@ fun SettingsScreenPreview() {
       languageMetadataManager = LanguageMetadataManager(context, kotlinx.coroutines.flow.MutableStateFlow(emptyList())),
       availableLanguages = previewLangs,
       catalog = null,
+      adblockDownloadState = DownloadState(),
+      adblockInstalled = false,
       onSettingsChange = {},
       onManageLanguages = {},
+      onDeleteAdblockSupport = {},
     )
   }
 }
@@ -1016,8 +1183,11 @@ fun SettingsScreenDarkPreview() {
       languageMetadataManager = LanguageMetadataManager(context, kotlinx.coroutines.flow.MutableStateFlow(emptyList())),
       availableLanguages = previewLangs,
       catalog = null,
+      adblockDownloadState = DownloadState(),
+      adblockInstalled = true,
       onSettingsChange = {},
       onManageLanguages = {},
+      onDeleteAdblockSupport = {},
     )
   }
 }

--- a/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
+++ b/app/src/main/java/dev/davidv/translator/ui/screens/TranslatorApp.kt
@@ -168,6 +168,9 @@ fun TranslatorApp(
   val downloadStates by downloadService?.downloadStates?.collectAsState() ?: remember {
     kotlinx.coroutines.flow.MutableStateFlow<Map<Language, DownloadState>>(emptyMap())
   }.collectAsState()
+  val adblockDownloadState by downloadService?.adblockDownloadState?.collectAsState() ?: remember {
+    kotlinx.coroutines.flow.MutableStateFlow(DownloadState())
+  }.collectAsState()
   val isTranslating by viewModel.translationCoordinator.isTranslating.collectAsState()
   val ttsVoicesByLanguage by viewModel.ttsVoices.collectAsState()
 
@@ -483,11 +486,15 @@ fun TranslatorApp(
               } else {
                 languageState.translatorLanguages()
               }
+            val app = context.applicationContext as dev.davidv.translator.TranslatorApplication
+            val adblockReady by app.adblockManager.ready.collectAsState()
             SettingsScreen(
               settings = settings,
               languageMetadataManager = viewModel.languageMetadataManager,
               availableLanguages = availableWithEnglish,
               catalog = catalog,
+              adblockDownloadState = adblockDownloadState,
+              adblockInstalled = adblockReady || catalog?.supportInstalledByKind("adblock") == true,
               onSettingsChange = { newSettings ->
                 viewModel.settingsManager.updateSettings(newSettings)
                 if (newSettings.defaultTargetLanguageCode != settings.defaultTargetLanguageCode) {
@@ -502,6 +509,10 @@ fun TranslatorApp(
               },
               onManageLanguages = {
                 navController.navigate("language_manager")
+              },
+              onDeleteAdblockSupport = {
+                viewModel.languageStateManager.deleteSupportByKind("adblock")
+                app.adblockManager.reload()
               },
             )
           }

--- a/app/src/main/res/drawable/chrome_reader_mode.xml
+++ b/app/src/main/res/drawable/chrome_reader_mode.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FF1F1F1F"
+      android:pathData="M160,800q-33,0 -56.5,-23.5T80,720v-480q0,-33 23.5,-56.5T160,160h640q33,0 56.5,23.5T880,240v480q0,33 -23.5,56.5T800,800H160zM160,720h280v-480H160v480zM520,720h280v-480H520v480zM560,600h200v-60H560v60zM560,500h200v-60H560v60zM560,400h200v-60H560v60zM160,720v-480,480z" />
+</vector>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -15,4 +15,12 @@
 
     <style name="Theme.Translator.CropImage" parent="Theme.AppCompat.Light.DarkActionBar">
     </style>
+
+    <style name="Theme.Translator.WebView.Light" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:isLightTheme">true</item>
+    </style>
+
+    <style name="Theme.Translator.WebView.Dark" parent="android:Theme.Material.NoActionBar">
+        <item name="android:isLightTheme">false</item>
+    </style>
 </resources>

--- a/catalog_adblock.py
+++ b/catalog_adblock.py
@@ -53,6 +53,11 @@ def build_adblock_zip(source_catalog: dict, bucket_dir: Path) -> int:
         raise FileNotFoundError(f"Missing {len(missing)} adblock source files.\n{sample}")
 
     output_path = adblock_bundle_path(bucket_dir)
+    if output_path.exists():
+        output_mtime = output_path.stat().st_mtime
+        if all(path.stat().st_mtime <= output_mtime for _, path in source_files):
+            return 0
+
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = output_path.with_name(output_path.name + ".tmp")
     with ZipFile(temp_path, "w", compression=ZIP_DEFLATED) as archive:

--- a/catalog_adblock.py
+++ b/catalog_adblock.py
@@ -1,0 +1,109 @@
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+import catalog_mirror
+
+
+ADBLOCK_KIND = "adblock"
+ADBLOCK_VERSION = 1
+ADBLOCK_ZIP_NAME = f"adblock-lists-v{ADBLOCK_VERSION}.zip"
+ADBLOCK_ZIP_INSTALL_PATH = f"adblock/{ADBLOCK_ZIP_NAME}"
+ADBLOCK_INSTALL_MARKER_PATH = "adblock/.install-info.json"
+
+
+def adblock_source_files(source_catalog: dict, bucket_dir: Path) -> list[tuple[str, Path]]:
+    files = []
+    for pack in source_catalog.get("packs", {}).values():
+        if pack.get("kind") != ADBLOCK_KIND:
+            continue
+        for file_info in pack.get("files", []):
+            install_path = file_info.get("installPath", "")
+            if not install_path.startswith("adblock/") or not install_path.endswith(".txt"):
+                continue
+            mirror_path = catalog_mirror.mirror_path_for_file(pack, file_info)
+            files.append((install_path, catalog_mirror.bucket_path(bucket_dir, mirror_path)))
+    return sorted(files)
+
+
+def adblock_bundle_mirror_path() -> str:
+    return catalog_mirror.mirror_path_for_file(
+        {
+            "feature": "support",
+            "kind": ADBLOCK_KIND,
+        },
+        {
+            "name": ADBLOCK_ZIP_NAME,
+            "installPath": ADBLOCK_ZIP_INSTALL_PATH,
+        },
+    )
+
+
+def adblock_bundle_path(bucket_dir: Path) -> Path:
+    return catalog_mirror.bucket_path(bucket_dir, adblock_bundle_mirror_path())
+
+
+def build_adblock_zip(source_catalog: dict, bucket_dir: Path) -> int:
+    source_files = adblock_source_files(source_catalog, bucket_dir)
+    if not source_files:
+        return 0
+
+    missing = [str(path) for _, path in source_files if not path.exists()]
+    if missing:
+        sample = "\n".join(missing[:20])
+        raise FileNotFoundError(f"Missing {len(missing)} adblock source files.\n{sample}")
+
+    output_path = adblock_bundle_path(bucket_dir)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = output_path.with_name(output_path.name + ".tmp")
+    with ZipFile(temp_path, "w", compression=ZIP_DEFLATED) as archive:
+        for install_path, path in source_files:
+            archive.write(path, arcname=install_path)
+    temp_path.replace(output_path)
+    return output_path.stat().st_size
+
+
+def publish_adblock_pack(published: dict, bucket_dir: Path, base_url: str) -> None:
+    bundle_path = adblock_bundle_path(bucket_dir)
+    if not bundle_path.exists():
+        raise FileNotFoundError(f"Missing adblock bundle: {bundle_path}")
+
+    original_packs = published.get("packs", {})
+    adblock_metadata = []
+    for pack_id, pack in sorted(original_packs.items()):
+        if pack.get("kind") == ADBLOCK_KIND:
+            metadata = pack.get("metadata") or {}
+            adblock_metadata.append(
+                {
+                    "packId": pack_id,
+                    "listId": metadata.get("listId"),
+                    "description": metadata.get("description"),
+                },
+            )
+
+    published["packs"] = {
+        pack_id: pack
+        for pack_id, pack in original_packs.items()
+        if pack.get("kind") != ADBLOCK_KIND
+    }
+    published["packs"][f"support-adblock-lists-v{ADBLOCK_VERSION}"] = {
+        "feature": "support",
+        "kind": ADBLOCK_KIND,
+        "files": [
+            {
+                "name": ADBLOCK_ZIP_NAME,
+                "sizeBytes": bundle_path.stat().st_size,
+                "installPath": ADBLOCK_ZIP_INSTALL_PATH,
+                "url": catalog_mirror.mirror_url(base_url, adblock_bundle_mirror_path()),
+                "archiveFormat": "zip",
+                "extractTo": ".",
+                "deleteAfterExtract": True,
+                "installMarkerPath": ADBLOCK_INSTALL_MARKER_PATH,
+                "installMarkerVersion": ADBLOCK_VERSION,
+            },
+        ],
+        "dependsOn": [],
+        "metadata": {
+            "version": ADBLOCK_VERSION,
+            "lists": adblock_metadata,
+        },
+    }

--- a/catalog_mirror.py
+++ b/catalog_mirror.py
@@ -90,6 +90,8 @@ def mirror_path_for_file(pack_or_feature, file_info: dict) -> str:
 
 def apply_mirror_paths(catalog: dict) -> dict:
     for pack in catalog.get("packs", {}).values():
+        if pack.get("kind") == "adblock":
+            continue
         for file_info in pack.get("files", []):
             file_info["mirrorPath"] = mirror_path_for_file(pack, file_info)
     return catalog

--- a/catalog_sources/source_catalog.json
+++ b/catalog_sources/source_catalog.json
@@ -2874,7 +2874,7 @@
       "files": [
         {
           "name": "ara.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1432056,
           "installPath": "tesseract/tessdata/ara.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ara.traineddata",
           "sourcePath": "ara.traineddata",
@@ -2892,7 +2892,7 @@
       "files": [
         {
           "name": "aze.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3524799,
           "installPath": "tesseract/tessdata/aze.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/aze.traineddata",
           "sourcePath": "aze.traineddata",
@@ -2910,7 +2910,7 @@
       "files": [
         {
           "name": "bel.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3692098,
           "installPath": "tesseract/tessdata/bel.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/bel.traineddata",
           "sourcePath": "bel.traineddata",
@@ -2928,7 +2928,7 @@
       "files": [
         {
           "name": "bul.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1675212,
           "installPath": "tesseract/tessdata/bul.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/bul.traineddata",
           "sourcePath": "bul.traineddata",
@@ -2946,7 +2946,7 @@
       "files": [
         {
           "name": "ben.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 855841,
           "installPath": "tesseract/tessdata/ben.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ben.traineddata",
           "sourcePath": "ben.traineddata",
@@ -2964,7 +2964,7 @@
       "files": [
         {
           "name": "bos.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2498242,
           "installPath": "tesseract/tessdata/bos.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/bos.traineddata",
           "sourcePath": "bos.traineddata",
@@ -2982,7 +2982,7 @@
       "files": [
         {
           "name": "cat.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1146012,
           "installPath": "tesseract/tessdata/cat.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/cat.traineddata",
           "sourcePath": "cat.traineddata",
@@ -3000,7 +3000,7 @@
       "files": [
         {
           "name": "ces.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3795684,
           "installPath": "tesseract/tessdata/ces.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ces.traineddata",
           "sourcePath": "ces.traineddata",
@@ -3018,7 +3018,7 @@
       "files": [
         {
           "name": "dan.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2580059,
           "installPath": "tesseract/tessdata/dan.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/dan.traineddata",
           "sourcePath": "dan.traineddata",
@@ -3036,7 +3036,7 @@
       "files": [
         {
           "name": "deu.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1525436,
           "installPath": "tesseract/tessdata/deu.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/deu.traineddata",
           "sourcePath": "deu.traineddata",
@@ -3054,7 +3054,7 @@
       "files": [
         {
           "name": "ell.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1419514,
           "installPath": "tesseract/tessdata/ell.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ell.traineddata",
           "sourcePath": "ell.traineddata",
@@ -3072,7 +3072,7 @@
       "files": [
         {
           "name": "eng.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 4113088,
           "installPath": "tesseract/tessdata/eng.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/eng.traineddata",
           "sourcePath": "eng.traineddata",
@@ -3088,7 +3088,7 @@
       "files": [
         {
           "name": "spa.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2294433,
           "installPath": "tesseract/tessdata/spa.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/spa.traineddata",
           "sourcePath": "spa.traineddata",
@@ -3106,7 +3106,7 @@
       "files": [
         {
           "name": "est.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 4458101,
           "installPath": "tesseract/tessdata/est.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/est.traineddata",
           "sourcePath": "est.traineddata",
@@ -3124,7 +3124,7 @@
       "files": [
         {
           "name": "fas.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 431500,
           "installPath": "tesseract/tessdata/fas.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/fas.traineddata",
           "sourcePath": "fas.traineddata",
@@ -3142,7 +3142,7 @@
       "files": [
         {
           "name": "fin.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 7865732,
           "installPath": "tesseract/tessdata/fin.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/fin.traineddata",
           "sourcePath": "fin.traineddata",
@@ -3160,7 +3160,7 @@
       "files": [
         {
           "name": "fra.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1130365,
           "installPath": "tesseract/tessdata/fra.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/fra.traineddata",
           "sourcePath": "fra.traineddata",
@@ -3178,7 +3178,7 @@
       "files": [
         {
           "name": "guj.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1418394,
           "installPath": "tesseract/tessdata/guj.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/guj.traineddata",
           "sourcePath": "guj.traineddata",
@@ -3196,7 +3196,7 @@
       "files": [
         {
           "name": "heb.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 961404,
           "installPath": "tesseract/tessdata/heb.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/heb.traineddata",
           "sourcePath": "heb.traineddata",
@@ -3214,7 +3214,7 @@
       "files": [
         {
           "name": "hin.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1122751,
           "installPath": "tesseract/tessdata/hin.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/hin.traineddata",
           "sourcePath": "hin.traineddata",
@@ -3232,7 +3232,7 @@
       "files": [
         {
           "name": "hrv.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 4103348,
           "installPath": "tesseract/tessdata/hrv.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/hrv.traineddata",
           "sourcePath": "hrv.traineddata",
@@ -3250,7 +3250,7 @@
       "files": [
         {
           "name": "hun.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 5296273,
           "installPath": "tesseract/tessdata/hun.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/hun.traineddata",
           "sourcePath": "hun.traineddata",
@@ -3268,7 +3268,7 @@
       "files": [
         {
           "name": "ind.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1122661,
           "installPath": "tesseract/tessdata/ind.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ind.traineddata",
           "sourcePath": "ind.traineddata",
@@ -3286,7 +3286,7 @@
       "files": [
         {
           "name": "isl.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2278973,
           "installPath": "tesseract/tessdata/isl.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/isl.traineddata",
           "sourcePath": "isl.traineddata",
@@ -3304,7 +3304,7 @@
       "files": [
         {
           "name": "ita.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2701314,
           "installPath": "tesseract/tessdata/ita.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ita.traineddata",
           "sourcePath": "ita.traineddata",
@@ -3346,7 +3346,7 @@
       "files": [
         {
           "name": "kan.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3608331,
           "installPath": "tesseract/tessdata/kan.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/kan.traineddata",
           "sourcePath": "kan.traineddata",
@@ -3364,7 +3364,7 @@
       "files": [
         {
           "name": "kor.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1677415,
           "installPath": "tesseract/tessdata/kor.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/kor.traineddata",
           "sourcePath": "kor.traineddata",
@@ -3382,7 +3382,7 @@
       "files": [
         {
           "name": "lit.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3154896,
           "installPath": "tesseract/tessdata/lit.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/lit.traineddata",
           "sourcePath": "lit.traineddata",
@@ -3400,7 +3400,7 @@
       "files": [
         {
           "name": "lav.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2717247,
           "installPath": "tesseract/tessdata/lav.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/lav.traineddata",
           "sourcePath": "lav.traineddata",
@@ -3418,7 +3418,7 @@
       "files": [
         {
           "name": "mal.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 5275996,
           "installPath": "tesseract/tessdata/mal.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/mal.traineddata",
           "sourcePath": "mal.traineddata",
@@ -3436,7 +3436,7 @@
       "files": [
         {
           "name": "msa.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1747801,
           "installPath": "tesseract/tessdata/msa.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/msa.traineddata",
           "sourcePath": "msa.traineddata",
@@ -3454,7 +3454,7 @@
       "files": [
         {
           "name": "nor.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3610079,
           "installPath": "tesseract/tessdata/nor.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/nor.traineddata",
           "sourcePath": "nor.traineddata",
@@ -3472,7 +3472,7 @@
       "files": [
         {
           "name": "nld.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 6050296,
           "installPath": "tesseract/tessdata/nld.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/nld.traineddata",
           "sourcePath": "nld.traineddata",
@@ -3490,7 +3490,7 @@
       "files": [
         {
           "name": "nor.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3610079,
           "installPath": "tesseract/tessdata/nor.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/nor.traineddata",
           "sourcePath": "nor.traineddata",
@@ -3508,7 +3508,7 @@
       "files": [
         {
           "name": "nor.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3610079,
           "installPath": "tesseract/tessdata/nor.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/nor.traineddata",
           "sourcePath": "nor.traineddata",
@@ -3526,7 +3526,7 @@
       "files": [
         {
           "name": "pol.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 4765518,
           "installPath": "tesseract/tessdata/pol.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/pol.traineddata",
           "sourcePath": "pol.traineddata",
@@ -3544,7 +3544,7 @@
       "files": [
         {
           "name": "por.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1982756,
           "installPath": "tesseract/tessdata/por.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/por.traineddata",
           "sourcePath": "por.traineddata",
@@ -3562,7 +3562,7 @@
       "files": [
         {
           "name": "ron.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2376323,
           "installPath": "tesseract/tessdata/ron.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ron.traineddata",
           "sourcePath": "ron.traineddata",
@@ -3580,7 +3580,7 @@
       "files": [
         {
           "name": "rus.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3861738,
           "installPath": "tesseract/tessdata/rus.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/rus.traineddata",
           "sourcePath": "rus.traineddata",
@@ -3598,7 +3598,7 @@
       "files": [
         {
           "name": "slk.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 4427661,
           "installPath": "tesseract/tessdata/slk.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/slk.traineddata",
           "sourcePath": "slk.traineddata",
@@ -3616,7 +3616,7 @@
       "files": [
         {
           "name": "slv.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3003829,
           "installPath": "tesseract/tessdata/slv.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/slv.traineddata",
           "sourcePath": "slv.traineddata",
@@ -3634,7 +3634,7 @@
       "files": [
         {
           "name": "sqi.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1874705,
           "installPath": "tesseract/tessdata/sqi.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/sqi.traineddata",
           "sourcePath": "sqi.traineddata",
@@ -3652,7 +3652,7 @@
       "files": [
         {
           "name": "srp.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2149931,
           "installPath": "tesseract/tessdata/srp.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/srp.traineddata",
           "sourcePath": "srp.traineddata",
@@ -3670,7 +3670,7 @@
       "files": [
         {
           "name": "swe.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 4167034,
           "installPath": "tesseract/tessdata/swe.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/swe.traineddata",
           "sourcePath": "swe.traineddata",
@@ -3688,7 +3688,7 @@
       "files": [
         {
           "name": "tam.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3237963,
           "installPath": "tesseract/tessdata/tam.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/tam.traineddata",
           "sourcePath": "tam.traineddata",
@@ -3706,7 +3706,7 @@
       "files": [
         {
           "name": "tel.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2769654,
           "installPath": "tesseract/tessdata/tel.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/tel.traineddata",
           "sourcePath": "tel.traineddata",
@@ -3724,7 +3724,7 @@
       "files": [
         {
           "name": "tha.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 1072600,
           "installPath": "tesseract/tessdata/tha.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/tha.traineddata",
           "sourcePath": "tha.traineddata",
@@ -3742,7 +3742,7 @@
       "files": [
         {
           "name": "tur.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 4550554,
           "installPath": "tesseract/tessdata/tur.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/tur.traineddata",
           "sourcePath": "tur.traineddata",
@@ -3760,7 +3760,7 @@
       "files": [
         {
           "name": "ukr.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 3825102,
           "installPath": "tesseract/tessdata/ukr.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/ukr.traineddata",
           "sourcePath": "ukr.traineddata",
@@ -3778,7 +3778,7 @@
       "files": [
         {
           "name": "vie.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 531275,
           "installPath": "tesseract/tessdata/vie.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/vie.traineddata",
           "sourcePath": "vie.traineddata",
@@ -3796,7 +3796,7 @@
       "files": [
         {
           "name": "chi_sim.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2469156,
           "installPath": "tesseract/tessdata/chi_sim.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/chi_sim.traineddata",
           "sourcePath": "chi_sim.traineddata",
@@ -3814,7 +3814,7 @@
       "files": [
         {
           "name": "chi_tra.traineddata",
-          "sizeBytes": 0,
+          "sizeBytes": 2366642,
           "installPath": "tesseract/tessdata/chi_tra.traineddata",
           "url": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main/chi_tra.traineddata",
           "sourcePath": "chi_tra.traineddata",
@@ -3832,7 +3832,7 @@
       "files": [
         {
           "name": "mucab.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 6967556,
           "installPath": "bin/mucab.bin",
           "url": "https://offline-translator.davidv.dev/dictionaries/extra/mucab.bin",
           "sourcePath": "extra/mucab.bin",
@@ -3848,7 +3848,7 @@
       "files": [
         {
           "name": "model.aren.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23224456,
           "installPath": "bin/model.aren.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ar-en/retrain_base-memory_X9fDxFreTOCslPKzb1CXTg/exported/model.aren.intgemm.alphas.bin.gz",
           "sourcePath": "models/ar-en/retrain_base-memory_X9fDxFreTOCslPKzb1CXTg/exported/model.aren.intgemm.alphas.bin.gz",
@@ -3856,7 +3856,7 @@
         },
         {
           "name": "vocab.aren.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 416700,
           "installPath": "bin/vocab.aren.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ar-en/retrain_base-memory_X9fDxFreTOCslPKzb1CXTg/exported/vocab.aren.spm.gz",
           "sourcePath": "models/ar-en/retrain_base-memory_X9fDxFreTOCslPKzb1CXTg/exported/vocab.aren.spm.gz",
@@ -3864,7 +3864,7 @@
         },
         {
           "name": "lex.50.50.aren.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2259861,
           "installPath": "bin/lex.50.50.aren.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ar-en/retrain_base-memory_X9fDxFreTOCslPKzb1CXTg/exported/lex.50.50.aren.s2t.bin.gz",
           "sourcePath": "models/ar-en/retrain_base-memory_X9fDxFreTOCslPKzb1CXTg/exported/lex.50.50.aren.s2t.bin.gz",
@@ -3880,7 +3880,7 @@
       "files": [
         {
           "name": "model.azen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12740106,
           "installPath": "bin/model.azen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/az-en/h1-2025_Tm4nvtoLQnakAWSGhBZ-eA/exported/model.azen.intgemm.alphas.bin.gz",
           "sourcePath": "models/az-en/h1-2025_Tm4nvtoLQnakAWSGhBZ-eA/exported/model.azen.intgemm.alphas.bin.gz",
@@ -3888,7 +3888,7 @@
         },
         {
           "name": "vocab.azen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 418965,
           "installPath": "bin/vocab.azen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/az-en/h1-2025_Tm4nvtoLQnakAWSGhBZ-eA/exported/vocab.azen.spm.gz",
           "sourcePath": "models/az-en/h1-2025_Tm4nvtoLQnakAWSGhBZ-eA/exported/vocab.azen.spm.gz",
@@ -3896,7 +3896,7 @@
         },
         {
           "name": "lex.50.50.azen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2267101,
           "installPath": "bin/lex.50.50.azen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/az-en/h1-2025_Tm4nvtoLQnakAWSGhBZ-eA/exported/lex.50.50.azen.s2t.bin.gz",
           "sourcePath": "models/az-en/h1-2025_Tm4nvtoLQnakAWSGhBZ-eA/exported/lex.50.50.azen.s2t.bin.gz",
@@ -3912,7 +3912,7 @@
       "files": [
         {
           "name": "model.been.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12413897,
           "installPath": "bin/model.been.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/be-en/h1-2025_ARgOSPOSRVmOWTwFvRVOjA/exported/model.been.intgemm.alphas.bin.gz",
           "sourcePath": "models/be-en/h1-2025_ARgOSPOSRVmOWTwFvRVOjA/exported/model.been.intgemm.alphas.bin.gz",
@@ -3920,7 +3920,7 @@
         },
         {
           "name": "vocab.been.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 435364,
           "installPath": "bin/vocab.been.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/be-en/h1-2025_ARgOSPOSRVmOWTwFvRVOjA/exported/vocab.been.spm.gz",
           "sourcePath": "models/be-en/h1-2025_ARgOSPOSRVmOWTwFvRVOjA/exported/vocab.been.spm.gz",
@@ -3928,7 +3928,7 @@
         },
         {
           "name": "lex.50.50.been.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2197076,
           "installPath": "bin/lex.50.50.been.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/be-en/h1-2025_ARgOSPOSRVmOWTwFvRVOjA/exported/lex.50.50.been.s2t.bin.gz",
           "sourcePath": "models/be-en/h1-2025_ARgOSPOSRVmOWTwFvRVOjA/exported/lex.50.50.been.s2t.bin.gz",
@@ -3944,7 +3944,7 @@
       "files": [
         {
           "name": "model.bgen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22399269,
           "installPath": "bin/model.bgen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bg-en/retrain_hr_WvwHu4k6TgmJ2YTvL4Mu2g/exported/model.bgen.intgemm.alphas.bin.gz",
           "sourcePath": "models/bg-en/retrain_hr_WvwHu4k6TgmJ2YTvL4Mu2g/exported/model.bgen.intgemm.alphas.bin.gz",
@@ -3952,7 +3952,7 @@
         },
         {
           "name": "vocab.bgen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 434940,
           "installPath": "bin/vocab.bgen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bg-en/retrain_hr_WvwHu4k6TgmJ2YTvL4Mu2g/exported/vocab.bgen.spm.gz",
           "sourcePath": "models/bg-en/retrain_hr_WvwHu4k6TgmJ2YTvL4Mu2g/exported/vocab.bgen.spm.gz",
@@ -3960,7 +3960,7 @@
         },
         {
           "name": "lex.50.50.bgen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2187053,
           "installPath": "bin/lex.50.50.bgen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bg-en/retrain_hr_WvwHu4k6TgmJ2YTvL4Mu2g/exported/lex.50.50.bgen.s2t.bin.gz",
           "sourcePath": "models/bg-en/retrain_hr_WvwHu4k6TgmJ2YTvL4Mu2g/exported/lex.50.50.bgen.s2t.bin.gz",
@@ -3976,7 +3976,7 @@
       "files": [
         {
           "name": "model.bnen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12665857,
           "installPath": "bin/model.bnen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bn-en/h1-2025_XcpBlhA1SyOJCH2UzoIMyQ/exported/model.bnen.intgemm.alphas.bin.gz",
           "sourcePath": "models/bn-en/h1-2025_XcpBlhA1SyOJCH2UzoIMyQ/exported/model.bnen.intgemm.alphas.bin.gz",
@@ -3984,7 +3984,7 @@
         },
         {
           "name": "vocab.bnen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 437571,
           "installPath": "bin/vocab.bnen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bn-en/h1-2025_XcpBlhA1SyOJCH2UzoIMyQ/exported/vocab.bnen.spm.gz",
           "sourcePath": "models/bn-en/h1-2025_XcpBlhA1SyOJCH2UzoIMyQ/exported/vocab.bnen.spm.gz",
@@ -3992,7 +3992,7 @@
         },
         {
           "name": "lex.50.50.bnen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2264284,
           "installPath": "bin/lex.50.50.bnen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bn-en/h1-2025_XcpBlhA1SyOJCH2UzoIMyQ/exported/lex.50.50.bnen.s2t.bin.gz",
           "sourcePath": "models/bn-en/h1-2025_XcpBlhA1SyOJCH2UzoIMyQ/exported/lex.50.50.bnen.s2t.bin.gz",
@@ -4008,7 +4008,7 @@
       "files": [
         {
           "name": "model.bsen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13415215,
           "installPath": "bin/model.bsen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bs-en/spring-2024_ArlZLOUDTlqbe5WcnWGt_A/exported/model.bsen.intgemm.alphas.bin.gz",
           "sourcePath": "models/bs-en/spring-2024_ArlZLOUDTlqbe5WcnWGt_A/exported/model.bsen.intgemm.alphas.bin.gz",
@@ -4016,7 +4016,7 @@
         },
         {
           "name": "vocab.bsen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 396913,
           "installPath": "bin/vocab.bsen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bs-en/spring-2024_ArlZLOUDTlqbe5WcnWGt_A/exported/vocab.bsen.spm.gz",
           "sourcePath": "models/bs-en/spring-2024_ArlZLOUDTlqbe5WcnWGt_A/exported/vocab.bsen.spm.gz",
@@ -4024,7 +4024,7 @@
         },
         {
           "name": "lex.50.50.bsen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1426937,
           "installPath": "bin/lex.50.50.bsen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/bs-en/spring-2024_ArlZLOUDTlqbe5WcnWGt_A/exported/lex.50.50.bsen.s2t.bin.gz",
           "sourcePath": "models/bs-en/spring-2024_ArlZLOUDTlqbe5WcnWGt_A/exported/lex.50.50.bsen.s2t.bin.gz",
@@ -4040,7 +4040,7 @@
       "files": [
         {
           "name": "model.caen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22787743,
           "installPath": "bin/model.caen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ca-en/target-side-dedup_xxxxxxxxRxSxxxxxxxxxxA/exported/model.caen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ca-en/target-side-dedup_xxxxxxxxRxSxxxxxxxxxxA/exported/model.caen.intgemm.alphas.bin.gz",
@@ -4048,7 +4048,7 @@
         },
         {
           "name": "vocab.caen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409662,
           "installPath": "bin/vocab.caen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ca-en/target-side-dedup_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.caen.spm.gz",
           "sourcePath": "models/ca-en/target-side-dedup_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.caen.spm.gz",
@@ -4056,7 +4056,7 @@
         },
         {
           "name": "lex.50.50.caen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2257590,
           "installPath": "bin/lex.50.50.caen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ca-en/target-side-dedup_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.caen.s2t.bin.gz",
           "sourcePath": "models/ca-en/target-side-dedup_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.caen.s2t.bin.gz",
@@ -4072,7 +4072,7 @@
       "files": [
         {
           "name": "model.csen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22830296,
           "installPath": "bin/model.csen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/cs-en/retrain_hr_EwWhUov8TP6D_oolATvbUA/exported/model.csen.intgemm.alphas.bin.gz",
           "sourcePath": "models/cs-en/retrain_hr_EwWhUov8TP6D_oolATvbUA/exported/model.csen.intgemm.alphas.bin.gz",
@@ -4080,7 +4080,7 @@
         },
         {
           "name": "vocab.csen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 412691,
           "installPath": "bin/vocab.csen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/cs-en/retrain_hr_EwWhUov8TP6D_oolATvbUA/exported/vocab.csen.spm.gz",
           "sourcePath": "models/cs-en/retrain_hr_EwWhUov8TP6D_oolATvbUA/exported/vocab.csen.spm.gz",
@@ -4088,7 +4088,7 @@
         },
         {
           "name": "lex.50.50.csen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2493702,
           "installPath": "bin/lex.50.50.csen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/cs-en/retrain_hr_EwWhUov8TP6D_oolATvbUA/exported/lex.50.50.csen.s2t.bin.gz",
           "sourcePath": "models/cs-en/retrain_hr_EwWhUov8TP6D_oolATvbUA/exported/lex.50.50.csen.s2t.bin.gz",
@@ -4104,7 +4104,7 @@
       "files": [
         {
           "name": "model.daen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12525769,
           "installPath": "bin/model.daen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/da-en/spring-2024_U1vVpsWWT-K4L9pRfP1K1g/exported/model.daen.intgemm.alphas.bin.gz",
           "sourcePath": "models/da-en/spring-2024_U1vVpsWWT-K4L9pRfP1K1g/exported/model.daen.intgemm.alphas.bin.gz",
@@ -4112,7 +4112,7 @@
         },
         {
           "name": "vocab.daen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 399344,
           "installPath": "bin/vocab.daen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/da-en/spring-2024_U1vVpsWWT-K4L9pRfP1K1g/exported/vocab.daen.spm.gz",
           "sourcePath": "models/da-en/spring-2024_U1vVpsWWT-K4L9pRfP1K1g/exported/vocab.daen.spm.gz",
@@ -4120,7 +4120,7 @@
         },
         {
           "name": "lex.50.50.daen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2170970,
           "installPath": "bin/lex.50.50.daen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/da-en/spring-2024_U1vVpsWWT-K4L9pRfP1K1g/exported/lex.50.50.daen.s2t.bin.gz",
           "sourcePath": "models/da-en/spring-2024_U1vVpsWWT-K4L9pRfP1K1g/exported/lex.50.50.daen.s2t.bin.gz",
@@ -4136,7 +4136,7 @@
       "files": [
         {
           "name": "model.deen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22403755,
           "installPath": "bin/model.deen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/de-en/retrain_hr2_WZOW24i4QJmIib61LeHfwg/exported/model.deen.intgemm.alphas.bin.gz",
           "sourcePath": "models/de-en/retrain_hr2_WZOW24i4QJmIib61LeHfwg/exported/model.deen.intgemm.alphas.bin.gz",
@@ -4144,7 +4144,7 @@
         },
         {
           "name": "vocab.deen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 413879,
           "installPath": "bin/vocab.deen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/de-en/retrain_hr2_WZOW24i4QJmIib61LeHfwg/exported/vocab.deen.spm.gz",
           "sourcePath": "models/de-en/retrain_hr2_WZOW24i4QJmIib61LeHfwg/exported/vocab.deen.spm.gz",
@@ -4152,7 +4152,7 @@
         },
         {
           "name": "lex.50.50.deen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2626658,
           "installPath": "bin/lex.50.50.deen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/de-en/retrain_hr2_WZOW24i4QJmIib61LeHfwg/exported/lex.50.50.deen.s2t.bin.gz",
           "sourcePath": "models/de-en/retrain_hr2_WZOW24i4QJmIib61LeHfwg/exported/lex.50.50.deen.s2t.bin.gz",
@@ -4168,7 +4168,7 @@
       "files": [
         {
           "name": "model.elen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12696541,
           "installPath": "bin/model.elen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/el-en/spring-2024_RJucgx7LRMKB9E4oSSzdtA/exported/model.elen.intgemm.alphas.bin.gz",
           "sourcePath": "models/el-en/spring-2024_RJucgx7LRMKB9E4oSSzdtA/exported/model.elen.intgemm.alphas.bin.gz",
@@ -4176,7 +4176,7 @@
         },
         {
           "name": "vocab.elen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 419174,
           "installPath": "bin/vocab.elen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/el-en/spring-2024_RJucgx7LRMKB9E4oSSzdtA/exported/vocab.elen.spm.gz",
           "sourcePath": "models/el-en/spring-2024_RJucgx7LRMKB9E4oSSzdtA/exported/vocab.elen.spm.gz",
@@ -4184,7 +4184,7 @@
         },
         {
           "name": "lex.50.50.elen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1851246,
           "installPath": "bin/lex.50.50.elen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/el-en/spring-2024_RJucgx7LRMKB9E4oSSzdtA/exported/lex.50.50.elen.s2t.bin.gz",
           "sourcePath": "models/el-en/spring-2024_RJucgx7LRMKB9E4oSSzdtA/exported/lex.50.50.elen.s2t.bin.gz",
@@ -4200,7 +4200,7 @@
       "files": [
         {
           "name": "model.enar.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22857819,
           "installPath": "bin/model.enar.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ar/retrain_base-memory_G3CmhwG_TZext3cys-udHg/exported/model.enar.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ar/retrain_base-memory_G3CmhwG_TZext3cys-udHg/exported/model.enar.intgemm.alphas.bin.gz",
@@ -4208,7 +4208,7 @@
         },
         {
           "name": "vocab.enar.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 418930,
           "installPath": "bin/vocab.enar.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ar/retrain_base-memory_G3CmhwG_TZext3cys-udHg/exported/vocab.enar.spm.gz",
           "sourcePath": "models/en-ar/retrain_base-memory_G3CmhwG_TZext3cys-udHg/exported/vocab.enar.spm.gz",
@@ -4216,7 +4216,7 @@
         },
         {
           "name": "lex.50.50.enar.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1639219,
           "installPath": "bin/lex.50.50.enar.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ar/retrain_base-memory_G3CmhwG_TZext3cys-udHg/exported/lex.50.50.enar.s2t.bin.gz",
           "sourcePath": "models/en-ar/retrain_base-memory_G3CmhwG_TZext3cys-udHg/exported/lex.50.50.enar.s2t.bin.gz",
@@ -4232,7 +4232,7 @@
       "files": [
         {
           "name": "model.enaz.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13233108,
           "installPath": "bin/model.enaz.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-az/h1-2025_fu1HFuR0QY-zVBcKYQkJIA/exported/model.enaz.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-az/h1-2025_fu1HFuR0QY-zVBcKYQkJIA/exported/model.enaz.intgemm.alphas.bin.gz",
@@ -4240,7 +4240,7 @@
         },
         {
           "name": "vocab.enaz.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 418956,
           "installPath": "bin/vocab.enaz.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-az/h1-2025_fu1HFuR0QY-zVBcKYQkJIA/exported/vocab.enaz.spm.gz",
           "sourcePath": "models/en-az/h1-2025_fu1HFuR0QY-zVBcKYQkJIA/exported/vocab.enaz.spm.gz",
@@ -4248,7 +4248,7 @@
         },
         {
           "name": "lex.50.50.enaz.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1711544,
           "installPath": "bin/lex.50.50.enaz.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-az/h1-2025_fu1HFuR0QY-zVBcKYQkJIA/exported/lex.50.50.enaz.s2t.bin.gz",
           "sourcePath": "models/en-az/h1-2025_fu1HFuR0QY-zVBcKYQkJIA/exported/lex.50.50.enaz.s2t.bin.gz",
@@ -4264,7 +4264,7 @@
       "files": [
         {
           "name": "model.enbg.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23432015,
           "installPath": "bin/model.enbg.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bg/retrain_hr_eAF9fkYRScmBmvvfdT4XWw/exported/model.enbg.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-bg/retrain_hr_eAF9fkYRScmBmvvfdT4XWw/exported/model.enbg.intgemm.alphas.bin.gz",
@@ -4272,7 +4272,7 @@
         },
         {
           "name": "vocab.enbg.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 434940,
           "installPath": "bin/vocab.enbg.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bg/retrain_hr_eAF9fkYRScmBmvvfdT4XWw/exported/vocab.enbg.spm.gz",
           "sourcePath": "models/en-bg/retrain_hr_eAF9fkYRScmBmvvfdT4XWw/exported/vocab.enbg.spm.gz",
@@ -4280,7 +4280,7 @@
         },
         {
           "name": "lex.50.50.enbg.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1548577,
           "installPath": "bin/lex.50.50.enbg.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bg/retrain_hr_eAF9fkYRScmBmvvfdT4XWw/exported/lex.50.50.enbg.s2t.bin.gz",
           "sourcePath": "models/en-bg/retrain_hr_eAF9fkYRScmBmvvfdT4XWw/exported/lex.50.50.enbg.s2t.bin.gz",
@@ -4296,7 +4296,7 @@
       "files": [
         {
           "name": "model.enbn.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12821521,
           "installPath": "bin/model.enbn.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bn/h1-2025_TYlSskC_Sk6lBlfWRetXmg/exported/model.enbn.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-bn/h1-2025_TYlSskC_Sk6lBlfWRetXmg/exported/model.enbn.intgemm.alphas.bin.gz",
@@ -4304,7 +4304,7 @@
         },
         {
           "name": "vocab.enbn.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 437373,
           "installPath": "bin/vocab.enbn.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bn/h1-2025_TYlSskC_Sk6lBlfWRetXmg/exported/vocab.enbn.spm.gz",
           "sourcePath": "models/en-bn/h1-2025_TYlSskC_Sk6lBlfWRetXmg/exported/vocab.enbn.spm.gz",
@@ -4312,7 +4312,7 @@
         },
         {
           "name": "lex.50.50.enbn.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1607697,
           "installPath": "bin/lex.50.50.enbn.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bn/h1-2025_TYlSskC_Sk6lBlfWRetXmg/exported/lex.50.50.enbn.s2t.bin.gz",
           "sourcePath": "models/en-bn/h1-2025_TYlSskC_Sk6lBlfWRetXmg/exported/lex.50.50.enbn.s2t.bin.gz",
@@ -4328,7 +4328,7 @@
       "files": [
         {
           "name": "model.enbs.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22932779,
           "installPath": "bin/model.enbs.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bs/hbs-topk10_HBBkp2ozSYaY9f7WVGRtpA/exported/model.enbs.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-bs/hbs-topk10_HBBkp2ozSYaY9f7WVGRtpA/exported/model.enbs.intgemm.alphas.bin.gz",
@@ -4336,7 +4336,7 @@
         },
         {
           "name": "vocab.enbs.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 412204,
           "installPath": "bin/vocab.enbs.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bs/hbs-topk10_HBBkp2ozSYaY9f7WVGRtpA/exported/vocab.enbs.spm.gz",
           "sourcePath": "models/en-bs/hbs-topk10_HBBkp2ozSYaY9f7WVGRtpA/exported/vocab.enbs.spm.gz",
@@ -4344,7 +4344,7 @@
         },
         {
           "name": "lex.50.50.enbs.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1682912,
           "installPath": "bin/lex.50.50.enbs.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-bs/hbs-topk10_HBBkp2ozSYaY9f7WVGRtpA/exported/lex.50.50.enbs.s2t.bin.gz",
           "sourcePath": "models/en-bs/hbs-topk10_HBBkp2ozSYaY9f7WVGRtpA/exported/lex.50.50.enbs.s2t.bin.gz",
@@ -4360,7 +4360,7 @@
       "files": [
         {
           "name": "model.enca.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23174479,
           "installPath": "bin/model.enca.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ca/short-sentences_dqpjVFEaT2WLVB2nV0_H2g/exported/model.enca.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ca/short-sentences_dqpjVFEaT2WLVB2nV0_H2g/exported/model.enca.intgemm.alphas.bin.gz",
@@ -4368,7 +4368,7 @@
         },
         {
           "name": "vocab.enca.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409866,
           "installPath": "bin/vocab.enca.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ca/short-sentences_dqpjVFEaT2WLVB2nV0_H2g/exported/vocab.enca.spm.gz",
           "sourcePath": "models/en-ca/short-sentences_dqpjVFEaT2WLVB2nV0_H2g/exported/vocab.enca.spm.gz",
@@ -4376,7 +4376,7 @@
         },
         {
           "name": "lex.50.50.enca.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2085904,
           "installPath": "bin/lex.50.50.enca.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ca/short-sentences_dqpjVFEaT2WLVB2nV0_H2g/exported/lex.50.50.enca.s2t.bin.gz",
           "sourcePath": "models/en-ca/short-sentences_dqpjVFEaT2WLVB2nV0_H2g/exported/lex.50.50.enca.s2t.bin.gz",
@@ -4392,7 +4392,7 @@
       "files": [
         {
           "name": "model.encs.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23192301,
           "installPath": "bin/model.encs.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-cs/retrain_hr_F_JF0vqvSjSwn3caQQcicA/exported/model.encs.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-cs/retrain_hr_F_JF0vqvSjSwn3caQQcicA/exported/model.encs.intgemm.alphas.bin.gz",
@@ -4400,7 +4400,7 @@
         },
         {
           "name": "vocab.encs.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 412691,
           "installPath": "bin/vocab.encs.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-cs/retrain_hr_F_JF0vqvSjSwn3caQQcicA/exported/vocab.encs.spm.gz",
           "sourcePath": "models/en-cs/retrain_hr_F_JF0vqvSjSwn3caQQcicA/exported/vocab.encs.spm.gz",
@@ -4408,7 +4408,7 @@
         },
         {
           "name": "lex.50.50.encs.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1896925,
           "installPath": "bin/lex.50.50.encs.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-cs/retrain_hr_F_JF0vqvSjSwn3caQQcicA/exported/lex.50.50.encs.s2t.bin.gz",
           "sourcePath": "models/en-cs/retrain_hr_F_JF0vqvSjSwn3caQQcicA/exported/lex.50.50.encs.s2t.bin.gz",
@@ -4424,7 +4424,7 @@
       "files": [
         {
           "name": "model.enda.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12723889,
           "installPath": "bin/model.enda.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-da/spring-2024_XUm0Ij8WSfabkKeKA_Xv_g/exported/model.enda.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-da/spring-2024_XUm0Ij8WSfabkKeKA_Xv_g/exported/model.enda.intgemm.alphas.bin.gz",
@@ -4432,7 +4432,7 @@
         },
         {
           "name": "vocab.enda.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 398818,
           "installPath": "bin/vocab.enda.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-da/spring-2024_XUm0Ij8WSfabkKeKA_Xv_g/exported/vocab.enda.spm.gz",
           "sourcePath": "models/en-da/spring-2024_XUm0Ij8WSfabkKeKA_Xv_g/exported/vocab.enda.spm.gz",
@@ -4440,7 +4440,7 @@
         },
         {
           "name": "lex.50.50.enda.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1582768,
           "installPath": "bin/lex.50.50.enda.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-da/spring-2024_XUm0Ij8WSfabkKeKA_Xv_g/exported/lex.50.50.enda.s2t.bin.gz",
           "sourcePath": "models/en-da/spring-2024_XUm0Ij8WSfabkKeKA_Xv_g/exported/lex.50.50.enda.s2t.bin.gz",
@@ -4456,7 +4456,7 @@
       "files": [
         {
           "name": "model.ende.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22992073,
           "installPath": "bin/model.ende.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-de/retrain_hr_fix_names_SCgGhxUPQ2WAECHLRtzrMg/exported/model.ende.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-de/retrain_hr_fix_names_SCgGhxUPQ2WAECHLRtzrMg/exported/model.ende.intgemm.alphas.bin.gz",
@@ -4464,7 +4464,7 @@
         },
         {
           "name": "vocab.ende.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 413879,
           "installPath": "bin/vocab.ende.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-de/retrain_hr_fix_names_SCgGhxUPQ2WAECHLRtzrMg/exported/vocab.ende.spm.gz",
           "sourcePath": "models/en-de/retrain_hr_fix_names_SCgGhxUPQ2WAECHLRtzrMg/exported/vocab.ende.spm.gz",
@@ -4472,7 +4472,7 @@
         },
         {
           "name": "lex.50.50.ende.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2314750,
           "installPath": "bin/lex.50.50.ende.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-de/retrain_hr_fix_names_SCgGhxUPQ2WAECHLRtzrMg/exported/lex.50.50.ende.s2t.bin.gz",
           "sourcePath": "models/en-de/retrain_hr_fix_names_SCgGhxUPQ2WAECHLRtzrMg/exported/lex.50.50.ende.s2t.bin.gz",
@@ -4488,7 +4488,7 @@
       "files": [
         {
           "name": "model.enel.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12808027,
           "installPath": "bin/model.enel.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-el/spring-2024_Y3ThG3XkTxG4ROUQK2LpVg/exported/model.enel.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-el/spring-2024_Y3ThG3XkTxG4ROUQK2LpVg/exported/model.enel.intgemm.alphas.bin.gz",
@@ -4496,7 +4496,7 @@
         },
         {
           "name": "vocab.enel.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 419275,
           "installPath": "bin/vocab.enel.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-el/spring-2024_Y3ThG3XkTxG4ROUQK2LpVg/exported/vocab.enel.spm.gz",
           "sourcePath": "models/en-el/spring-2024_Y3ThG3XkTxG4ROUQK2LpVg/exported/vocab.enel.spm.gz",
@@ -4504,7 +4504,7 @@
         },
         {
           "name": "lex.50.50.enel.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1352643,
           "installPath": "bin/lex.50.50.enel.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-el/spring-2024_Y3ThG3XkTxG4ROUQK2LpVg/exported/lex.50.50.enel.s2t.bin.gz",
           "sourcePath": "models/en-el/spring-2024_Y3ThG3XkTxG4ROUQK2LpVg/exported/lex.50.50.enel.s2t.bin.gz",
@@ -4520,7 +4520,7 @@
       "files": [
         {
           "name": "model.enes.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22698792,
           "installPath": "bin/model.enes.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-es/retrain_hr_fix_names_CUAEXUHoQum_cFqh-ZAryw/exported/model.enes.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-es/retrain_hr_fix_names_CUAEXUHoQum_cFqh-ZAryw/exported/model.enes.intgemm.alphas.bin.gz",
@@ -4528,7 +4528,7 @@
         },
         {
           "name": "vocab.enes.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409312,
           "installPath": "bin/vocab.enes.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-es/retrain_hr_fix_names_CUAEXUHoQum_cFqh-ZAryw/exported/vocab.enes.spm.gz",
           "sourcePath": "models/en-es/retrain_hr_fix_names_CUAEXUHoQum_cFqh-ZAryw/exported/vocab.enes.spm.gz",
@@ -4536,7 +4536,7 @@
         },
         {
           "name": "lex.50.50.enes.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2265250,
           "installPath": "bin/lex.50.50.enes.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-es/retrain_hr_fix_names_CUAEXUHoQum_cFqh-ZAryw/exported/lex.50.50.enes.s2t.bin.gz",
           "sourcePath": "models/en-es/retrain_hr_fix_names_CUAEXUHoQum_cFqh-ZAryw/exported/lex.50.50.enes.s2t.bin.gz",
@@ -4552,7 +4552,7 @@
       "files": [
         {
           "name": "model.enet.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22951751,
           "installPath": "bin/model.enet.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-et/retrain_hr_GubU3EaMRY2VkR8p1dPUNw/exported/model.enet.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-et/retrain_hr_GubU3EaMRY2VkR8p1dPUNw/exported/model.enet.intgemm.alphas.bin.gz",
@@ -4560,7 +4560,7 @@
         },
         {
           "name": "vocab.enet.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 414262,
           "installPath": "bin/vocab.enet.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-et/retrain_hr_GubU3EaMRY2VkR8p1dPUNw/exported/vocab.enet.spm.gz",
           "sourcePath": "models/en-et/retrain_hr_GubU3EaMRY2VkR8p1dPUNw/exported/vocab.enet.spm.gz",
@@ -4568,7 +4568,7 @@
         },
         {
           "name": "lex.50.50.enet.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1865410,
           "installPath": "bin/lex.50.50.enet.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-et/retrain_hr_GubU3EaMRY2VkR8p1dPUNw/exported/lex.50.50.enet.s2t.bin.gz",
           "sourcePath": "models/en-et/retrain_hr_GubU3EaMRY2VkR8p1dPUNw/exported/lex.50.50.enet.s2t.bin.gz",
@@ -4584,7 +4584,7 @@
       "files": [
         {
           "name": "model.enfa.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13058508,
           "installPath": "bin/model.enfa.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fa/h1-2025_c_TYU1BOTByxOnnkAunO7g/exported/model.enfa.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-fa/h1-2025_c_TYU1BOTByxOnnkAunO7g/exported/model.enfa.intgemm.alphas.bin.gz",
@@ -4592,7 +4592,7 @@
         },
         {
           "name": "vocab.enfa.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 416223,
           "installPath": "bin/vocab.enfa.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fa/h1-2025_c_TYU1BOTByxOnnkAunO7g/exported/vocab.enfa.spm.gz",
           "sourcePath": "models/en-fa/h1-2025_c_TYU1BOTByxOnnkAunO7g/exported/vocab.enfa.spm.gz",
@@ -4600,7 +4600,7 @@
         },
         {
           "name": "lex.50.50.enfa.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1728367,
           "installPath": "bin/lex.50.50.enfa.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fa/h1-2025_c_TYU1BOTByxOnnkAunO7g/exported/lex.50.50.enfa.s2t.bin.gz",
           "sourcePath": "models/en-fa/h1-2025_c_TYU1BOTByxOnnkAunO7g/exported/lex.50.50.enfa.s2t.bin.gz",
@@ -4616,7 +4616,7 @@
       "files": [
         {
           "name": "model.enfi.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22580027,
           "installPath": "bin/model.enfi.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fi/retrain_hr_b45LsGaNQFyDRhHAvBbKrA/exported/model.enfi.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-fi/retrain_hr_b45LsGaNQFyDRhHAvBbKrA/exported/model.enfi.intgemm.alphas.bin.gz",
@@ -4624,7 +4624,7 @@
         },
         {
           "name": "vocab.enfi.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 414280,
           "installPath": "bin/vocab.enfi.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fi/retrain_hr_b45LsGaNQFyDRhHAvBbKrA/exported/vocab.enfi.spm.gz",
           "sourcePath": "models/en-fi/retrain_hr_b45LsGaNQFyDRhHAvBbKrA/exported/vocab.enfi.spm.gz",
@@ -4632,7 +4632,7 @@
         },
         {
           "name": "lex.50.50.enfi.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1875557,
           "installPath": "bin/lex.50.50.enfi.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fi/retrain_hr_b45LsGaNQFyDRhHAvBbKrA/exported/lex.50.50.enfi.s2t.bin.gz",
           "sourcePath": "models/en-fi/retrain_hr_b45LsGaNQFyDRhHAvBbKrA/exported/lex.50.50.enfi.s2t.bin.gz",
@@ -4648,7 +4648,7 @@
       "files": [
         {
           "name": "model.enfr.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23045432,
           "installPath": "bin/model.enfr.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fr/retrain_hr_NLIxDbE1TBGyOTI-zwZagw/exported/model.enfr.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-fr/retrain_hr_NLIxDbE1TBGyOTI-zwZagw/exported/model.enfr.intgemm.alphas.bin.gz",
@@ -4656,7 +4656,7 @@
         },
         {
           "name": "vocab.enfr.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409706,
           "installPath": "bin/vocab.enfr.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fr/retrain_hr_NLIxDbE1TBGyOTI-zwZagw/exported/vocab.enfr.spm.gz",
           "sourcePath": "models/en-fr/retrain_hr_NLIxDbE1TBGyOTI-zwZagw/exported/vocab.enfr.spm.gz",
@@ -4664,7 +4664,7 @@
         },
         {
           "name": "lex.50.50.enfr.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2297334,
           "installPath": "bin/lex.50.50.enfr.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-fr/retrain_hr_NLIxDbE1TBGyOTI-zwZagw/exported/lex.50.50.enfr.s2t.bin.gz",
           "sourcePath": "models/en-fr/retrain_hr_NLIxDbE1TBGyOTI-zwZagw/exported/lex.50.50.enfr.s2t.bin.gz",
@@ -4680,7 +4680,7 @@
       "files": [
         {
           "name": "model.engu.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12657911,
           "installPath": "bin/model.engu.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-gu/h1-2025_Na2-WpCIR1Sdy17l-XDeLA/exported/model.engu.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-gu/h1-2025_Na2-WpCIR1Sdy17l-XDeLA/exported/model.engu.intgemm.alphas.bin.gz",
@@ -4688,7 +4688,7 @@
         },
         {
           "name": "vocab.engu.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 434881,
           "installPath": "bin/vocab.engu.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-gu/h1-2025_Na2-WpCIR1Sdy17l-XDeLA/exported/vocab.engu.spm.gz",
           "sourcePath": "models/en-gu/h1-2025_Na2-WpCIR1Sdy17l-XDeLA/exported/vocab.engu.spm.gz",
@@ -4696,7 +4696,7 @@
         },
         {
           "name": "lex.50.50.engu.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1529098,
           "installPath": "bin/lex.50.50.engu.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-gu/h1-2025_Na2-WpCIR1Sdy17l-XDeLA/exported/lex.50.50.engu.s2t.bin.gz",
           "sourcePath": "models/en-gu/h1-2025_Na2-WpCIR1Sdy17l-XDeLA/exported/lex.50.50.engu.s2t.bin.gz",
@@ -4712,7 +4712,7 @@
       "files": [
         {
           "name": "model.enhe.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12979964,
           "installPath": "bin/model.enhe.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-he/h1-2025_QtanzRiDRISacRVw4WzWYQ/exported/model.enhe.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-he/h1-2025_QtanzRiDRISacRVw4WzWYQ/exported/model.enhe.intgemm.alphas.bin.gz",
@@ -4720,7 +4720,7 @@
         },
         {
           "name": "vocab.enhe.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 411686,
           "installPath": "bin/vocab.enhe.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-he/h1-2025_QtanzRiDRISacRVw4WzWYQ/exported/vocab.enhe.spm.gz",
           "sourcePath": "models/en-he/h1-2025_QtanzRiDRISacRVw4WzWYQ/exported/vocab.enhe.spm.gz",
@@ -4728,7 +4728,7 @@
         },
         {
           "name": "lex.50.50.enhe.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1567190,
           "installPath": "bin/lex.50.50.enhe.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-he/h1-2025_QtanzRiDRISacRVw4WzWYQ/exported/lex.50.50.enhe.s2t.bin.gz",
           "sourcePath": "models/en-he/h1-2025_QtanzRiDRISacRVw4WzWYQ/exported/lex.50.50.enhe.s2t.bin.gz",
@@ -4744,7 +4744,7 @@
       "files": [
         {
           "name": "model.enhi.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12736263,
           "installPath": "bin/model.enhi.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hi/h1-2025_KoJuCNf_Q42R2Bz6j2jlOQ/exported/model.enhi.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-hi/h1-2025_KoJuCNf_Q42R2Bz6j2jlOQ/exported/model.enhi.intgemm.alphas.bin.gz",
@@ -4752,7 +4752,7 @@
         },
         {
           "name": "vocab.enhi.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 430026,
           "installPath": "bin/vocab.enhi.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hi/h1-2025_KoJuCNf_Q42R2Bz6j2jlOQ/exported/vocab.enhi.spm.gz",
           "sourcePath": "models/en-hi/h1-2025_KoJuCNf_Q42R2Bz6j2jlOQ/exported/vocab.enhi.spm.gz",
@@ -4760,7 +4760,7 @@
         },
         {
           "name": "lex.50.50.enhi.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1690062,
           "installPath": "bin/lex.50.50.enhi.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hi/h1-2025_KoJuCNf_Q42R2Bz6j2jlOQ/exported/lex.50.50.enhi.s2t.bin.gz",
           "sourcePath": "models/en-hi/h1-2025_KoJuCNf_Q42R2Bz6j2jlOQ/exported/lex.50.50.enhi.s2t.bin.gz",
@@ -4776,7 +4776,7 @@
       "files": [
         {
           "name": "model.enhr.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22758240,
           "installPath": "bin/model.enhr.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hr/hbs-topk10_PLHJ-5OxSNyWlwZM12Kghw/exported/model.enhr.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-hr/hbs-topk10_PLHJ-5OxSNyWlwZM12Kghw/exported/model.enhr.intgemm.alphas.bin.gz",
@@ -4784,7 +4784,7 @@
         },
         {
           "name": "vocab.enhr.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 410897,
           "installPath": "bin/vocab.enhr.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hr/hbs-topk10_PLHJ-5OxSNyWlwZM12Kghw/exported/vocab.enhr.spm.gz",
           "sourcePath": "models/en-hr/hbs-topk10_PLHJ-5OxSNyWlwZM12Kghw/exported/vocab.enhr.spm.gz",
@@ -4792,7 +4792,7 @@
         },
         {
           "name": "lex.50.50.enhr.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1713561,
           "installPath": "bin/lex.50.50.enhr.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hr/hbs-topk10_PLHJ-5OxSNyWlwZM12Kghw/exported/lex.50.50.enhr.s2t.bin.gz",
           "sourcePath": "models/en-hr/hbs-topk10_PLHJ-5OxSNyWlwZM12Kghw/exported/lex.50.50.enhr.s2t.bin.gz",
@@ -4808,7 +4808,7 @@
       "files": [
         {
           "name": "model.enhu.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23710206,
           "installPath": "bin/model.enhu.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hu/h1-2025_J8_9zNmQT2GfHg7_heOI_Q/exported/model.enhu.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-hu/h1-2025_J8_9zNmQT2GfHg7_heOI_Q/exported/model.enhu.intgemm.alphas.bin.gz",
@@ -4816,7 +4816,7 @@
         },
         {
           "name": "vocab.enhu.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 405720,
           "installPath": "bin/vocab.enhu.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hu/h1-2025_J8_9zNmQT2GfHg7_heOI_Q/exported/vocab.enhu.spm.gz",
           "sourcePath": "models/en-hu/h1-2025_J8_9zNmQT2GfHg7_heOI_Q/exported/vocab.enhu.spm.gz",
@@ -4824,7 +4824,7 @@
         },
         {
           "name": "lex.50.50.enhu.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1768398,
           "installPath": "bin/lex.50.50.enhu.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-hu/h1-2025_J8_9zNmQT2GfHg7_heOI_Q/exported/lex.50.50.enhu.s2t.bin.gz",
           "sourcePath": "models/en-hu/h1-2025_J8_9zNmQT2GfHg7_heOI_Q/exported/lex.50.50.enhu.s2t.bin.gz",
@@ -4840,7 +4840,7 @@
       "files": [
         {
           "name": "model.enid.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12503257,
           "installPath": "bin/model.enid.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-id/spring-2024_bbjDBFoDTNGSUo2if3ET_A/exported/model.enid.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-id/spring-2024_bbjDBFoDTNGSUo2if3ET_A/exported/model.enid.intgemm.alphas.bin.gz",
@@ -4848,7 +4848,7 @@
         },
         {
           "name": "vocab.enid.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 379806,
           "installPath": "bin/vocab.enid.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-id/spring-2024_bbjDBFoDTNGSUo2if3ET_A/exported/vocab.enid.spm.gz",
           "sourcePath": "models/en-id/spring-2024_bbjDBFoDTNGSUo2if3ET_A/exported/vocab.enid.spm.gz",
@@ -4856,7 +4856,7 @@
         },
         {
           "name": "lex.50.50.enid.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1734565,
           "installPath": "bin/lex.50.50.enid.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-id/spring-2024_bbjDBFoDTNGSUo2if3ET_A/exported/lex.50.50.enid.s2t.bin.gz",
           "sourcePath": "models/en-id/spring-2024_bbjDBFoDTNGSUo2if3ET_A/exported/lex.50.50.enid.s2t.bin.gz",
@@ -4872,7 +4872,7 @@
       "files": [
         {
           "name": "model.enis.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22588003,
           "installPath": "bin/model.enis.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-is/docmt-vocab_EkZBaZqDS5Cce_lC2BpxlA/exported/model.enis.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-is/docmt-vocab_EkZBaZqDS5Cce_lC2BpxlA/exported/model.enis.intgemm.alphas.bin.gz",
@@ -4880,7 +4880,7 @@
         },
         {
           "name": "vocab.enis.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 413543,
           "installPath": "bin/vocab.enis.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-is/docmt-vocab_EkZBaZqDS5Cce_lC2BpxlA/exported/vocab.enis.spm.gz",
           "sourcePath": "models/en-is/docmt-vocab_EkZBaZqDS5Cce_lC2BpxlA/exported/vocab.enis.spm.gz",
@@ -4888,7 +4888,7 @@
         },
         {
           "name": "lex.50.50.enis.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1977789,
           "installPath": "bin/lex.50.50.enis.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-is/docmt-vocab_EkZBaZqDS5Cce_lC2BpxlA/exported/lex.50.50.enis.s2t.bin.gz",
           "sourcePath": "models/en-is/docmt-vocab_EkZBaZqDS5Cce_lC2BpxlA/exported/lex.50.50.enis.s2t.bin.gz",
@@ -4904,7 +4904,7 @@
       "files": [
         {
           "name": "model.enit.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23892889,
           "installPath": "bin/model.enit.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-it/retrain_hr_fix_names_GPSr_u8PSmC9fOx1ZDCHoA/exported/model.enit.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-it/retrain_hr_fix_names_GPSr_u8PSmC9fOx1ZDCHoA/exported/model.enit.intgemm.alphas.bin.gz",
@@ -4912,7 +4912,7 @@
         },
         {
           "name": "vocab.enit.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 407598,
           "installPath": "bin/vocab.enit.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-it/retrain_hr_fix_names_GPSr_u8PSmC9fOx1ZDCHoA/exported/vocab.enit.spm.gz",
           "sourcePath": "models/en-it/retrain_hr_fix_names_GPSr_u8PSmC9fOx1ZDCHoA/exported/vocab.enit.spm.gz",
@@ -4920,7 +4920,7 @@
         },
         {
           "name": "lex.50.50.enit.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2209348,
           "installPath": "bin/lex.50.50.enit.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-it/retrain_hr_fix_names_GPSr_u8PSmC9fOx1ZDCHoA/exported/lex.50.50.enit.s2t.bin.gz",
           "sourcePath": "models/en-it/retrain_hr_fix_names_GPSr_u8PSmC9fOx1ZDCHoA/exported/lex.50.50.enit.s2t.bin.gz",
@@ -4936,7 +4936,7 @@
       "files": [
         {
           "name": "model.enja.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 33052218,
           "installPath": "bin/model.enja.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/model.enja.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/model.enja.intgemm.alphas.bin.gz",
@@ -4944,7 +4944,7 @@
         },
         {
           "name": "srcvocab.enja.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 404352,
           "installPath": "bin/srcvocab.enja.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/srcvocab.enja.spm.gz",
           "sourcePath": "models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/srcvocab.enja.spm.gz",
@@ -4952,7 +4952,7 @@
         },
         {
           "name": "trgvocab.enja.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 431278,
           "installPath": "bin/trgvocab.enja.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/trgvocab.enja.spm.gz",
           "sourcePath": "models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/trgvocab.enja.spm.gz",
@@ -4960,7 +4960,7 @@
         },
         {
           "name": "lex.50.50.enja.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2341409,
           "installPath": "bin/lex.50.50.enja.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/lex.50.50.enja.s2t.bin.gz",
           "sourcePath": "models/en-ja/llmaat_finetune10M_qe8_f2_ApiGGQIwTKuF9i_k3n9Q2Q/exported/lex.50.50.enja.s2t.bin.gz",
@@ -4976,7 +4976,7 @@
       "files": [
         {
           "name": "model.enkn.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13009213,
           "installPath": "bin/model.enkn.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-kn/h1-2025_DDVsjRwsQ8GL3-JAiAmmfQ/exported/model.enkn.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-kn/h1-2025_DDVsjRwsQ8GL3-JAiAmmfQ/exported/model.enkn.intgemm.alphas.bin.gz",
@@ -4984,7 +4984,7 @@
         },
         {
           "name": "vocab.enkn.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 450046,
           "installPath": "bin/vocab.enkn.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-kn/h1-2025_DDVsjRwsQ8GL3-JAiAmmfQ/exported/vocab.enkn.spm.gz",
           "sourcePath": "models/en-kn/h1-2025_DDVsjRwsQ8GL3-JAiAmmfQ/exported/vocab.enkn.spm.gz",
@@ -4992,7 +4992,7 @@
         },
         {
           "name": "lex.50.50.enkn.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1416160,
           "installPath": "bin/lex.50.50.enkn.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-kn/h1-2025_DDVsjRwsQ8GL3-JAiAmmfQ/exported/lex.50.50.enkn.s2t.bin.gz",
           "sourcePath": "models/en-kn/h1-2025_DDVsjRwsQ8GL3-JAiAmmfQ/exported/lex.50.50.enkn.s2t.bin.gz",
@@ -5008,7 +5008,7 @@
       "files": [
         {
           "name": "model.enko.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 33738001,
           "installPath": "bin/model.enko.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/model.enko.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/model.enko.intgemm.alphas.bin.gz",
@@ -5016,7 +5016,7 @@
         },
         {
           "name": "srcvocab.enko.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 402480,
           "installPath": "bin/srcvocab.enko.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/srcvocab.enko.spm.gz",
           "sourcePath": "models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/srcvocab.enko.spm.gz",
@@ -5024,7 +5024,7 @@
         },
         {
           "name": "trgvocab.enko.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 412614,
           "installPath": "bin/trgvocab.enko.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/trgvocab.enko.spm.gz",
           "sourcePath": "models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/trgvocab.enko.spm.gz",
@@ -5032,7 +5032,7 @@
         },
         {
           "name": "lex.50.50.enko.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 3471311,
           "installPath": "bin/lex.50.50.enko.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/lex.50.50.enko.s2t.bin.gz",
           "sourcePath": "models/en-ko/cjk_retrain_base-memory_GP50C3MpQ9apCWZOW-f3PA/exported/lex.50.50.enko.s2t.bin.gz",
@@ -5048,7 +5048,7 @@
       "files": [
         {
           "name": "model.enlt.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22865642,
           "installPath": "bin/model.enlt.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-lt/h1-2025_CpawQ31iTrmnax9Xi0DkBw/exported/model.enlt.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-lt/h1-2025_CpawQ31iTrmnax9Xi0DkBw/exported/model.enlt.intgemm.alphas.bin.gz",
@@ -5056,7 +5056,7 @@
         },
         {
           "name": "vocab.enlt.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 403356,
           "installPath": "bin/vocab.enlt.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-lt/h1-2025_CpawQ31iTrmnax9Xi0DkBw/exported/vocab.enlt.spm.gz",
           "sourcePath": "models/en-lt/h1-2025_CpawQ31iTrmnax9Xi0DkBw/exported/vocab.enlt.spm.gz",
@@ -5064,7 +5064,7 @@
         },
         {
           "name": "lex.50.50.enlt.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1769752,
           "installPath": "bin/lex.50.50.enlt.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-lt/h1-2025_CpawQ31iTrmnax9Xi0DkBw/exported/lex.50.50.enlt.s2t.bin.gz",
           "sourcePath": "models/en-lt/h1-2025_CpawQ31iTrmnax9Xi0DkBw/exported/lex.50.50.enlt.s2t.bin.gz",
@@ -5080,7 +5080,7 @@
       "files": [
         {
           "name": "model.enlv.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23727668,
           "installPath": "bin/model.enlv.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-lv/h1-2025_L9sajlF2TCKfEzDro4tK3Q/exported/model.enlv.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-lv/h1-2025_L9sajlF2TCKfEzDro4tK3Q/exported/model.enlv.intgemm.alphas.bin.gz",
@@ -5088,7 +5088,7 @@
         },
         {
           "name": "vocab.enlv.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 407540,
           "installPath": "bin/vocab.enlv.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-lv/h1-2025_L9sajlF2TCKfEzDro4tK3Q/exported/vocab.enlv.spm.gz",
           "sourcePath": "models/en-lv/h1-2025_L9sajlF2TCKfEzDro4tK3Q/exported/vocab.enlv.spm.gz",
@@ -5096,7 +5096,7 @@
         },
         {
           "name": "lex.50.50.enlv.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1725879,
           "installPath": "bin/lex.50.50.enlv.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-lv/h1-2025_L9sajlF2TCKfEzDro4tK3Q/exported/lex.50.50.enlv.s2t.bin.gz",
           "sourcePath": "models/en-lv/h1-2025_L9sajlF2TCKfEzDro4tK3Q/exported/lex.50.50.enlv.s2t.bin.gz",
@@ -5112,7 +5112,7 @@
       "files": [
         {
           "name": "model.enml.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12570038,
           "installPath": "bin/model.enml.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ml/h1-2025_UylcthuMRoelqd6lsCbXJw/exported/model.enml.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ml/h1-2025_UylcthuMRoelqd6lsCbXJw/exported/model.enml.intgemm.alphas.bin.gz",
@@ -5120,7 +5120,7 @@
         },
         {
           "name": "vocab.enml.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 454768,
           "installPath": "bin/vocab.enml.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ml/h1-2025_UylcthuMRoelqd6lsCbXJw/exported/vocab.enml.spm.gz",
           "sourcePath": "models/en-ml/h1-2025_UylcthuMRoelqd6lsCbXJw/exported/vocab.enml.spm.gz",
@@ -5128,7 +5128,7 @@
         },
         {
           "name": "lex.50.50.enml.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1275347,
           "installPath": "bin/lex.50.50.enml.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ml/h1-2025_UylcthuMRoelqd6lsCbXJw/exported/lex.50.50.enml.s2t.bin.gz",
           "sourcePath": "models/en-ml/h1-2025_UylcthuMRoelqd6lsCbXJw/exported/lex.50.50.enml.s2t.bin.gz",
@@ -5144,7 +5144,7 @@
       "files": [
         {
           "name": "model.enms.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13039668,
           "installPath": "bin/model.enms.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ms/h1-2025_Ba76abX1Qtums6Vbv95tzg/exported/model.enms.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ms/h1-2025_Ba76abX1Qtums6Vbv95tzg/exported/model.enms.intgemm.alphas.bin.gz",
@@ -5152,7 +5152,7 @@
         },
         {
           "name": "vocab.enms.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 404033,
           "installPath": "bin/vocab.enms.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ms/h1-2025_Ba76abX1Qtums6Vbv95tzg/exported/vocab.enms.spm.gz",
           "sourcePath": "models/en-ms/h1-2025_Ba76abX1Qtums6Vbv95tzg/exported/vocab.enms.spm.gz",
@@ -5160,7 +5160,7 @@
         },
         {
           "name": "lex.50.50.enms.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2044118,
           "installPath": "bin/lex.50.50.enms.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ms/h1-2025_Ba76abX1Qtums6Vbv95tzg/exported/lex.50.50.enms.s2t.bin.gz",
           "sourcePath": "models/en-ms/h1-2025_Ba76abX1Qtums6Vbv95tzg/exported/lex.50.50.enms.s2t.bin.gz",
@@ -5176,7 +5176,7 @@
       "files": [
         {
           "name": "model.ennb.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12713727,
           "installPath": "bin/model.ennb.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-nb/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/model.ennb.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-nb/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/model.ennb.intgemm.alphas.bin.gz",
@@ -5184,7 +5184,7 @@
         },
         {
           "name": "vocab.ennb.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409037,
           "installPath": "bin/vocab.ennb.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-nb/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/vocab.ennb.spm.gz",
           "sourcePath": "models/en-nb/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/vocab.ennb.spm.gz",
@@ -5192,7 +5192,7 @@
         },
         {
           "name": "lex.50.50.ennb.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2193397,
           "installPath": "bin/lex.50.50.ennb.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-nb/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/lex.50.50.ennb.s2t.bin.gz",
           "sourcePath": "models/en-nb/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/lex.50.50.ennb.s2t.bin.gz",
@@ -5208,7 +5208,7 @@
       "files": [
         {
           "name": "model.ennl.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23386633,
           "installPath": "bin/model.ennl.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-nl/retrain_hr_fix_names_fR8XhBiBQniIbi4I_ebJ2Q/exported/model.ennl.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-nl/retrain_hr_fix_names_fR8XhBiBQniIbi4I_ebJ2Q/exported/model.ennl.intgemm.alphas.bin.gz",
@@ -5216,7 +5216,7 @@
         },
         {
           "name": "vocab.ennl.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 410222,
           "installPath": "bin/vocab.ennl.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-nl/retrain_hr_fix_names_fR8XhBiBQniIbi4I_ebJ2Q/exported/vocab.ennl.spm.gz",
           "sourcePath": "models/en-nl/retrain_hr_fix_names_fR8XhBiBQniIbi4I_ebJ2Q/exported/vocab.ennl.spm.gz",
@@ -5224,7 +5224,7 @@
         },
         {
           "name": "lex.50.50.ennl.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2155034,
           "installPath": "bin/lex.50.50.ennl.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-nl/retrain_hr_fix_names_fR8XhBiBQniIbi4I_ebJ2Q/exported/lex.50.50.ennl.s2t.bin.gz",
           "sourcePath": "models/en-nl/retrain_hr_fix_names_fR8XhBiBQniIbi4I_ebJ2Q/exported/lex.50.50.ennl.s2t.bin.gz",
@@ -5240,7 +5240,7 @@
       "files": [
         {
           "name": "model.enno.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12713727,
           "installPath": "bin/model.enno.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-no/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/model.enno.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-no/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/model.enno.intgemm.alphas.bin.gz",
@@ -5248,7 +5248,7 @@
         },
         {
           "name": "vocab.enno.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409037,
           "installPath": "bin/vocab.enno.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-no/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/vocab.enno.spm.gz",
           "sourcePath": "models/en-no/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/vocab.enno.spm.gz",
@@ -5256,7 +5256,7 @@
         },
         {
           "name": "lex.50.50.enno.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2193397,
           "installPath": "bin/lex.50.50.enno.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-no/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/lex.50.50.enno.s2t.bin.gz",
           "sourcePath": "models/en-no/h1-2025_A0d8NsivR6Szy2dI4Nz6FQ/exported/lex.50.50.enno.s2t.bin.gz",
@@ -5272,7 +5272,7 @@
       "files": [
         {
           "name": "model.enpl.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22577447,
           "installPath": "bin/model.enpl.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-pl/retrain_hr_fix_names_YmTlfuUsSKCbUp75UXaUuw/exported/model.enpl.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-pl/retrain_hr_fix_names_YmTlfuUsSKCbUp75UXaUuw/exported/model.enpl.intgemm.alphas.bin.gz",
@@ -5280,7 +5280,7 @@
         },
         {
           "name": "vocab.enpl.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 413194,
           "installPath": "bin/vocab.enpl.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-pl/retrain_hr_fix_names_YmTlfuUsSKCbUp75UXaUuw/exported/vocab.enpl.spm.gz",
           "sourcePath": "models/en-pl/retrain_hr_fix_names_YmTlfuUsSKCbUp75UXaUuw/exported/vocab.enpl.spm.gz",
@@ -5288,7 +5288,7 @@
         },
         {
           "name": "lex.50.50.enpl.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1874327,
           "installPath": "bin/lex.50.50.enpl.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-pl/retrain_hr_fix_names_YmTlfuUsSKCbUp75UXaUuw/exported/lex.50.50.enpl.s2t.bin.gz",
           "sourcePath": "models/en-pl/retrain_hr_fix_names_YmTlfuUsSKCbUp75UXaUuw/exported/lex.50.50.enpl.s2t.bin.gz",
@@ -5304,7 +5304,7 @@
       "files": [
         {
           "name": "model.enpt.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23340019,
           "installPath": "bin/model.enpt.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-pt/retrain_hr_fix_names_Vnb0RUXTTd67hR-oLHM3eg/exported/model.enpt.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-pt/retrain_hr_fix_names_Vnb0RUXTTd67hR-oLHM3eg/exported/model.enpt.intgemm.alphas.bin.gz",
@@ -5312,7 +5312,7 @@
         },
         {
           "name": "vocab.enpt.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 408686,
           "installPath": "bin/vocab.enpt.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-pt/retrain_hr_fix_names_Vnb0RUXTTd67hR-oLHM3eg/exported/vocab.enpt.spm.gz",
           "sourcePath": "models/en-pt/retrain_hr_fix_names_Vnb0RUXTTd67hR-oLHM3eg/exported/vocab.enpt.spm.gz",
@@ -5320,7 +5320,7 @@
         },
         {
           "name": "lex.50.50.enpt.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2117608,
           "installPath": "bin/lex.50.50.enpt.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-pt/retrain_hr_fix_names_Vnb0RUXTTd67hR-oLHM3eg/exported/lex.50.50.enpt.s2t.bin.gz",
           "sourcePath": "models/en-pt/retrain_hr_fix_names_Vnb0RUXTTd67hR-oLHM3eg/exported/lex.50.50.enpt.s2t.bin.gz",
@@ -5336,7 +5336,7 @@
       "files": [
         {
           "name": "model.enro.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12207487,
           "installPath": "bin/model.enro.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ro/spring-2024_Ov3G4D_DRJa-4qTlILkPhg/exported/model.enro.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ro/spring-2024_Ov3G4D_DRJa-4qTlILkPhg/exported/model.enro.intgemm.alphas.bin.gz",
@@ -5344,7 +5344,7 @@
         },
         {
           "name": "vocab.enro.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 397137,
           "installPath": "bin/vocab.enro.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ro/spring-2024_Ov3G4D_DRJa-4qTlILkPhg/exported/vocab.enro.spm.gz",
           "sourcePath": "models/en-ro/spring-2024_Ov3G4D_DRJa-4qTlILkPhg/exported/vocab.enro.spm.gz",
@@ -5352,7 +5352,7 @@
         },
         {
           "name": "lex.50.50.enro.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1846074,
           "installPath": "bin/lex.50.50.enro.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ro/spring-2024_Ov3G4D_DRJa-4qTlILkPhg/exported/lex.50.50.enro.s2t.bin.gz",
           "sourcePath": "models/en-ro/spring-2024_Ov3G4D_DRJa-4qTlILkPhg/exported/lex.50.50.enro.s2t.bin.gz",
@@ -5368,7 +5368,7 @@
       "files": [
         {
           "name": "model.enru.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 21988864,
           "installPath": "bin/model.enru.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ru/retrain_base-memory_KJ23-iDVTcymG1ZldWY17w/exported/model.enru.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ru/retrain_base-memory_KJ23-iDVTcymG1ZldWY17w/exported/model.enru.intgemm.alphas.bin.gz",
@@ -5376,7 +5376,7 @@
         },
         {
           "name": "vocab.enru.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 419005,
           "installPath": "bin/vocab.enru.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ru/retrain_base-memory_KJ23-iDVTcymG1ZldWY17w/exported/vocab.enru.spm.gz",
           "sourcePath": "models/en-ru/retrain_base-memory_KJ23-iDVTcymG1ZldWY17w/exported/vocab.enru.spm.gz",
@@ -5384,7 +5384,7 @@
         },
         {
           "name": "lex.50.50.enru.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1378563,
           "installPath": "bin/lex.50.50.enru.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ru/retrain_base-memory_KJ23-iDVTcymG1ZldWY17w/exported/lex.50.50.enru.s2t.bin.gz",
           "sourcePath": "models/en-ru/retrain_base-memory_KJ23-iDVTcymG1ZldWY17w/exported/lex.50.50.enru.s2t.bin.gz",
@@ -5400,7 +5400,7 @@
       "files": [
         {
           "name": "model.ensk.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22902983,
           "installPath": "bin/model.ensk.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sk/h1-2025_NbGVkenLTPiss8w800509A/exported/model.ensk.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-sk/h1-2025_NbGVkenLTPiss8w800509A/exported/model.ensk.intgemm.alphas.bin.gz",
@@ -5408,7 +5408,7 @@
         },
         {
           "name": "vocab.ensk.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 405652,
           "installPath": "bin/vocab.ensk.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sk/h1-2025_NbGVkenLTPiss8w800509A/exported/vocab.ensk.spm.gz",
           "sourcePath": "models/en-sk/h1-2025_NbGVkenLTPiss8w800509A/exported/vocab.ensk.spm.gz",
@@ -5416,7 +5416,7 @@
         },
         {
           "name": "lex.50.50.ensk.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1708788,
           "installPath": "bin/lex.50.50.ensk.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sk/h1-2025_NbGVkenLTPiss8w800509A/exported/lex.50.50.ensk.s2t.bin.gz",
           "sourcePath": "models/en-sk/h1-2025_NbGVkenLTPiss8w800509A/exported/lex.50.50.ensk.s2t.bin.gz",
@@ -5432,7 +5432,7 @@
       "files": [
         {
           "name": "model.ensl.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22669559,
           "installPath": "bin/model.ensl.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sl/h1-2025_Ph0DK4RhRMe7z4cLk-f7eg/exported/model.ensl.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-sl/h1-2025_Ph0DK4RhRMe7z4cLk-f7eg/exported/model.ensl.intgemm.alphas.bin.gz",
@@ -5440,7 +5440,7 @@
         },
         {
           "name": "vocab.ensl.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 398763,
           "installPath": "bin/vocab.ensl.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sl/h1-2025_Ph0DK4RhRMe7z4cLk-f7eg/exported/vocab.ensl.spm.gz",
           "sourcePath": "models/en-sl/h1-2025_Ph0DK4RhRMe7z4cLk-f7eg/exported/vocab.ensl.spm.gz",
@@ -5448,7 +5448,7 @@
         },
         {
           "name": "lex.50.50.ensl.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1741316,
           "installPath": "bin/lex.50.50.ensl.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sl/h1-2025_Ph0DK4RhRMe7z4cLk-f7eg/exported/lex.50.50.ensl.s2t.bin.gz",
           "sourcePath": "models/en-sl/h1-2025_Ph0DK4RhRMe7z4cLk-f7eg/exported/lex.50.50.ensl.s2t.bin.gz",
@@ -5464,7 +5464,7 @@
       "files": [
         {
           "name": "model.ensq.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13366206,
           "installPath": "bin/model.ensq.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sq/h1-2025_HIreYm8_RDymI1qFdn0V5Q/exported/model.ensq.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-sq/h1-2025_HIreYm8_RDymI1qFdn0V5Q/exported/model.ensq.intgemm.alphas.bin.gz",
@@ -5472,7 +5472,7 @@
         },
         {
           "name": "vocab.ensq.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 410650,
           "installPath": "bin/vocab.ensq.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sq/h1-2025_HIreYm8_RDymI1qFdn0V5Q/exported/vocab.ensq.spm.gz",
           "sourcePath": "models/en-sq/h1-2025_HIreYm8_RDymI1qFdn0V5Q/exported/vocab.ensq.spm.gz",
@@ -5480,7 +5480,7 @@
         },
         {
           "name": "lex.50.50.ensq.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1599959,
           "installPath": "bin/lex.50.50.ensq.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sq/h1-2025_HIreYm8_RDymI1qFdn0V5Q/exported/lex.50.50.ensq.s2t.bin.gz",
           "sourcePath": "models/en-sq/h1-2025_HIreYm8_RDymI1qFdn0V5Q/exported/lex.50.50.ensq.s2t.bin.gz",
@@ -5496,7 +5496,7 @@
       "files": [
         {
           "name": "model.ensr.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23014587,
           "installPath": "bin/model.ensr.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sr/hbs-topk10_KZK68xhrQWWeK6xcMRtd9A/exported/model.ensr.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-sr/hbs-topk10_KZK68xhrQWWeK6xcMRtd9A/exported/model.ensr.intgemm.alphas.bin.gz",
@@ -5504,7 +5504,7 @@
         },
         {
           "name": "vocab.ensr.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 433623,
           "installPath": "bin/vocab.ensr.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sr/hbs-topk10_KZK68xhrQWWeK6xcMRtd9A/exported/vocab.ensr.spm.gz",
           "sourcePath": "models/en-sr/hbs-topk10_KZK68xhrQWWeK6xcMRtd9A/exported/vocab.ensr.spm.gz",
@@ -5512,7 +5512,7 @@
         },
         {
           "name": "lex.50.50.ensr.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1289317,
           "installPath": "bin/lex.50.50.ensr.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sr/hbs-topk10_KZK68xhrQWWeK6xcMRtd9A/exported/lex.50.50.ensr.s2t.bin.gz",
           "sourcePath": "models/en-sr/hbs-topk10_KZK68xhrQWWeK6xcMRtd9A/exported/lex.50.50.ensr.s2t.bin.gz",
@@ -5528,7 +5528,7 @@
       "files": [
         {
           "name": "model.ensv.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12775086,
           "installPath": "bin/model.ensv.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sv/spring-2024_bQQme71PS4eZRDl3NM-kgA/exported/model.ensv.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-sv/spring-2024_bQQme71PS4eZRDl3NM-kgA/exported/model.ensv.intgemm.alphas.bin.gz",
@@ -5536,7 +5536,7 @@
         },
         {
           "name": "vocab.ensv.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 398384,
           "installPath": "bin/vocab.ensv.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sv/spring-2024_bQQme71PS4eZRDl3NM-kgA/exported/vocab.ensv.spm.gz",
           "sourcePath": "models/en-sv/spring-2024_bQQme71PS4eZRDl3NM-kgA/exported/vocab.ensv.spm.gz",
@@ -5544,7 +5544,7 @@
         },
         {
           "name": "lex.50.50.ensv.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1921270,
           "installPath": "bin/lex.50.50.ensv.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-sv/spring-2024_bQQme71PS4eZRDl3NM-kgA/exported/lex.50.50.ensv.s2t.bin.gz",
           "sourcePath": "models/en-sv/spring-2024_bQQme71PS4eZRDl3NM-kgA/exported/lex.50.50.ensv.s2t.bin.gz",
@@ -5560,7 +5560,7 @@
       "files": [
         {
           "name": "model.enta.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12645399,
           "installPath": "bin/model.enta.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ta/h1-2025_aPztISjSRums11fBuT--4A/exported/model.enta.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-ta/h1-2025_aPztISjSRums11fBuT--4A/exported/model.enta.intgemm.alphas.bin.gz",
@@ -5568,7 +5568,7 @@
         },
         {
           "name": "vocab.enta.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 446752,
           "installPath": "bin/vocab.enta.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ta/h1-2025_aPztISjSRums11fBuT--4A/exported/vocab.enta.spm.gz",
           "sourcePath": "models/en-ta/h1-2025_aPztISjSRums11fBuT--4A/exported/vocab.enta.spm.gz",
@@ -5576,7 +5576,7 @@
         },
         {
           "name": "lex.50.50.enta.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1453949,
           "installPath": "bin/lex.50.50.enta.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-ta/h1-2025_aPztISjSRums11fBuT--4A/exported/lex.50.50.enta.s2t.bin.gz",
           "sourcePath": "models/en-ta/h1-2025_aPztISjSRums11fBuT--4A/exported/lex.50.50.enta.s2t.bin.gz",
@@ -5592,7 +5592,7 @@
       "files": [
         {
           "name": "model.ente.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12590862,
           "installPath": "bin/model.ente.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-te/h1-2025_J_7yoPHaRJqsevUR512RsQ/exported/model.ente.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-te/h1-2025_J_7yoPHaRJqsevUR512RsQ/exported/model.ente.intgemm.alphas.bin.gz",
@@ -5600,7 +5600,7 @@
         },
         {
           "name": "vocab.ente.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 448838,
           "installPath": "bin/vocab.ente.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-te/h1-2025_J_7yoPHaRJqsevUR512RsQ/exported/vocab.ente.spm.gz",
           "sourcePath": "models/en-te/h1-2025_J_7yoPHaRJqsevUR512RsQ/exported/vocab.ente.spm.gz",
@@ -5608,7 +5608,7 @@
         },
         {
           "name": "lex.50.50.ente.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1434105,
           "installPath": "bin/lex.50.50.ente.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-te/h1-2025_J_7yoPHaRJqsevUR512RsQ/exported/lex.50.50.ente.s2t.bin.gz",
           "sourcePath": "models/en-te/h1-2025_J_7yoPHaRJqsevUR512RsQ/exported/lex.50.50.ente.s2t.bin.gz",
@@ -5624,7 +5624,7 @@
       "files": [
         {
           "name": "model.enth.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22976729,
           "installPath": "bin/model.enth.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-th/new-opuscleaner-en-th-onestage-topk10_WIvJuHhrSyiXLtJBJOUrsA/exported/model.enth.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-th/new-opuscleaner-en-th-onestage-topk10_WIvJuHhrSyiXLtJBJOUrsA/exported/model.enth.intgemm.alphas.bin.gz",
@@ -5632,7 +5632,7 @@
         },
         {
           "name": "vocab.enth.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 450379,
           "installPath": "bin/vocab.enth.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-th/new-opuscleaner-en-th-onestage-topk10_WIvJuHhrSyiXLtJBJOUrsA/exported/vocab.enth.spm.gz",
           "sourcePath": "models/en-th/new-opuscleaner-en-th-onestage-topk10_WIvJuHhrSyiXLtJBJOUrsA/exported/vocab.enth.spm.gz",
@@ -5640,7 +5640,7 @@
         },
         {
           "name": "lex.50.50.enth.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1601933,
           "installPath": "bin/lex.50.50.enth.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-th/new-opuscleaner-en-th-onestage-topk10_WIvJuHhrSyiXLtJBJOUrsA/exported/lex.50.50.enth.s2t.bin.gz",
           "sourcePath": "models/en-th/new-opuscleaner-en-th-onestage-topk10_WIvJuHhrSyiXLtJBJOUrsA/exported/lex.50.50.enth.s2t.bin.gz",
@@ -5656,7 +5656,7 @@
       "files": [
         {
           "name": "model.entr.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13159314,
           "installPath": "bin/model.entr.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-tr/spring-2024_LiFGeNrEQpKdNlziG2qP_A/exported/model.entr.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-tr/spring-2024_LiFGeNrEQpKdNlziG2qP_A/exported/model.entr.intgemm.alphas.bin.gz",
@@ -5664,7 +5664,7 @@
         },
         {
           "name": "vocab.entr.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 395473,
           "installPath": "bin/vocab.entr.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-tr/spring-2024_LiFGeNrEQpKdNlziG2qP_A/exported/vocab.entr.spm.gz",
           "sourcePath": "models/en-tr/spring-2024_LiFGeNrEQpKdNlziG2qP_A/exported/vocab.entr.spm.gz",
@@ -5672,7 +5672,7 @@
         },
         {
           "name": "lex.50.50.entr.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1546258,
           "installPath": "bin/lex.50.50.entr.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-tr/spring-2024_LiFGeNrEQpKdNlziG2qP_A/exported/lex.50.50.entr.s2t.bin.gz",
           "sourcePath": "models/en-tr/spring-2024_LiFGeNrEQpKdNlziG2qP_A/exported/lex.50.50.entr.s2t.bin.gz",
@@ -5688,7 +5688,7 @@
       "files": [
         {
           "name": "model.enuk.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22864374,
           "installPath": "bin/model.enuk.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-uk/docmt-vocab_a2OVwdI-Sg-SBZ_0Joqb0w/exported/model.enuk.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-uk/docmt-vocab_a2OVwdI-Sg-SBZ_0Joqb0w/exported/model.enuk.intgemm.alphas.bin.gz",
@@ -5696,7 +5696,7 @@
         },
         {
           "name": "vocab.enuk.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 436850,
           "installPath": "bin/vocab.enuk.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-uk/docmt-vocab_a2OVwdI-Sg-SBZ_0Joqb0w/exported/vocab.enuk.spm.gz",
           "sourcePath": "models/en-uk/docmt-vocab_a2OVwdI-Sg-SBZ_0Joqb0w/exported/vocab.enuk.spm.gz",
@@ -5704,7 +5704,7 @@
         },
         {
           "name": "lex.50.50.enuk.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1564122,
           "installPath": "bin/lex.50.50.enuk.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-uk/docmt-vocab_a2OVwdI-Sg-SBZ_0Joqb0w/exported/lex.50.50.enuk.s2t.bin.gz",
           "sourcePath": "models/en-uk/docmt-vocab_a2OVwdI-Sg-SBZ_0Joqb0w/exported/lex.50.50.enuk.s2t.bin.gz",
@@ -5720,7 +5720,7 @@
       "files": [
         {
           "name": "model.envi.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 24244705,
           "installPath": "bin/model.envi.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-vi/test_prompsit_Ep8JhBQ3QRizDT91JVy8KQ/exported/model.envi.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-vi/test_prompsit_Ep8JhBQ3QRizDT91JVy8KQ/exported/model.envi.intgemm.alphas.bin.gz",
@@ -5728,7 +5728,7 @@
         },
         {
           "name": "vocab.envi.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 400183,
           "installPath": "bin/vocab.envi.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-vi/test_prompsit_Ep8JhBQ3QRizDT91JVy8KQ/exported/vocab.envi.spm.gz",
           "sourcePath": "models/en-vi/test_prompsit_Ep8JhBQ3QRizDT91JVy8KQ/exported/vocab.envi.spm.gz",
@@ -5736,7 +5736,7 @@
         },
         {
           "name": "lex.50.50.envi.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2246027,
           "installPath": "bin/lex.50.50.envi.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-vi/test_prompsit_Ep8JhBQ3QRizDT91JVy8KQ/exported/lex.50.50.envi.s2t.bin.gz",
           "sourcePath": "models/en-vi/test_prompsit_Ep8JhBQ3QRizDT91JVy8KQ/exported/lex.50.50.envi.s2t.bin.gz",
@@ -5752,7 +5752,7 @@
       "files": [
         {
           "name": "model.enzh.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 33375922,
           "installPath": "bin/model.enzh.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/model.enzh.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/model.enzh.intgemm.alphas.bin.gz",
@@ -5760,7 +5760,7 @@
         },
         {
           "name": "srcvocab.enzh.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 407784,
           "installPath": "bin/srcvocab.enzh.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/srcvocab.enzh.spm.gz",
           "sourcePath": "models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/srcvocab.enzh.spm.gz",
@@ -5768,7 +5768,7 @@
         },
         {
           "name": "trgvocab.enzh.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 425748,
           "installPath": "bin/trgvocab.enzh.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/trgvocab.enzh.spm.gz",
           "sourcePath": "models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/trgvocab.enzh.spm.gz",
@@ -5776,7 +5776,7 @@
         },
         {
           "name": "lex.50.50.enzh.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2536039,
           "installPath": "bin/lex.50.50.enzh.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/lex.50.50.enzh.s2t.bin.gz",
           "sourcePath": "models/en-zh/llmaat_finetune10M_qe8_f2_ByQcSxGXQRqGi-UTxYE43g/exported/lex.50.50.enzh.s2t.bin.gz",
@@ -5792,7 +5792,7 @@
       "files": [
         {
           "name": "model.enzh_hant.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 33291007,
           "installPath": "bin/model.enzh_hant.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/model.enzh_hant.intgemm.alphas.bin.gz",
           "sourcePath": "models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/model.enzh_hant.intgemm.alphas.bin.gz",
@@ -5800,7 +5800,7 @@
         },
         {
           "name": "srcvocab.enzh_hant.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 404976,
           "installPath": "bin/srcvocab.enzh_hant.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/srcvocab.enzh_hant.spm.gz",
           "sourcePath": "models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/srcvocab.enzh_hant.spm.gz",
@@ -5808,7 +5808,7 @@
         },
         {
           "name": "trgvocab.enzh_hant.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 416659,
           "installPath": "bin/trgvocab.enzh_hant.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/trgvocab.enzh_hant.spm.gz",
           "sourcePath": "models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/trgvocab.enzh_hant.spm.gz",
@@ -5816,7 +5816,7 @@
         },
         {
           "name": "lex.50.50.enzh_hant.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2290215,
           "installPath": "bin/lex.50.50.enzh_hant.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/lex.50.50.enzh_hant.s2t.bin.gz",
           "sourcePath": "models/en-zh_hant/zh_hant_llmaat_finetune10M_qe8_f2_aQ8azdOMQOSBVjBDOVDIZQ/exported/lex.50.50.enzh_hant.s2t.bin.gz",
@@ -5832,7 +5832,7 @@
       "files": [
         {
           "name": "model.esen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23288494,
           "installPath": "bin/model.esen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/es-en/retrain_hr_HbNjJ60BTwmVTbhfFxuduA/exported/model.esen.intgemm.alphas.bin.gz",
           "sourcePath": "models/es-en/retrain_hr_HbNjJ60BTwmVTbhfFxuduA/exported/model.esen.intgemm.alphas.bin.gz",
@@ -5840,7 +5840,7 @@
         },
         {
           "name": "vocab.esen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409312,
           "installPath": "bin/vocab.esen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/es-en/retrain_hr_HbNjJ60BTwmVTbhfFxuduA/exported/vocab.esen.spm.gz",
           "sourcePath": "models/es-en/retrain_hr_HbNjJ60BTwmVTbhfFxuduA/exported/vocab.esen.spm.gz",
@@ -5848,7 +5848,7 @@
         },
         {
           "name": "lex.50.50.esen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2543246,
           "installPath": "bin/lex.50.50.esen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/es-en/retrain_hr_HbNjJ60BTwmVTbhfFxuduA/exported/lex.50.50.esen.s2t.bin.gz",
           "sourcePath": "models/es-en/retrain_hr_HbNjJ60BTwmVTbhfFxuduA/exported/lex.50.50.esen.s2t.bin.gz",
@@ -5864,7 +5864,7 @@
       "files": [
         {
           "name": "model.eten.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22785077,
           "installPath": "bin/model.eten.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/et-en/retrain_hr_RNXxp-Q9Q4GRExCoMAT77Q/exported/model.eten.intgemm.alphas.bin.gz",
           "sourcePath": "models/et-en/retrain_hr_RNXxp-Q9Q4GRExCoMAT77Q/exported/model.eten.intgemm.alphas.bin.gz",
@@ -5872,7 +5872,7 @@
         },
         {
           "name": "vocab.eten.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 414262,
           "installPath": "bin/vocab.eten.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/et-en/retrain_hr_RNXxp-Q9Q4GRExCoMAT77Q/exported/vocab.eten.spm.gz",
           "sourcePath": "models/et-en/retrain_hr_RNXxp-Q9Q4GRExCoMAT77Q/exported/vocab.eten.spm.gz",
@@ -5880,7 +5880,7 @@
         },
         {
           "name": "lex.50.50.eten.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2321326,
           "installPath": "bin/lex.50.50.eten.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/et-en/retrain_hr_RNXxp-Q9Q4GRExCoMAT77Q/exported/lex.50.50.eten.s2t.bin.gz",
           "sourcePath": "models/et-en/retrain_hr_RNXxp-Q9Q4GRExCoMAT77Q/exported/lex.50.50.eten.s2t.bin.gz",
@@ -5896,7 +5896,7 @@
       "files": [
         {
           "name": "model.faen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13071390,
           "installPath": "bin/model.faen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fa-en/h1-2025_dyvKzoMQToKWHx7bbP-TtQ/exported/model.faen.intgemm.alphas.bin.gz",
           "sourcePath": "models/fa-en/h1-2025_dyvKzoMQToKWHx7bbP-TtQ/exported/model.faen.intgemm.alphas.bin.gz",
@@ -5904,7 +5904,7 @@
         },
         {
           "name": "vocab.faen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 416123,
           "installPath": "bin/vocab.faen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fa-en/h1-2025_dyvKzoMQToKWHx7bbP-TtQ/exported/vocab.faen.spm.gz",
           "sourcePath": "models/fa-en/h1-2025_dyvKzoMQToKWHx7bbP-TtQ/exported/vocab.faen.spm.gz",
@@ -5912,7 +5912,7 @@
         },
         {
           "name": "lex.50.50.faen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1939291,
           "installPath": "bin/lex.50.50.faen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fa-en/h1-2025_dyvKzoMQToKWHx7bbP-TtQ/exported/lex.50.50.faen.s2t.bin.gz",
           "sourcePath": "models/fa-en/h1-2025_dyvKzoMQToKWHx7bbP-TtQ/exported/lex.50.50.faen.s2t.bin.gz",
@@ -5928,7 +5928,7 @@
       "files": [
         {
           "name": "model.fien.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22935246,
           "installPath": "bin/model.fien.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fi-en/retrain_hr_C7-zSzS7Tm6zkOfVP7k0Gw/exported/model.fien.intgemm.alphas.bin.gz",
           "sourcePath": "models/fi-en/retrain_hr_C7-zSzS7Tm6zkOfVP7k0Gw/exported/model.fien.intgemm.alphas.bin.gz",
@@ -5936,7 +5936,7 @@
         },
         {
           "name": "vocab.fien.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 414280,
           "installPath": "bin/vocab.fien.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fi-en/retrain_hr_C7-zSzS7Tm6zkOfVP7k0Gw/exported/vocab.fien.spm.gz",
           "sourcePath": "models/fi-en/retrain_hr_C7-zSzS7Tm6zkOfVP7k0Gw/exported/vocab.fien.spm.gz",
@@ -5944,7 +5944,7 @@
         },
         {
           "name": "lex.50.50.fien.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2580517,
           "installPath": "bin/lex.50.50.fien.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fi-en/retrain_hr_C7-zSzS7Tm6zkOfVP7k0Gw/exported/lex.50.50.fien.s2t.bin.gz",
           "sourcePath": "models/fi-en/retrain_hr_C7-zSzS7Tm6zkOfVP7k0Gw/exported/lex.50.50.fien.s2t.bin.gz",
@@ -5960,7 +5960,7 @@
       "files": [
         {
           "name": "model.fren.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23175075,
           "installPath": "bin/model.fren.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fr-en/retrain_hr_EFgIftH_RrCyzl5gjemVNg/exported/model.fren.intgemm.alphas.bin.gz",
           "sourcePath": "models/fr-en/retrain_hr_EFgIftH_RrCyzl5gjemVNg/exported/model.fren.intgemm.alphas.bin.gz",
@@ -5968,7 +5968,7 @@
         },
         {
           "name": "vocab.fren.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409706,
           "installPath": "bin/vocab.fren.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fr-en/retrain_hr_EFgIftH_RrCyzl5gjemVNg/exported/vocab.fren.spm.gz",
           "sourcePath": "models/fr-en/retrain_hr_EFgIftH_RrCyzl5gjemVNg/exported/vocab.fren.spm.gz",
@@ -5976,7 +5976,7 @@
         },
         {
           "name": "lex.50.50.fren.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2649934,
           "installPath": "bin/lex.50.50.fren.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/fr-en/retrain_hr_EFgIftH_RrCyzl5gjemVNg/exported/lex.50.50.fren.s2t.bin.gz",
           "sourcePath": "models/fr-en/retrain_hr_EFgIftH_RrCyzl5gjemVNg/exported/lex.50.50.fren.s2t.bin.gz",
@@ -5992,7 +5992,7 @@
       "files": [
         {
           "name": "model.guen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12917932,
           "installPath": "bin/model.guen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/gu-en/h1-2025_AbHCTUgSSguJ1-Pq-XLnVA/exported/model.guen.intgemm.alphas.bin.gz",
           "sourcePath": "models/gu-en/h1-2025_AbHCTUgSSguJ1-Pq-XLnVA/exported/model.guen.intgemm.alphas.bin.gz",
@@ -6000,7 +6000,7 @@
         },
         {
           "name": "vocab.guen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 435011,
           "installPath": "bin/vocab.guen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/gu-en/h1-2025_AbHCTUgSSguJ1-Pq-XLnVA/exported/vocab.guen.spm.gz",
           "sourcePath": "models/gu-en/h1-2025_AbHCTUgSSguJ1-Pq-XLnVA/exported/vocab.guen.spm.gz",
@@ -6008,7 +6008,7 @@
         },
         {
           "name": "lex.50.50.guen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2028621,
           "installPath": "bin/lex.50.50.guen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/gu-en/h1-2025_AbHCTUgSSguJ1-Pq-XLnVA/exported/lex.50.50.guen.s2t.bin.gz",
           "sourcePath": "models/gu-en/h1-2025_AbHCTUgSSguJ1-Pq-XLnVA/exported/lex.50.50.guen.s2t.bin.gz",
@@ -6024,7 +6024,7 @@
       "files": [
         {
           "name": "model.heen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12999905,
           "installPath": "bin/model.heen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/he-en/h1-2025_IZKPrf3xQaKu56F3zmH0cw/exported/model.heen.intgemm.alphas.bin.gz",
           "sourcePath": "models/he-en/h1-2025_IZKPrf3xQaKu56F3zmH0cw/exported/model.heen.intgemm.alphas.bin.gz",
@@ -6032,7 +6032,7 @@
         },
         {
           "name": "vocab.heen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 411769,
           "installPath": "bin/vocab.heen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/he-en/h1-2025_IZKPrf3xQaKu56F3zmH0cw/exported/vocab.heen.spm.gz",
           "sourcePath": "models/he-en/h1-2025_IZKPrf3xQaKu56F3zmH0cw/exported/vocab.heen.spm.gz",
@@ -6040,7 +6040,7 @@
         },
         {
           "name": "lex.50.50.heen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2232949,
           "installPath": "bin/lex.50.50.heen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/he-en/h1-2025_IZKPrf3xQaKu56F3zmH0cw/exported/lex.50.50.heen.s2t.bin.gz",
           "sourcePath": "models/he-en/h1-2025_IZKPrf3xQaKu56F3zmH0cw/exported/lex.50.50.heen.s2t.bin.gz",
@@ -6056,7 +6056,7 @@
       "files": [
         {
           "name": "model.hien.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12752013,
           "installPath": "bin/model.hien.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hi-en/h1-2025_IcUQD-GbSJWB6WV08oDoEw/exported/model.hien.intgemm.alphas.bin.gz",
           "sourcePath": "models/hi-en/h1-2025_IcUQD-GbSJWB6WV08oDoEw/exported/model.hien.intgemm.alphas.bin.gz",
@@ -6064,7 +6064,7 @@
         },
         {
           "name": "vocab.hien.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 430096,
           "installPath": "bin/vocab.hien.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hi-en/h1-2025_IcUQD-GbSJWB6WV08oDoEw/exported/vocab.hien.spm.gz",
           "sourcePath": "models/hi-en/h1-2025_IcUQD-GbSJWB6WV08oDoEw/exported/vocab.hien.spm.gz",
@@ -6072,7 +6072,7 @@
         },
         {
           "name": "lex.50.50.hien.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2319675,
           "installPath": "bin/lex.50.50.hien.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hi-en/h1-2025_IcUQD-GbSJWB6WV08oDoEw/exported/lex.50.50.hien.s2t.bin.gz",
           "sourcePath": "models/hi-en/h1-2025_IcUQD-GbSJWB6WV08oDoEw/exported/lex.50.50.hien.s2t.bin.gz",
@@ -6088,7 +6088,7 @@
       "files": [
         {
           "name": "model.hren.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13050395,
           "installPath": "bin/model.hren.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hr-en/spring-2024_eIcYjCedS26HE07kVyt5Qw/exported/model.hren.intgemm.alphas.bin.gz",
           "sourcePath": "models/hr-en/spring-2024_eIcYjCedS26HE07kVyt5Qw/exported/model.hren.intgemm.alphas.bin.gz",
@@ -6096,7 +6096,7 @@
         },
         {
           "name": "vocab.hren.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 394548,
           "installPath": "bin/vocab.hren.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hr-en/spring-2024_eIcYjCedS26HE07kVyt5Qw/exported/vocab.hren.spm.gz",
           "sourcePath": "models/hr-en/spring-2024_eIcYjCedS26HE07kVyt5Qw/exported/vocab.hren.spm.gz",
@@ -6104,7 +6104,7 @@
         },
         {
           "name": "lex.50.50.hren.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1888089,
           "installPath": "bin/lex.50.50.hren.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hr-en/spring-2024_eIcYjCedS26HE07kVyt5Qw/exported/lex.50.50.hren.s2t.bin.gz",
           "sourcePath": "models/hr-en/spring-2024_eIcYjCedS26HE07kVyt5Qw/exported/lex.50.50.hren.s2t.bin.gz",
@@ -6120,7 +6120,7 @@
       "files": [
         {
           "name": "model.huen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13181613,
           "installPath": "bin/model.huen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hu-en/andre_xxxxxxxxRxSxxxxxxxxxxA/exported/model.huen.intgemm.alphas.bin.gz",
           "sourcePath": "models/hu-en/andre_xxxxxxxxRxSxxxxxxxxxxA/exported/model.huen.intgemm.alphas.bin.gz",
@@ -6128,7 +6128,7 @@
         },
         {
           "name": "vocab.huen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 419908,
           "installPath": "bin/vocab.huen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hu-en/andre_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.huen.spm.gz",
           "sourcePath": "models/hu-en/andre_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.huen.spm.gz",
@@ -6136,7 +6136,7 @@
         },
         {
           "name": "lex.50.50.huen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2778202,
           "installPath": "bin/lex.50.50.huen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/hu-en/andre_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.huen.s2t.bin.gz",
           "sourcePath": "models/hu-en/andre_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.huen.s2t.bin.gz",
@@ -6152,7 +6152,7 @@
       "files": [
         {
           "name": "model.iden.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13010657,
           "installPath": "bin/model.iden.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/id-en/spring-2024_Yl0wXq-iQE6G9PpA3AQfcg/exported/model.iden.intgemm.alphas.bin.gz",
           "sourcePath": "models/id-en/spring-2024_Yl0wXq-iQE6G9PpA3AQfcg/exported/model.iden.intgemm.alphas.bin.gz",
@@ -6160,7 +6160,7 @@
         },
         {
           "name": "vocab.iden.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 379859,
           "installPath": "bin/vocab.iden.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/id-en/spring-2024_Yl0wXq-iQE6G9PpA3AQfcg/exported/vocab.iden.spm.gz",
           "sourcePath": "models/id-en/spring-2024_Yl0wXq-iQE6G9PpA3AQfcg/exported/vocab.iden.spm.gz",
@@ -6168,7 +6168,7 @@
         },
         {
           "name": "lex.50.50.iden.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1818222,
           "installPath": "bin/lex.50.50.iden.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/id-en/spring-2024_Yl0wXq-iQE6G9PpA3AQfcg/exported/lex.50.50.iden.s2t.bin.gz",
           "sourcePath": "models/id-en/spring-2024_Yl0wXq-iQE6G9PpA3AQfcg/exported/lex.50.50.iden.s2t.bin.gz",
@@ -6184,7 +6184,7 @@
       "files": [
         {
           "name": "model.isen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23229378,
           "installPath": "bin/model.isen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/is-en/docmt-vocab_I4Fy2MnOQHSOT4SYlCjPWw/exported/model.isen.intgemm.alphas.bin.gz",
           "sourcePath": "models/is-en/docmt-vocab_I4Fy2MnOQHSOT4SYlCjPWw/exported/model.isen.intgemm.alphas.bin.gz",
@@ -6192,7 +6192,7 @@
         },
         {
           "name": "vocab.isen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 412304,
           "installPath": "bin/vocab.isen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/is-en/docmt-vocab_I4Fy2MnOQHSOT4SYlCjPWw/exported/vocab.isen.spm.gz",
           "sourcePath": "models/is-en/docmt-vocab_I4Fy2MnOQHSOT4SYlCjPWw/exported/vocab.isen.spm.gz",
@@ -6200,7 +6200,7 @@
         },
         {
           "name": "lex.50.50.isen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2012853,
           "installPath": "bin/lex.50.50.isen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/is-en/docmt-vocab_I4Fy2MnOQHSOT4SYlCjPWw/exported/lex.50.50.isen.s2t.bin.gz",
           "sourcePath": "models/is-en/docmt-vocab_I4Fy2MnOQHSOT4SYlCjPWw/exported/lex.50.50.isen.s2t.bin.gz",
@@ -6216,7 +6216,7 @@
       "files": [
         {
           "name": "model.iten.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23301774,
           "installPath": "bin/model.iten.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/it-en/retrain_hr_d1nPDwVeSD6t-HdtWA4xNg/exported/model.iten.intgemm.alphas.bin.gz",
           "sourcePath": "models/it-en/retrain_hr_d1nPDwVeSD6t-HdtWA4xNg/exported/model.iten.intgemm.alphas.bin.gz",
@@ -6224,7 +6224,7 @@
         },
         {
           "name": "vocab.iten.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 407598,
           "installPath": "bin/vocab.iten.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/it-en/retrain_hr_d1nPDwVeSD6t-HdtWA4xNg/exported/vocab.iten.spm.gz",
           "sourcePath": "models/it-en/retrain_hr_d1nPDwVeSD6t-HdtWA4xNg/exported/vocab.iten.spm.gz",
@@ -6232,7 +6232,7 @@
         },
         {
           "name": "lex.50.50.iten.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2532929,
           "installPath": "bin/lex.50.50.iten.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/it-en/retrain_hr_d1nPDwVeSD6t-HdtWA4xNg/exported/lex.50.50.iten.s2t.bin.gz",
           "sourcePath": "models/it-en/retrain_hr_d1nPDwVeSD6t-HdtWA4xNg/exported/lex.50.50.iten.s2t.bin.gz",
@@ -6248,7 +6248,7 @@
       "files": [
         {
           "name": "model.jaen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 32577435,
           "installPath": "bin/model.jaen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ja-en/cjk_retrain_base-memory_NLRJLD_pQFyrvgKtbie2nA/exported/model.jaen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ja-en/cjk_retrain_base-memory_NLRJLD_pQFyrvgKtbie2nA/exported/model.jaen.intgemm.alphas.bin.gz",
@@ -6256,7 +6256,7 @@
         },
         {
           "name": "vocab.jaen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 746616,
           "installPath": "bin/vocab.jaen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ja-en/cjk_retrain_base-memory_NLRJLD_pQFyrvgKtbie2nA/exported/vocab.jaen.spm.gz",
           "sourcePath": "models/ja-en/cjk_retrain_base-memory_NLRJLD_pQFyrvgKtbie2nA/exported/vocab.jaen.spm.gz",
@@ -6264,7 +6264,7 @@
         },
         {
           "name": "lex.50.50.jaen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 4819610,
           "installPath": "bin/lex.50.50.jaen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ja-en/cjk_retrain_base-memory_NLRJLD_pQFyrvgKtbie2nA/exported/lex.50.50.jaen.s2t.bin.gz",
           "sourcePath": "models/ja-en/cjk_retrain_base-memory_NLRJLD_pQFyrvgKtbie2nA/exported/lex.50.50.jaen.s2t.bin.gz",
@@ -6280,7 +6280,7 @@
       "files": [
         {
           "name": "model.knen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13077357,
           "installPath": "bin/model.knen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/kn-en/h1-2025_Ql24XjW0Sp-zWsmLrV5TGQ/exported/model.knen.intgemm.alphas.bin.gz",
           "sourcePath": "models/kn-en/h1-2025_Ql24XjW0Sp-zWsmLrV5TGQ/exported/model.knen.intgemm.alphas.bin.gz",
@@ -6288,7 +6288,7 @@
         },
         {
           "name": "vocab.knen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 450324,
           "installPath": "bin/vocab.knen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/kn-en/h1-2025_Ql24XjW0Sp-zWsmLrV5TGQ/exported/vocab.knen.spm.gz",
           "sourcePath": "models/kn-en/h1-2025_Ql24XjW0Sp-zWsmLrV5TGQ/exported/vocab.knen.spm.gz",
@@ -6296,7 +6296,7 @@
         },
         {
           "name": "lex.50.50.knen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2128860,
           "installPath": "bin/lex.50.50.knen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/kn-en/h1-2025_Ql24XjW0Sp-zWsmLrV5TGQ/exported/lex.50.50.knen.s2t.bin.gz",
           "sourcePath": "models/kn-en/h1-2025_Ql24XjW0Sp-zWsmLrV5TGQ/exported/lex.50.50.knen.s2t.bin.gz",
@@ -6312,7 +6312,7 @@
       "files": [
         {
           "name": "model.koen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 32152814,
           "installPath": "bin/model.koen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ko-en/cjk_retrain_base-memory_QgYNtG3BTzKBFSV1wl06Pg/exported/model.koen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ko-en/cjk_retrain_base-memory_QgYNtG3BTzKBFSV1wl06Pg/exported/model.koen.intgemm.alphas.bin.gz",
@@ -6320,7 +6320,7 @@
         },
         {
           "name": "vocab.koen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 706864,
           "installPath": "bin/vocab.koen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ko-en/cjk_retrain_base-memory_QgYNtG3BTzKBFSV1wl06Pg/exported/vocab.koen.spm.gz",
           "sourcePath": "models/ko-en/cjk_retrain_base-memory_QgYNtG3BTzKBFSV1wl06Pg/exported/vocab.koen.spm.gz",
@@ -6328,7 +6328,7 @@
         },
         {
           "name": "lex.50.50.koen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 4381854,
           "installPath": "bin/lex.50.50.koen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ko-en/cjk_retrain_base-memory_QgYNtG3BTzKBFSV1wl06Pg/exported/lex.50.50.koen.s2t.bin.gz",
           "sourcePath": "models/ko-en/cjk_retrain_base-memory_QgYNtG3BTzKBFSV1wl06Pg/exported/lex.50.50.koen.s2t.bin.gz",
@@ -6344,7 +6344,7 @@
       "files": [
         {
           "name": "model.lten.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12571257,
           "installPath": "bin/model.lten.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/lt-en/spring-2024_aAroslw9Ru-c5cam6SvLBg/exported/model.lten.intgemm.alphas.bin.gz",
           "sourcePath": "models/lt-en/spring-2024_aAroslw9Ru-c5cam6SvLBg/exported/model.lten.intgemm.alphas.bin.gz",
@@ -6352,7 +6352,7 @@
         },
         {
           "name": "vocab.lten.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 403960,
           "installPath": "bin/vocab.lten.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/lt-en/spring-2024_aAroslw9Ru-c5cam6SvLBg/exported/vocab.lten.spm.gz",
           "sourcePath": "models/lt-en/spring-2024_aAroslw9Ru-c5cam6SvLBg/exported/vocab.lten.spm.gz",
@@ -6360,7 +6360,7 @@
         },
         {
           "name": "lex.50.50.lten.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2308876,
           "installPath": "bin/lex.50.50.lten.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/lt-en/spring-2024_aAroslw9Ru-c5cam6SvLBg/exported/lex.50.50.lten.s2t.bin.gz",
           "sourcePath": "models/lt-en/spring-2024_aAroslw9Ru-c5cam6SvLBg/exported/lex.50.50.lten.s2t.bin.gz",
@@ -6376,7 +6376,7 @@
       "files": [
         {
           "name": "model.lven.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12689153,
           "installPath": "bin/model.lven.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/lv-en/spring-2024_fkUrjGNcQiWrTQ5BcYbkgg/exported/model.lven.intgemm.alphas.bin.gz",
           "sourcePath": "models/lv-en/spring-2024_fkUrjGNcQiWrTQ5BcYbkgg/exported/model.lven.intgemm.alphas.bin.gz",
@@ -6384,7 +6384,7 @@
         },
         {
           "name": "vocab.lven.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 407237,
           "installPath": "bin/vocab.lven.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/lv-en/spring-2024_fkUrjGNcQiWrTQ5BcYbkgg/exported/vocab.lven.spm.gz",
           "sourcePath": "models/lv-en/spring-2024_fkUrjGNcQiWrTQ5BcYbkgg/exported/vocab.lven.spm.gz",
@@ -6392,7 +6392,7 @@
         },
         {
           "name": "lex.50.50.lven.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2131786,
           "installPath": "bin/lex.50.50.lven.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/lv-en/spring-2024_fkUrjGNcQiWrTQ5BcYbkgg/exported/lex.50.50.lven.s2t.bin.gz",
           "sourcePath": "models/lv-en/spring-2024_fkUrjGNcQiWrTQ5BcYbkgg/exported/lex.50.50.lven.s2t.bin.gz",
@@ -6408,7 +6408,7 @@
       "files": [
         {
           "name": "model.mlen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12792306,
           "installPath": "bin/model.mlen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ml-en/h1-2025_Ahkzk6jNTAut7rz6laKkGQ/exported/model.mlen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ml-en/h1-2025_Ahkzk6jNTAut7rz6laKkGQ/exported/model.mlen.intgemm.alphas.bin.gz",
@@ -6416,7 +6416,7 @@
         },
         {
           "name": "vocab.mlen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 454911,
           "installPath": "bin/vocab.mlen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ml-en/h1-2025_Ahkzk6jNTAut7rz6laKkGQ/exported/vocab.mlen.spm.gz",
           "sourcePath": "models/ml-en/h1-2025_Ahkzk6jNTAut7rz6laKkGQ/exported/vocab.mlen.spm.gz",
@@ -6424,7 +6424,7 @@
         },
         {
           "name": "lex.50.50.mlen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2296381,
           "installPath": "bin/lex.50.50.mlen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ml-en/h1-2025_Ahkzk6jNTAut7rz6laKkGQ/exported/lex.50.50.mlen.s2t.bin.gz",
           "sourcePath": "models/ml-en/h1-2025_Ahkzk6jNTAut7rz6laKkGQ/exported/lex.50.50.mlen.s2t.bin.gz",
@@ -6440,7 +6440,7 @@
       "files": [
         {
           "name": "model.msen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12538542,
           "installPath": "bin/model.msen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ms-en/h1-2025_afzwIUAqQRWx5PtvozOHnw/exported/model.msen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ms-en/h1-2025_afzwIUAqQRWx5PtvozOHnw/exported/model.msen.intgemm.alphas.bin.gz",
@@ -6448,7 +6448,7 @@
         },
         {
           "name": "vocab.msen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 403877,
           "installPath": "bin/vocab.msen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ms-en/h1-2025_afzwIUAqQRWx5PtvozOHnw/exported/vocab.msen.spm.gz",
           "sourcePath": "models/ms-en/h1-2025_afzwIUAqQRWx5PtvozOHnw/exported/vocab.msen.spm.gz",
@@ -6456,7 +6456,7 @@
         },
         {
           "name": "lex.50.50.msen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2141259,
           "installPath": "bin/lex.50.50.msen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ms-en/h1-2025_afzwIUAqQRWx5PtvozOHnw/exported/lex.50.50.msen.s2t.bin.gz",
           "sourcePath": "models/ms-en/h1-2025_afzwIUAqQRWx5PtvozOHnw/exported/lex.50.50.msen.s2t.bin.gz",
@@ -6472,7 +6472,7 @@
       "files": [
         {
           "name": "model.nben.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13193689,
           "installPath": "bin/model.nben.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nb-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/model.nben.intgemm.alphas.bin.gz",
           "sourcePath": "models/nb-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/model.nben.intgemm.alphas.bin.gz",
@@ -6480,7 +6480,7 @@
         },
         {
           "name": "vocab.nben.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409135,
           "installPath": "bin/vocab.nben.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nb-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/vocab.nben.spm.gz",
           "sourcePath": "models/nb-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/vocab.nben.spm.gz",
@@ -6488,7 +6488,7 @@
         },
         {
           "name": "lex.50.50.nben.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2308582,
           "installPath": "bin/lex.50.50.nben.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nb-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/lex.50.50.nben.s2t.bin.gz",
           "sourcePath": "models/nb-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/lex.50.50.nben.s2t.bin.gz",
@@ -6504,7 +6504,7 @@
       "files": [
         {
           "name": "model.nlen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22647743,
           "installPath": "bin/model.nlen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nl-en/retrain_hr_JbTCb42HREGvK8d6aOCjFQ/exported/model.nlen.intgemm.alphas.bin.gz",
           "sourcePath": "models/nl-en/retrain_hr_JbTCb42HREGvK8d6aOCjFQ/exported/model.nlen.intgemm.alphas.bin.gz",
@@ -6512,7 +6512,7 @@
         },
         {
           "name": "vocab.nlen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 410222,
           "installPath": "bin/vocab.nlen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nl-en/retrain_hr_JbTCb42HREGvK8d6aOCjFQ/exported/vocab.nlen.spm.gz",
           "sourcePath": "models/nl-en/retrain_hr_JbTCb42HREGvK8d6aOCjFQ/exported/vocab.nlen.spm.gz",
@@ -6520,7 +6520,7 @@
         },
         {
           "name": "lex.50.50.nlen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2616098,
           "installPath": "bin/lex.50.50.nlen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nl-en/retrain_hr_JbTCb42HREGvK8d6aOCjFQ/exported/lex.50.50.nlen.s2t.bin.gz",
           "sourcePath": "models/nl-en/retrain_hr_JbTCb42HREGvK8d6aOCjFQ/exported/lex.50.50.nlen.s2t.bin.gz",
@@ -6536,7 +6536,7 @@
       "files": [
         {
           "name": "model.nnen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 10465158,
           "installPath": "bin/model.nnen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nn-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/model.nnen.intgemm.alphas.bin.gz",
           "sourcePath": "models/nn-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/model.nnen.intgemm.alphas.bin.gz",
@@ -6544,7 +6544,7 @@
         },
         {
           "name": "vocab.nnen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 269397,
           "installPath": "bin/vocab.nnen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nn-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.nnen.spm.gz",
           "sourcePath": "models/nn-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.nnen.spm.gz",
@@ -6552,7 +6552,7 @@
         },
         {
           "name": "lex.50.50.nnen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 731899,
           "installPath": "bin/lex.50.50.nnen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/nn-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.nnen.s2t.bin.gz",
           "sourcePath": "models/nn-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.nnen.s2t.bin.gz",
@@ -6568,7 +6568,7 @@
       "files": [
         {
           "name": "model.noen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13193689,
           "installPath": "bin/model.noen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/no-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/model.noen.intgemm.alphas.bin.gz",
           "sourcePath": "models/no-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/model.noen.intgemm.alphas.bin.gz",
@@ -6576,7 +6576,7 @@
         },
         {
           "name": "vocab.noen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409135,
           "installPath": "bin/vocab.noen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/no-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/vocab.noen.spm.gz",
           "sourcePath": "models/no-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/vocab.noen.spm.gz",
@@ -6584,7 +6584,7 @@
         },
         {
           "name": "lex.50.50.noen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2308582,
           "installPath": "bin/lex.50.50.noen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/no-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/lex.50.50.noen.s2t.bin.gz",
           "sourcePath": "models/no-en/h1-2025_YKogHXi6Q4es3P7fEWEaBw/exported/lex.50.50.noen.s2t.bin.gz",
@@ -6600,7 +6600,7 @@
       "files": [
         {
           "name": "model.plen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22630393,
           "installPath": "bin/model.plen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/pl-en/retrain_hr_HLLa6ZwsSomB0kyBr7Iz6w/exported/model.plen.intgemm.alphas.bin.gz",
           "sourcePath": "models/pl-en/retrain_hr_HLLa6ZwsSomB0kyBr7Iz6w/exported/model.plen.intgemm.alphas.bin.gz",
@@ -6608,7 +6608,7 @@
         },
         {
           "name": "vocab.plen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 413194,
           "installPath": "bin/vocab.plen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/pl-en/retrain_hr_HLLa6ZwsSomB0kyBr7Iz6w/exported/vocab.plen.spm.gz",
           "sourcePath": "models/pl-en/retrain_hr_HLLa6ZwsSomB0kyBr7Iz6w/exported/vocab.plen.spm.gz",
@@ -6616,7 +6616,7 @@
         },
         {
           "name": "lex.50.50.plen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2489764,
           "installPath": "bin/lex.50.50.plen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/pl-en/retrain_hr_HLLa6ZwsSomB0kyBr7Iz6w/exported/lex.50.50.plen.s2t.bin.gz",
           "sourcePath": "models/pl-en/retrain_hr_HLLa6ZwsSomB0kyBr7Iz6w/exported/lex.50.50.plen.s2t.bin.gz",
@@ -6632,7 +6632,7 @@
       "files": [
         {
           "name": "model.pten.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22700409,
           "installPath": "bin/model.pten.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/pt-en/retrain_hr_drxrs5bGSsOWvfK9lyZISw/exported/model.pten.intgemm.alphas.bin.gz",
           "sourcePath": "models/pt-en/retrain_hr_drxrs5bGSsOWvfK9lyZISw/exported/model.pten.intgemm.alphas.bin.gz",
@@ -6640,7 +6640,7 @@
         },
         {
           "name": "vocab.pten.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 408686,
           "installPath": "bin/vocab.pten.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/pt-en/retrain_hr_drxrs5bGSsOWvfK9lyZISw/exported/vocab.pten.spm.gz",
           "sourcePath": "models/pt-en/retrain_hr_drxrs5bGSsOWvfK9lyZISw/exported/vocab.pten.spm.gz",
@@ -6648,7 +6648,7 @@
         },
         {
           "name": "lex.50.50.pten.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2487847,
           "installPath": "bin/lex.50.50.pten.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/pt-en/retrain_hr_drxrs5bGSsOWvfK9lyZISw/exported/lex.50.50.pten.s2t.bin.gz",
           "sourcePath": "models/pt-en/retrain_hr_drxrs5bGSsOWvfK9lyZISw/exported/lex.50.50.pten.s2t.bin.gz",
@@ -6664,7 +6664,7 @@
       "files": [
         {
           "name": "model.roen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12722200,
           "installPath": "bin/model.roen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ro-en/spring-2024_RwH0W_MDRK2BmZA6VzAmBg/exported/model.roen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ro-en/spring-2024_RwH0W_MDRK2BmZA6VzAmBg/exported/model.roen.intgemm.alphas.bin.gz",
@@ -6672,7 +6672,7 @@
         },
         {
           "name": "vocab.roen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 396717,
           "installPath": "bin/vocab.roen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ro-en/spring-2024_RwH0W_MDRK2BmZA6VzAmBg/exported/vocab.roen.spm.gz",
           "sourcePath": "models/ro-en/spring-2024_RwH0W_MDRK2BmZA6VzAmBg/exported/vocab.roen.spm.gz",
@@ -6680,7 +6680,7 @@
         },
         {
           "name": "lex.50.50.roen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2159556,
           "installPath": "bin/lex.50.50.roen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ro-en/spring-2024_RwH0W_MDRK2BmZA6VzAmBg/exported/lex.50.50.roen.s2t.bin.gz",
           "sourcePath": "models/ro-en/spring-2024_RwH0W_MDRK2BmZA6VzAmBg/exported/lex.50.50.roen.s2t.bin.gz",
@@ -6696,7 +6696,7 @@
       "files": [
         {
           "name": "model.ruen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12613599,
           "installPath": "bin/model.ruen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ru-en/spring-2024_QrcdYgbwS7e7xbhtOSdoNQ/exported/model.ruen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ru-en/spring-2024_QrcdYgbwS7e7xbhtOSdoNQ/exported/model.ruen.intgemm.alphas.bin.gz",
@@ -6704,7 +6704,7 @@
         },
         {
           "name": "vocab.ruen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 419860,
           "installPath": "bin/vocab.ruen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ru-en/spring-2024_QrcdYgbwS7e7xbhtOSdoNQ/exported/vocab.ruen.spm.gz",
           "sourcePath": "models/ru-en/spring-2024_QrcdYgbwS7e7xbhtOSdoNQ/exported/vocab.ruen.spm.gz",
@@ -6712,7 +6712,7 @@
         },
         {
           "name": "lex.50.50.ruen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1962008,
           "installPath": "bin/lex.50.50.ruen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ru-en/spring-2024_QrcdYgbwS7e7xbhtOSdoNQ/exported/lex.50.50.ruen.s2t.bin.gz",
           "sourcePath": "models/ru-en/spring-2024_QrcdYgbwS7e7xbhtOSdoNQ/exported/lex.50.50.ruen.s2t.bin.gz",
@@ -6728,7 +6728,7 @@
       "files": [
         {
           "name": "model.sken.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12821519,
           "installPath": "bin/model.sken.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sk-en/spring-2024_TD01UwWXRKacv3wnYeVKbg/exported/model.sken.intgemm.alphas.bin.gz",
           "sourcePath": "models/sk-en/spring-2024_TD01UwWXRKacv3wnYeVKbg/exported/model.sken.intgemm.alphas.bin.gz",
@@ -6736,7 +6736,7 @@
         },
         {
           "name": "vocab.sken.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 405122,
           "installPath": "bin/vocab.sken.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sk-en/spring-2024_TD01UwWXRKacv3wnYeVKbg/exported/vocab.sken.spm.gz",
           "sourcePath": "models/sk-en/spring-2024_TD01UwWXRKacv3wnYeVKbg/exported/vocab.sken.spm.gz",
@@ -6744,7 +6744,7 @@
         },
         {
           "name": "lex.50.50.sken.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2348184,
           "installPath": "bin/lex.50.50.sken.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sk-en/spring-2024_TD01UwWXRKacv3wnYeVKbg/exported/lex.50.50.sken.s2t.bin.gz",
           "sourcePath": "models/sk-en/spring-2024_TD01UwWXRKacv3wnYeVKbg/exported/lex.50.50.sken.s2t.bin.gz",
@@ -6760,7 +6760,7 @@
       "files": [
         {
           "name": "model.slen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23730414,
           "installPath": "bin/model.slen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sl-en/h1-2025_TCeLyjkQRL2YbTXrUhTlAg/exported/model.slen.intgemm.alphas.bin.gz",
           "sourcePath": "models/sl-en/h1-2025_TCeLyjkQRL2YbTXrUhTlAg/exported/model.slen.intgemm.alphas.bin.gz",
@@ -6768,7 +6768,7 @@
         },
         {
           "name": "vocab.slen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 398535,
           "installPath": "bin/vocab.slen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sl-en/h1-2025_TCeLyjkQRL2YbTXrUhTlAg/exported/vocab.slen.spm.gz",
           "sourcePath": "models/sl-en/h1-2025_TCeLyjkQRL2YbTXrUhTlAg/exported/vocab.slen.spm.gz",
@@ -6776,7 +6776,7 @@
         },
         {
           "name": "lex.50.50.slen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2138548,
           "installPath": "bin/lex.50.50.slen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sl-en/h1-2025_TCeLyjkQRL2YbTXrUhTlAg/exported/lex.50.50.slen.s2t.bin.gz",
           "sourcePath": "models/sl-en/h1-2025_TCeLyjkQRL2YbTXrUhTlAg/exported/lex.50.50.slen.s2t.bin.gz",
@@ -6792,7 +6792,7 @@
       "files": [
         {
           "name": "model.sqen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12593638,
           "installPath": "bin/model.sqen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sq-en/h1-2025_I8xy7KMeQoe3mMEV3umzfQ/exported/model.sqen.intgemm.alphas.bin.gz",
           "sourcePath": "models/sq-en/h1-2025_I8xy7KMeQoe3mMEV3umzfQ/exported/model.sqen.intgemm.alphas.bin.gz",
@@ -6800,7 +6800,7 @@
         },
         {
           "name": "vocab.sqen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 410423,
           "installPath": "bin/vocab.sqen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sq-en/h1-2025_I8xy7KMeQoe3mMEV3umzfQ/exported/vocab.sqen.spm.gz",
           "sourcePath": "models/sq-en/h1-2025_I8xy7KMeQoe3mMEV3umzfQ/exported/vocab.sqen.spm.gz",
@@ -6808,7 +6808,7 @@
         },
         {
           "name": "lex.50.50.sqen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2165940,
           "installPath": "bin/lex.50.50.sqen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sq-en/h1-2025_I8xy7KMeQoe3mMEV3umzfQ/exported/lex.50.50.sqen.s2t.bin.gz",
           "sourcePath": "models/sq-en/h1-2025_I8xy7KMeQoe3mMEV3umzfQ/exported/lex.50.50.sqen.s2t.bin.gz",
@@ -6824,7 +6824,7 @@
       "files": [
         {
           "name": "model.sren.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12729754,
           "installPath": "bin/model.sren.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sr-en/spring-2024_H5GCfsx4SnqOP4YFIQdkdA/exported/model.sren.intgemm.alphas.bin.gz",
           "sourcePath": "models/sr-en/spring-2024_H5GCfsx4SnqOP4YFIQdkdA/exported/model.sren.intgemm.alphas.bin.gz",
@@ -6832,7 +6832,7 @@
         },
         {
           "name": "vocab.sren.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 403515,
           "installPath": "bin/vocab.sren.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sr-en/spring-2024_H5GCfsx4SnqOP4YFIQdkdA/exported/vocab.sren.spm.gz",
           "sourcePath": "models/sr-en/spring-2024_H5GCfsx4SnqOP4YFIQdkdA/exported/vocab.sren.spm.gz",
@@ -6840,7 +6840,7 @@
         },
         {
           "name": "lex.50.50.sren.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2117763,
           "installPath": "bin/lex.50.50.sren.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sr-en/spring-2024_H5GCfsx4SnqOP4YFIQdkdA/exported/lex.50.50.sren.s2t.bin.gz",
           "sourcePath": "models/sr-en/spring-2024_H5GCfsx4SnqOP4YFIQdkdA/exported/lex.50.50.sren.s2t.bin.gz",
@@ -6856,7 +6856,7 @@
       "files": [
         {
           "name": "model.sven.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12847259,
           "installPath": "bin/model.sven.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sv-en/spring-2024_ObaRXwXeSW6HA_-J5_dE-g/exported/model.sven.intgemm.alphas.bin.gz",
           "sourcePath": "models/sv-en/spring-2024_ObaRXwXeSW6HA_-J5_dE-g/exported/model.sven.intgemm.alphas.bin.gz",
@@ -6864,7 +6864,7 @@
         },
         {
           "name": "vocab.sven.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 397625,
           "installPath": "bin/vocab.sven.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sv-en/spring-2024_ObaRXwXeSW6HA_-J5_dE-g/exported/vocab.sven.spm.gz",
           "sourcePath": "models/sv-en/spring-2024_ObaRXwXeSW6HA_-J5_dE-g/exported/vocab.sven.spm.gz",
@@ -6872,7 +6872,7 @@
         },
         {
           "name": "lex.50.50.sven.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2165215,
           "installPath": "bin/lex.50.50.sven.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/sv-en/spring-2024_ObaRXwXeSW6HA_-J5_dE-g/exported/lex.50.50.sven.s2t.bin.gz",
           "sourcePath": "models/sv-en/spring-2024_ObaRXwXeSW6HA_-J5_dE-g/exported/lex.50.50.sven.s2t.bin.gz",
@@ -6888,7 +6888,7 @@
       "files": [
         {
           "name": "model.taen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 23673200,
           "installPath": "bin/model.taen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ta-en/h1-2025_SCQIuddKRXKyysmEsTGv-A/exported/model.taen.intgemm.alphas.bin.gz",
           "sourcePath": "models/ta-en/h1-2025_SCQIuddKRXKyysmEsTGv-A/exported/model.taen.intgemm.alphas.bin.gz",
@@ -6896,7 +6896,7 @@
         },
         {
           "name": "vocab.taen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 446919,
           "installPath": "bin/vocab.taen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ta-en/h1-2025_SCQIuddKRXKyysmEsTGv-A/exported/vocab.taen.spm.gz",
           "sourcePath": "models/ta-en/h1-2025_SCQIuddKRXKyysmEsTGv-A/exported/vocab.taen.spm.gz",
@@ -6904,7 +6904,7 @@
         },
         {
           "name": "lex.50.50.taen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2453155,
           "installPath": "bin/lex.50.50.taen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/ta-en/h1-2025_SCQIuddKRXKyysmEsTGv-A/exported/lex.50.50.taen.s2t.bin.gz",
           "sourcePath": "models/ta-en/h1-2025_SCQIuddKRXKyysmEsTGv-A/exported/lex.50.50.taen.s2t.bin.gz",
@@ -6920,7 +6920,7 @@
       "files": [
         {
           "name": "model.teen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 13202063,
           "installPath": "bin/model.teen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/te-en/h1-2025_YEapi_rWRsSUVTqbBTqupw/exported/model.teen.intgemm.alphas.bin.gz",
           "sourcePath": "models/te-en/h1-2025_YEapi_rWRsSUVTqbBTqupw/exported/model.teen.intgemm.alphas.bin.gz",
@@ -6928,7 +6928,7 @@
         },
         {
           "name": "vocab.teen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 448555,
           "installPath": "bin/vocab.teen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/te-en/h1-2025_YEapi_rWRsSUVTqbBTqupw/exported/vocab.teen.spm.gz",
           "sourcePath": "models/te-en/h1-2025_YEapi_rWRsSUVTqbBTqupw/exported/vocab.teen.spm.gz",
@@ -6936,7 +6936,7 @@
         },
         {
           "name": "lex.50.50.teen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2209444,
           "installPath": "bin/lex.50.50.teen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/te-en/h1-2025_YEapi_rWRsSUVTqbBTqupw/exported/lex.50.50.teen.s2t.bin.gz",
           "sourcePath": "models/te-en/h1-2025_YEapi_rWRsSUVTqbBTqupw/exported/lex.50.50.teen.s2t.bin.gz",
@@ -6952,7 +6952,7 @@
       "files": [
         {
           "name": "model.then.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 22974117,
           "installPath": "bin/model.then.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/th-en/new-opuscleaner-en-th_aIiNAAZbRny4ODcYGOMlEA/exported/model.then.intgemm.alphas.bin.gz",
           "sourcePath": "models/th-en/new-opuscleaner-en-th_aIiNAAZbRny4ODcYGOMlEA/exported/model.then.intgemm.alphas.bin.gz",
@@ -6960,7 +6960,7 @@
         },
         {
           "name": "vocab.then.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 451231,
           "installPath": "bin/vocab.then.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/th-en/new-opuscleaner-en-th_aIiNAAZbRny4ODcYGOMlEA/exported/vocab.then.spm.gz",
           "sourcePath": "models/th-en/new-opuscleaner-en-th_aIiNAAZbRny4ODcYGOMlEA/exported/vocab.then.spm.gz",
@@ -6968,7 +6968,7 @@
         },
         {
           "name": "lex.50.50.then.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2239323,
           "installPath": "bin/lex.50.50.then.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/th-en/new-opuscleaner-en-th_aIiNAAZbRny4ODcYGOMlEA/exported/lex.50.50.then.s2t.bin.gz",
           "sourcePath": "models/th-en/new-opuscleaner-en-th_aIiNAAZbRny4ODcYGOMlEA/exported/lex.50.50.then.s2t.bin.gz",
@@ -6984,7 +6984,7 @@
       "files": [
         {
           "name": "model.tren.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12362908,
           "installPath": "bin/model.tren.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/tr-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/model.tren.intgemm.alphas.bin.gz",
           "sourcePath": "models/tr-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/model.tren.intgemm.alphas.bin.gz",
@@ -6992,7 +6992,7 @@
         },
         {
           "name": "vocab.tren.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 409060,
           "installPath": "bin/vocab.tren.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/tr-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.tren.spm.gz",
           "sourcePath": "models/tr-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/vocab.tren.spm.gz",
@@ -7000,7 +7000,7 @@
         },
         {
           "name": "lex.50.50.tren.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 2470683,
           "installPath": "bin/lex.50.50.tren.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/tr-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.tren.s2t.bin.gz",
           "sourcePath": "models/tr-en/statmt_xxxxxxxxRxSxxxxxxxxxxA/exported/lex.50.50.tren.s2t.bin.gz",
@@ -7016,7 +7016,7 @@
       "files": [
         {
           "name": "model.uken.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12677432,
           "installPath": "bin/model.uken.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/uk-en/spring-2024_WEPBsc-zQWSDn34b5KFscw/exported/model.uken.intgemm.alphas.bin.gz",
           "sourcePath": "models/uk-en/spring-2024_WEPBsc-zQWSDn34b5KFscw/exported/model.uken.intgemm.alphas.bin.gz",
@@ -7024,7 +7024,7 @@
         },
         {
           "name": "vocab.uken.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 415266,
           "installPath": "bin/vocab.uken.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/uk-en/spring-2024_WEPBsc-zQWSDn34b5KFscw/exported/vocab.uken.spm.gz",
           "sourcePath": "models/uk-en/spring-2024_WEPBsc-zQWSDn34b5KFscw/exported/vocab.uken.spm.gz",
@@ -7032,7 +7032,7 @@
         },
         {
           "name": "lex.50.50.uken.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1790588,
           "installPath": "bin/lex.50.50.uken.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/uk-en/spring-2024_WEPBsc-zQWSDn34b5KFscw/exported/lex.50.50.uken.s2t.bin.gz",
           "sourcePath": "models/uk-en/spring-2024_WEPBsc-zQWSDn34b5KFscw/exported/lex.50.50.uken.s2t.bin.gz",
@@ -7048,7 +7048,7 @@
       "files": [
         {
           "name": "model.vien.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 12914609,
           "installPath": "bin/model.vien.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/vi-en/spring-2024_Nc0SHbrgQaiFt4_FmKBXOA/exported/model.vien.intgemm.alphas.bin.gz",
           "sourcePath": "models/vi-en/spring-2024_Nc0SHbrgQaiFt4_FmKBXOA/exported/model.vien.intgemm.alphas.bin.gz",
@@ -7056,7 +7056,7 @@
         },
         {
           "name": "vocab.vien.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 375643,
           "installPath": "bin/vocab.vien.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/vi-en/spring-2024_Nc0SHbrgQaiFt4_FmKBXOA/exported/vocab.vien.spm.gz",
           "sourcePath": "models/vi-en/spring-2024_Nc0SHbrgQaiFt4_FmKBXOA/exported/vocab.vien.spm.gz",
@@ -7064,7 +7064,7 @@
         },
         {
           "name": "lex.50.50.vien.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 1887658,
           "installPath": "bin/lex.50.50.vien.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/vi-en/spring-2024_Nc0SHbrgQaiFt4_FmKBXOA/exported/lex.50.50.vien.s2t.bin.gz",
           "sourcePath": "models/vi-en/spring-2024_Nc0SHbrgQaiFt4_FmKBXOA/exported/lex.50.50.vien.s2t.bin.gz",
@@ -7080,7 +7080,7 @@
       "files": [
         {
           "name": "model.zhen.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 32726806,
           "installPath": "bin/model.zhen.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/zh-en/cjk_retrain_base-memory_cNY_yaJCStGwnTeXgW8A5w/exported/model.zhen.intgemm.alphas.bin.gz",
           "sourcePath": "models/zh-en/cjk_retrain_base-memory_cNY_yaJCStGwnTeXgW8A5w/exported/model.zhen.intgemm.alphas.bin.gz",
@@ -7088,7 +7088,7 @@
         },
         {
           "name": "vocab.zhen.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 738862,
           "installPath": "bin/vocab.zhen.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/zh-en/cjk_retrain_base-memory_cNY_yaJCStGwnTeXgW8A5w/exported/vocab.zhen.spm.gz",
           "sourcePath": "models/zh-en/cjk_retrain_base-memory_cNY_yaJCStGwnTeXgW8A5w/exported/vocab.zhen.spm.gz",
@@ -7096,7 +7096,7 @@
         },
         {
           "name": "lex.50.50.zhen.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 4822158,
           "installPath": "bin/lex.50.50.zhen.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/zh-en/cjk_retrain_base-memory_cNY_yaJCStGwnTeXgW8A5w/exported/lex.50.50.zhen.s2t.bin.gz",
           "sourcePath": "models/zh-en/cjk_retrain_base-memory_cNY_yaJCStGwnTeXgW8A5w/exported/lex.50.50.zhen.s2t.bin.gz",
@@ -7112,7 +7112,7 @@
       "files": [
         {
           "name": "model.zh_hanten.intgemm.alphas.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 33653648,
           "installPath": "bin/model.zh_hanten.intgemm.alphas.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/model.zh_hanten.intgemm.alphas.bin.gz",
           "sourcePath": "models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/model.zh_hanten.intgemm.alphas.bin.gz",
@@ -7120,7 +7120,7 @@
         },
         {
           "name": "srcvocab.zh_hanten.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 423691,
           "installPath": "bin/srcvocab.zh_hanten.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/srcvocab.zh_hanten.spm.gz",
           "sourcePath": "models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/srcvocab.zh_hanten.spm.gz",
@@ -7128,7 +7128,7 @@
         },
         {
           "name": "trgvocab.zh_hanten.spm",
-          "sizeBytes": 0,
+          "sizeBytes": 408143,
           "installPath": "bin/trgvocab.zh_hanten.spm",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/trgvocab.zh_hanten.spm.gz",
           "sourcePath": "models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/trgvocab.zh_hanten.spm.gz",
@@ -7136,7 +7136,7 @@
         },
         {
           "name": "lex.50.50.zh_hanten.s2t.bin",
-          "sizeBytes": 0,
+          "sizeBytes": 3268812,
           "installPath": "bin/lex.50.50.zh_hanten.s2t.bin",
           "url": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/lex.50.50.zh_hanten.s2t.bin.gz",
           "sourcePath": "models/zh_hant-en/zh_hant_openlid_zh_tw_lr0002_WJi5Ozi7SZWC6hgfD5GhTA/exported/lex.50.50.zh_hanten.s2t.bin.gz",
@@ -7170,7 +7170,7 @@
       "files": [
         {
           "name": "ar_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 478165,
           "installPath": "bin/espeak-ng-data/ar_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/ar_dict",
           "mirrorPath": "tts/1/espeak-ng-data/ar_dict"
@@ -7186,7 +7186,7 @@
       "files": [
         {
           "name": "bg_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 87051,
           "installPath": "bin/espeak-ng-data/bg_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/bg_dict",
           "mirrorPath": "tts/1/espeak-ng-data/bg_dict"
@@ -7202,7 +7202,7 @@
       "files": [
         {
           "name": "ca_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 310331,
           "installPath": "bin/espeak-ng-data/ca_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/ca_dict",
           "mirrorPath": "tts/1/espeak-ng-data/ca_dict"
@@ -7218,7 +7218,7 @@
       "files": [
         {
           "name": "cmn_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 1566347,
           "installPath": "bin/espeak-ng-data/cmn_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/cmn_dict",
           "mirrorPath": "tts/1/espeak-ng-data/cmn_dict"
@@ -7234,7 +7234,7 @@
       "files": [
         {
           "name": "cs_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 50455,
           "installPath": "bin/espeak-ng-data/cs_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/cs_dict",
           "mirrorPath": "tts/1/espeak-ng-data/cs_dict"
@@ -7250,7 +7250,7 @@
       "files": [
         {
           "name": "da_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 245287,
           "installPath": "bin/espeak-ng-data/da_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/da_dict",
           "mirrorPath": "tts/1/espeak-ng-data/da_dict"
@@ -7266,7 +7266,7 @@
       "files": [
         {
           "name": "de_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 69277,
           "installPath": "bin/espeak-ng-data/de_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/de_dict",
           "mirrorPath": "tts/1/espeak-ng-data/de_dict"
@@ -7282,7 +7282,7 @@
       "files": [
         {
           "name": "el_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 72841,
           "installPath": "bin/espeak-ng-data/el_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/el_dict",
           "mirrorPath": "tts/1/espeak-ng-data/el_dict"
@@ -7298,7 +7298,7 @@
       "files": [
         {
           "name": "en_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 168204,
           "installPath": "bin/espeak-ng-data/en_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/en_dict",
           "mirrorPath": "tts/1/espeak-ng-data/en_dict"
@@ -7314,7 +7314,7 @@
       "files": [
         {
           "name": "es_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 49285,
           "installPath": "bin/espeak-ng-data/es_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/es_dict",
           "mirrorPath": "tts/1/espeak-ng-data/es_dict"
@@ -7330,7 +7330,7 @@
       "files": [
         {
           "name": "fa_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 292907,
           "installPath": "bin/espeak-ng-data/fa_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/fa_dict",
           "mirrorPath": "tts/1/espeak-ng-data/fa_dict"
@@ -7346,7 +7346,7 @@
       "files": [
         {
           "name": "fi_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 43928,
           "installPath": "bin/espeak-ng-data/fi_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/fi_dict",
           "mirrorPath": "tts/1/espeak-ng-data/fi_dict"
@@ -7362,7 +7362,7 @@
       "files": [
         {
           "name": "fr_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 63727,
           "installPath": "bin/espeak-ng-data/fr_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/fr_dict",
           "mirrorPath": "tts/1/espeak-ng-data/fr_dict"
@@ -7378,7 +7378,7 @@
       "files": [
         {
           "name": "hi_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 92143,
           "installPath": "bin/espeak-ng-data/hi_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/hi_dict",
           "mirrorPath": "tts/1/espeak-ng-data/hi_dict"
@@ -7394,7 +7394,7 @@
       "files": [
         {
           "name": "hu_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 177886,
           "installPath": "bin/espeak-ng-data/hu_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/hu_dict",
           "mirrorPath": "tts/1/espeak-ng-data/hu_dict"
@@ -7410,7 +7410,7 @@
       "files": [
         {
           "name": "id_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 43458,
           "installPath": "bin/espeak-ng-data/id_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/id_dict",
           "mirrorPath": "tts/1/espeak-ng-data/id_dict"
@@ -7426,7 +7426,7 @@
       "files": [
         {
           "name": "is_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 44354,
           "installPath": "bin/espeak-ng-data/is_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/is_dict",
           "mirrorPath": "tts/1/espeak-ng-data/is_dict"
@@ -7442,7 +7442,7 @@
       "files": [
         {
           "name": "it_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 154408,
           "installPath": "bin/espeak-ng-data/it_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/it_dict",
           "mirrorPath": "tts/1/espeak-ng-data/it_dict"
@@ -7458,7 +7458,7 @@
       "files": [
         {
           "name": "ja_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 47652,
           "installPath": "bin/espeak-ng-data/ja_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/ja_dict",
           "mirrorPath": "tts/1/espeak-ng-data/ja_dict"
@@ -7474,7 +7474,7 @@
       "files": [
         {
           "name": "ko_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 47523,
           "installPath": "bin/espeak-ng-data/ko_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/ko_dict",
           "mirrorPath": "tts/1/espeak-ng-data/ko_dict"
@@ -7490,7 +7490,7 @@
       "files": [
         {
           "name": "lv_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 66337,
           "installPath": "bin/espeak-ng-data/lv_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/lv_dict",
           "mirrorPath": "tts/1/espeak-ng-data/lv_dict"
@@ -7506,7 +7506,7 @@
       "files": [
         {
           "name": "ml_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 92345,
           "installPath": "bin/espeak-ng-data/ml_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/ml_dict",
           "mirrorPath": "tts/1/espeak-ng-data/ml_dict"
@@ -7522,7 +7522,7 @@
       "files": [
         {
           "name": "nl_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 65396,
           "installPath": "bin/espeak-ng-data/nl_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/nl_dict",
           "mirrorPath": "tts/1/espeak-ng-data/nl_dict"
@@ -7538,7 +7538,7 @@
       "files": [
         {
           "name": "no_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 4178,
           "installPath": "bin/espeak-ng-data/no_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/no_dict",
           "mirrorPath": "tts/1/espeak-ng-data/no_dict"
@@ -7554,7 +7554,7 @@
       "files": [
         {
           "name": "pl_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 76620,
           "installPath": "bin/espeak-ng-data/pl_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/pl_dict",
           "mirrorPath": "tts/1/espeak-ng-data/pl_dict"
@@ -7570,7 +7570,7 @@
       "files": [
         {
           "name": "pt_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 76389,
           "installPath": "bin/espeak-ng-data/pt_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/pt_dict",
           "mirrorPath": "tts/1/espeak-ng-data/pt_dict"
@@ -7586,7 +7586,7 @@
       "files": [
         {
           "name": "ro_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 68538,
           "installPath": "bin/espeak-ng-data/ro_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/ro_dict",
           "mirrorPath": "tts/1/espeak-ng-data/ro_dict"
@@ -7602,7 +7602,7 @@
       "files": [
         {
           "name": "ru_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 8538195,
           "installPath": "bin/espeak-ng-data/ru_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/ru_dict",
           "mirrorPath": "tts/1/espeak-ng-data/ru_dict"
@@ -7618,7 +7618,7 @@
       "files": [
         {
           "name": "sk_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 50002,
           "installPath": "bin/espeak-ng-data/sk_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/sk_dict",
           "mirrorPath": "tts/1/espeak-ng-data/sk_dict"
@@ -7634,7 +7634,7 @@
       "files": [
         {
           "name": "sl_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 45047,
           "installPath": "bin/espeak-ng-data/sl_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/sl_dict",
           "mirrorPath": "tts/1/espeak-ng-data/sl_dict"
@@ -7650,7 +7650,7 @@
       "files": [
         {
           "name": "sq_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 45003,
           "installPath": "bin/espeak-ng-data/sq_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/sq_dict",
           "mirrorPath": "tts/1/espeak-ng-data/sq_dict"
@@ -7666,7 +7666,7 @@
       "files": [
         {
           "name": "sr_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 46832,
           "installPath": "bin/espeak-ng-data/sr_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/sr_dict",
           "mirrorPath": "tts/1/espeak-ng-data/sr_dict"
@@ -7682,7 +7682,7 @@
       "files": [
         {
           "name": "sv_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 47836,
           "installPath": "bin/espeak-ng-data/sv_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/sv_dict",
           "mirrorPath": "tts/1/espeak-ng-data/sv_dict"
@@ -7698,7 +7698,7 @@
       "files": [
         {
           "name": "te_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 94837,
           "installPath": "bin/espeak-ng-data/te_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/te_dict",
           "mirrorPath": "tts/1/espeak-ng-data/te_dict"
@@ -7714,7 +7714,7 @@
       "files": [
         {
           "name": "tr_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 46793,
           "installPath": "bin/espeak-ng-data/tr_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/tr_dict",
           "mirrorPath": "tts/1/espeak-ng-data/tr_dict"
@@ -7730,7 +7730,7 @@
       "files": [
         {
           "name": "uk_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 3492,
           "installPath": "bin/espeak-ng-data/uk_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/uk_dict",
           "mirrorPath": "tts/1/espeak-ng-data/uk_dict"
@@ -7746,7 +7746,7 @@
       "files": [
         {
           "name": "vi_dict",
-          "sizeBytes": 0,
+          "sizeBytes": 52608,
           "installPath": "bin/espeak-ng-data/vi_dict",
           "url": "https://offline-translator.davidv.dev/tts/1/espeak-ng-data/vi_dict",
           "mirrorPath": "tts/1/espeak-ng-data/vi_dict"
@@ -11254,7 +11254,7 @@
       "files": [
         {
           "name": "adguard-mobile.txt",
-          "sizeBytes": 0,
+          "sizeBytes": 504571,
           "installPath": "adblock/adguard-mobile.txt",
           "url": "https://filters.adtidy.org/extension/ublock/filters/11.txt"
         }
@@ -11271,7 +11271,7 @@
       "files": [
         {
           "name": "easylist.txt",
-          "sizeBytes": 0,
+          "sizeBytes": 2267870,
           "installPath": "adblock/easylist.txt",
           "url": "https://easylist.to/easylist/easylist.txt"
         }
@@ -11288,7 +11288,7 @@
       "files": [
         {
           "name": "easyprivacy.txt",
-          "sizeBytes": 0,
+          "sizeBytes": 1481604,
           "installPath": "adblock/easyprivacy.txt",
           "url": "https://easylist.to/easylist/easyprivacy.txt"
         }
@@ -11305,7 +11305,7 @@
       "files": [
         {
           "name": "fanboy-annoyance.txt",
-          "sizeBytes": 0,
+          "sizeBytes": 1649123,
           "installPath": "adblock/fanboy-annoyance.txt",
           "url": "https://easylist.to/easylist/fanboy-annoyance.txt"
         }
@@ -11322,7 +11322,7 @@
       "files": [
         {
           "name": "ublock-filters.txt",
-          "sizeBytes": 0,
+          "sizeBytes": 477175,
           "installPath": "adblock/ublock-filters.txt",
           "url": "https://ublockorigin.github.io/uAssets/filters/filters.txt"
         }
@@ -11339,7 +11339,7 @@
       "files": [
         {
           "name": "ublock-unbreak.txt",
-          "sizeBytes": 0,
+          "sizeBytes": 273829,
           "installPath": "adblock/ublock-unbreak.txt",
           "url": "https://ublockorigin.github.io/uAssets/filters/unbreak.txt"
         }

--- a/catalog_sources/source_catalog.json
+++ b/catalog_sources/source_catalog.json
@@ -1,13 +1,13 @@
 {
   "formatVersion": 2,
-  "generatedAt": 1776550317,
+  "generatedAt": 1777135794,
   "translationModelsBaseUrl": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data",
   "tesseractModelsBaseUrl": "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main",
   "dictionaryBaseUrl": "https://offline-translator.davidv.dev/dictionaries",
   "dictionaryVersion": 1,
   "sources": {
     "languageIndexVersion": 1,
-    "languageIndexUpdatedAt": 1776550317,
+    "languageIndexUpdatedAt": 1777135794,
     "dictionaryIndexVersion": 1,
     "dictionaryIndexUpdatedAt": 1774864382,
     "gcsModelsUrl": "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/db/models.json",
@@ -11247,6 +11247,108 @@
       "dependsOn": [
         "tts-espeak-dict-cmn"
       ]
+    },
+    "support-adblock-adguard-mobile": {
+      "feature": "support",
+      "kind": "adblock",
+      "files": [
+        {
+          "name": "adguard-mobile.txt",
+          "sizeBytes": 0,
+          "installPath": "adblock/adguard-mobile.txt",
+          "url": "https://filters.adtidy.org/extension/ublock/filters/11.txt"
+        }
+      ],
+      "dependsOn": [],
+      "metadata": {
+        "listId": "adguard-mobile",
+        "description": "AdGuard Mobile Ads — mobile-specific ad slots and tracker patterns."
+      }
+    },
+    "support-adblock-easylist": {
+      "feature": "support",
+      "kind": "adblock",
+      "files": [
+        {
+          "name": "easylist.txt",
+          "sizeBytes": 0,
+          "installPath": "adblock/easylist.txt",
+          "url": "https://easylist.to/easylist/easylist.txt"
+        }
+      ],
+      "dependsOn": [],
+      "metadata": {
+        "listId": "easylist",
+        "description": "EasyList — primary advertising filter list."
+      }
+    },
+    "support-adblock-easyprivacy": {
+      "feature": "support",
+      "kind": "adblock",
+      "files": [
+        {
+          "name": "easyprivacy.txt",
+          "sizeBytes": 0,
+          "installPath": "adblock/easyprivacy.txt",
+          "url": "https://easylist.to/easylist/easyprivacy.txt"
+        }
+      ],
+      "dependsOn": [],
+      "metadata": {
+        "listId": "easyprivacy",
+        "description": "EasyPrivacy — tracking and analytics filter list."
+      }
+    },
+    "support-adblock-fanboy-annoyance": {
+      "feature": "support",
+      "kind": "adblock",
+      "files": [
+        {
+          "name": "fanboy-annoyance.txt",
+          "sizeBytes": 0,
+          "installPath": "adblock/fanboy-annoyance.txt",
+          "url": "https://easylist.to/easylist/fanboy-annoyance.txt"
+        }
+      ],
+      "dependsOn": [],
+      "metadata": {
+        "listId": "fanboy-annoyance",
+        "description": "Fanboy's Annoyances — cookie banners, social widgets, sticky video."
+      }
+    },
+    "support-adblock-ublock-filters": {
+      "feature": "support",
+      "kind": "adblock",
+      "files": [
+        {
+          "name": "ublock-filters.txt",
+          "sizeBytes": 0,
+          "installPath": "adblock/ublock-filters.txt",
+          "url": "https://ublockorigin.github.io/uAssets/filters/filters.txt"
+        }
+      ],
+      "dependsOn": [],
+      "metadata": {
+        "listId": "ublock-filters",
+        "description": "uBlock Origin filters — cosmetic supplement to EasyList."
+      }
+    },
+    "support-adblock-ublock-unbreak": {
+      "feature": "support",
+      "kind": "adblock",
+      "files": [
+        {
+          "name": "ublock-unbreak.txt",
+          "sizeBytes": 0,
+          "installPath": "adblock/ublock-unbreak.txt",
+          "url": "https://ublockorigin.github.io/uAssets/filters/unbreak.txt"
+        }
+      ],
+      "dependsOn": [],
+      "metadata": {
+        "listId": "ublock-unbreak",
+        "description": "uBlock Origin unbreak — exceptions to fix sites broken by other lists."
+      }
     }
   }
 }

--- a/catalog_upstream.py
+++ b/catalog_upstream.py
@@ -5,6 +5,63 @@ import catalog_mirror
 import catalog_tts
 
 
+ADBLOCK_PACK_KIND = "adblock"
+
+ADBLOCK_LISTS = {
+    "easylist": {
+        "url": "https://easylist.to/easylist/easylist.txt",
+        "filename": "easylist.txt",
+        "description": "EasyList — primary advertising filter list.",
+    },
+    "easyprivacy": {
+        "url": "https://easylist.to/easylist/easyprivacy.txt",
+        "filename": "easyprivacy.txt",
+        "description": "EasyPrivacy — tracking and analytics filter list.",
+    },
+    "fanboy-annoyance": {
+        "url": "https://easylist.to/easylist/fanboy-annoyance.txt",
+        "filename": "fanboy-annoyance.txt",
+        "description": "Fanboy's Annoyances — cookie banners, social widgets, sticky video.",
+    },
+    "ublock-filters": {
+        "url": "https://ublockorigin.github.io/uAssets/filters/filters.txt",
+        "filename": "ublock-filters.txt",
+        "description": "uBlock Origin filters — cosmetic supplement to EasyList.",
+    },
+    "ublock-unbreak": {
+        "url": "https://ublockorigin.github.io/uAssets/filters/unbreak.txt",
+        "filename": "ublock-unbreak.txt",
+        "description": "uBlock Origin unbreak — exceptions to fix sites broken by other lists.",
+    },
+    "adguard-mobile": {
+        "url": "https://filters.adtidy.org/extension/ublock/filters/11.txt",
+        "filename": "adguard-mobile.txt",
+        "description": "AdGuard Mobile Ads — mobile-specific ad slots and tracker patterns.",
+    },
+}
+
+
+def add_adblock_packs(catalog: dict) -> None:
+    for list_id, info in sorted(ADBLOCK_LISTS.items()):
+        catalog["packs"][f"support-adblock-{list_id}"] = {
+            "feature": "support",
+            "kind": ADBLOCK_PACK_KIND,
+            "files": [
+                {
+                    "name": info["filename"],
+                    "sizeBytes": 0,
+                    "installPath": f"adblock/{info['filename']}",
+                    "url": info["url"],
+                }
+            ],
+            "dependsOn": [],
+            "metadata": {
+                "listId": list_id,
+                "description": info["description"],
+            },
+        }
+
+
 MODELS_MANIFEST_URL = "https://storage.googleapis.com/moz-fx-translations-data--303e-prod-translations-data/db/models.json"
 TESSERACT_BASE_URL = "https://raw.githubusercontent.com/tesseract-ocr/tessdata_fast/refs/heads/main"
 DICTIONARY_BASE_URL = "https://offline-translator.davidv.dev/dictionaries"
@@ -361,6 +418,7 @@ def build_source_catalog(
         tts_version=tts_version,
         espeak_core_zip_size=espeak_core_zip_size,
     )
+    add_adblock_packs(catalog)
     catalog_mirror.apply_mirror_paths(catalog)
     catalog.setdefault("sources", {})
     catalog["sources"].update(

--- a/download_bucket.py
+++ b/download_bucket.py
@@ -35,6 +35,7 @@ class DownloadEntry:
     url: str
     dest: Path
     size_bytes: int | None
+    refresh_always: bool
 
 
 def known_size(size_bytes: int | None) -> int | None:
@@ -149,12 +150,14 @@ def build_download_entries(manifest: dict, output_dir: Path) -> list[DownloadEnt
         feature = pack.get("feature", "misc")
         for file_info in pack.get("files", []):
             dest = resolve_destination(pack, file_info, output_dir)
+            size_bytes = known_size(file_info.get("sizeBytes"))
             entry = DownloadEntry(
                 pack_id=pack_id,
                 feature=feature,
                 url=file_info["url"],
                 dest=dest,
-                size_bytes=known_size(file_info.get("sizeBytes")),
+                size_bytes=size_bytes,
+                refresh_always=pack.get("kind") == catalog_adblock.ADBLOCK_KIND or size_bytes is None,
             )
 
             existing = entries_by_dest.get(dest)
@@ -179,7 +182,7 @@ def summarize(entries: Iterable[DownloadEntry], output_dir: Path) -> tuple[int, 
     for entry in entries:
         total_files += 1
         total_bytes += entry.size_bytes or 0
-        if entry.dest.exists():
+        if should_skip(entry):
             present_files += 1
             present_bytes += entry.size_bytes or 0
         else:
@@ -205,7 +208,26 @@ def format_size(num_bytes: int) -> str:
 
 
 def should_skip(entry: DownloadEntry) -> bool:
-    return entry.dest.exists()
+    return entry.dest.exists() and not entry.refresh_always
+
+
+def update_manifest_sizes(manifest: dict, output_dir: Path, manifest_path: Path) -> None:
+    changed = False
+    for pack in manifest.get("packs", {}).values():
+        refresh_pack = pack.get("kind") == catalog_adblock.ADBLOCK_KIND
+        for file_info in pack.get("files", []):
+            dest = resolve_destination(pack, file_info, output_dir)
+            if not dest.exists():
+                continue
+            current_size = file_info.get("sizeBytes")
+            actual_size = dest.stat().st_size
+            if refresh_pack or not isinstance(current_size, int) or current_size <= 0:
+                if current_size != actual_size:
+                    file_info["sizeBytes"] = actual_size
+                    changed = True
+    if changed:
+        manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        print(f"updated_manifest_sizes={manifest_path}")
 
 
 def download_once(entry: DownloadEntry, timeout: int) -> str:
@@ -297,6 +319,7 @@ async def main() -> int:
         if result != 0:
             return result
 
+    update_manifest_sizes(manifest, args.output, args.manifest)
     adblock_size = await asyncio.to_thread(catalog_adblock.build_adblock_zip, manifest, args.output)
     if adblock_size > 0:
         print(f"adblock_bundle={catalog_adblock.adblock_bundle_path(args.output)}")

--- a/download_bucket.py
+++ b/download_bucket.py
@@ -20,6 +20,7 @@ if str(TRANSLATOR_DIR) not in sys.path:
     sys.path.insert(0, str(TRANSLATOR_DIR))
 
 import catalog_mirror
+import catalog_adblock
 
 
 DEFAULT_MANIFEST = SCRIPT_DIR / "catalog_sources/source_catalog.json"
@@ -291,9 +292,17 @@ async def main() -> int:
         return 0
     if missing_files == 0:
         print("All files already present.")
-        return 0
+    else:
+        result = await fetch_all(entries, args.concurrency, args.timeout, args.retries, args.verbose)
+        if result != 0:
+            return result
 
-    return await fetch_all(entries, args.concurrency, args.timeout, args.retries, args.verbose)
+    adblock_size = await asyncio.to_thread(catalog_adblock.build_adblock_zip, manifest, args.output)
+    if adblock_size > 0:
+        print(f"adblock_bundle={catalog_adblock.adblock_bundle_path(args.output)}")
+        print(f"adblock_bundle_size={adblock_size}")
+        print(f"adblock_bundle_size_pretty={format_size(adblock_size)}")
+    return 0
 
 
 if __name__ == "__main__":

--- a/download_bucket.py
+++ b/download_bucket.py
@@ -90,6 +90,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Print every resolved file path in dry-run mode and every completed file in download mode.",
     )
+    parser.add_argument(
+        "--refresh-adblock",
+        action="store_true",
+        help="Re-download adblock source lists even when they already exist.",
+    )
     return parser.parse_args()
 
 
@@ -143,7 +148,7 @@ def resolve_destination(pack: dict, file_info: dict, output_dir: Path) -> Path:
     return output_dir / feature / relative
 
 
-def build_download_entries(manifest: dict, output_dir: Path) -> list[DownloadEntry]:
+def build_download_entries(manifest: dict, output_dir: Path, refresh_adblock: bool) -> list[DownloadEntry]:
     entries_by_dest: dict[Path, DownloadEntry] = {}
 
     for pack_id, pack in manifest.get("packs", {}).items():
@@ -157,7 +162,7 @@ def build_download_entries(manifest: dict, output_dir: Path) -> list[DownloadEnt
                 url=file_info["url"],
                 dest=dest,
                 size_bytes=size_bytes,
-                refresh_always=pack.get("kind") == catalog_adblock.ADBLOCK_KIND or size_bytes is None,
+                refresh_always=refresh_adblock and pack.get("kind") == catalog_adblock.ADBLOCK_KIND,
             )
 
             existing = entries_by_dest.get(dest)
@@ -221,7 +226,7 @@ def update_manifest_sizes(manifest: dict, output_dir: Path, manifest_path: Path)
                 continue
             current_size = file_info.get("sizeBytes")
             actual_size = dest.stat().st_size
-            if refresh_pack or not isinstance(current_size, int) or current_size <= 0:
+            if not isinstance(current_size, int) or current_size <= 0:
                 if current_size != actual_size:
                     file_info["sizeBytes"] = actual_size
                     changed = True
@@ -298,7 +303,7 @@ async def fetch_all(entries: list[DownloadEntry], concurrency: int, timeout: int
 async def main() -> int:
     args = parse_args()
     manifest = load_manifest(args.manifest)
-    entries = build_download_entries(manifest, args.output)
+    entries = build_download_entries(manifest, args.output, args.refresh_adblock)
     total_files, total_bytes, missing_files, missing_bytes = summarize(entries, args.output)
     print(f"size_pretty={format_size(total_bytes)}")
     print(f"bytes_to_download_pretty={format_size(missing_bytes)}")

--- a/fastlane/metadata/android/en-US/changelogs/141.txt
+++ b/fastlane/metadata/android/en-US/changelogs/141.txt
@@ -1,2 +1,6 @@
 - Small UI fixes
 - Improve TTS pacing
+- Implement tap-to-translate notification
+- Implement quick settings launcher
+- Implement "translate website" - share a URL and it will be translated
+- Fix use-after-free on CLD2 causing crash on GrapheneOS

--- a/fastlane/metadata/android/en-US/changelogs/142.txt
+++ b/fastlane/metadata/android/en-US/changelogs/142.txt
@@ -1,2 +1,6 @@
 - Small UI fixes
 - Improve TTS pacing
+- Implement tap-to-translate notification
+- Implement quick settings launcher
+- Implement "translate website" - share a URL and it will be translated
+- Fix use-after-free on CLD2 causing crash on GrapheneOS

--- a/generate_index.py
+++ b/generate_index.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import catalog_base
+import catalog_adblock
 import catalog_mirror
 import catalog_tts
 import catalog_upstream
@@ -135,6 +136,8 @@ def build_public_catalog(source_catalog: dict, bucket_dir: Path, base_url: str, 
     published.pop("dictionaryBaseUrl", None)
 
     missing_paths = []
+
+    catalog_adblock.publish_adblock_pack(published, bucket_dir, base_url)
 
     for pack in published.get("packs", {}).values():
         for file_info in pack.get("files", []):


### PR DESCRIPTION
Closes #126 

https://github.com/user-attachments/assets/a8518ffd-2f81-4a15-8828-46ac96d553b6

This PR adds support for receiving URL shares from other apps, opening them in a webview and translating the content.

Supports reader mode via [Readability.js](https://github.com/mozilla/readability), supports ad blocking via Brave's [adblock](https://github.com/brave/adblock-rust/) crate.

In settings, there's a button to download the (2MB) lists for ad-blocking. Maybe I'll add some settings for readability in the future.