### PR TITLE
fix(browser): log main-frame WebView load errors via onReceivedError

### DIFF
--- a/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
+++ b/app/src/main/java/dev/davidv/translator/browser/BrowserActivity.kt
@@ -20,6 +20,7 @@ package dev.davidv.translator.browser
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.graphics.Bitmap
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.ContextThemeWrapper
@@ -28,6 +29,7 @@ import android.view.ViewGroup
 import android.webkit.ConsoleMessage
 import android.webkit.CookieManager
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebStorage
@@ -510,6 +512,21 @@ private fun BrowserWebView(
                   ) ?: return null
                 if (!verdict.matched || verdict.exception) return null
                 return WebResourceResponse("text/plain", "utf-8", ByteArray(0).inputStream())
+              }
+
+              override fun onReceivedError(
+                view: WebView?,
+                request: WebResourceRequest?,
+                error: WebResourceError?,
+              ) {
+                super.onReceivedError(view, request, error)
+                if (request?.isForMainFrame != true) return
+                val description = if (Build.VERSION.SDK_INT >= 23) {
+                  error?.description?.toString().orEmpty()
+                } else {
+                  ""
+                }
+                Log.w("BrowserActivity", "WebView failed to load ${request.url}: $description")
               }
             }
 


### PR DESCRIPTION
Closes #177.

`BrowserActivity` sets up the in-app browser's `WebViewClient` and overrides `onPageStarted`, `onPageFinished` and `shouldInterceptRequest`, but not `onReceivedError`. When the main-frame page fails to load (DNS, certificate, offline, 4xx/5xx) the WebView is left blank with nothing in logcat to debug from, even though `Log.i("AdblockManager", ...)` already covers the happy path.

Add a main-frame-only `onReceivedError` that logs the failing URL + description through `Log.w` so the failure leaves a trace:

```kotlin
override fun onReceivedError(
    view: WebView?,
    request: WebResourceRequest?,
    error: WebResourceError?,
) {
    super.onReceivedError(view, request, error)
    if (request?.isForMainFrame != true) return
    val description = if (Build.VERSION.SDK_INT >= 23) {
        error?.description?.toString().orEmpty()
    } else {
        ""
    }
    Log.w("BrowserActivity", "WebView failed to load ${request.url}: $description")
}
```

`isForMainFrame` keeps blocked sub-resources (including everything `shouldInterceptRequest` already kills for adblock) from spamming the log.
