### PR TITLE
Prevent Zip Slip (CWE-22) when extracting downloaded packs

### DIFF
--- a/app/src/main/java/dev/davidv/translator/DownloadService.kt
+++ b/app/src/main/java/dev/davidv/translator/DownloadService.kt
@@ -1234,23 +1234,15 @@ class DownloadService : Service() {
           ?.parentFile
           ?.name
 
-      fun normalizedEntryName(entryName: String): String {
-        val trimmed = entryName.trimStart('/').removePrefix("./")
-        if (trimmed.isBlank()) return trimmed
-        val rootName = installRootName ?: return trimmed
-        return if (trimmed == rootName || trimmed.startsWith("$rootName/")) {
-          trimmed
-        } else {
-          "$rootName/$trimmed"
-        }
-      }
-
       val managedPaths = mutableSetOf<File>()
       ZipFile(archiveFile).use { zipFile ->
         val entries = zipFile.entries()
         while (entries.hasMoreElements()) {
           val entry = entries.nextElement()
-          val normalizedName = normalizedEntryName(entry.name)
+          // Skip entries that would escape extractTo so they cannot influence
+          // which existing directories get deleted below (Zip Slip, CWE-22).
+          if (safeZipEntryTarget(extractTo, entry.name, installRootName) == null) continue
+          val normalizedName = normalizeZipEntryName(entry.name, installRootName)
           val parts = normalizedName.split('/').filter { it.isNotBlank() }
           if (parts.size >= 2) {
             managedPaths += File(extractTo, "${parts[0]}/${parts[1]}")
@@ -1270,8 +1262,12 @@ class DownloadService : Service() {
       ZipInputStream(archiveFile.inputStream().buffered()).use { zipInput ->
         var entry = zipInput.nextEntry
         while (entry != null) {
-          val output = File(extractTo, normalizedEntryName(entry.name))
-          if (entry.isDirectory) {
+          val output = safeZipEntryTarget(extractTo, entry.name, installRootName)
+          if (output == null) {
+            // Zip Slip guard: an entry resolving outside extractTo (via `..`, an
+            // absolute path, etc.) is dropped rather than written.
+            Log.w("DownloadService", "Skipping unsafe zip entry: ${entry.name}")
+          } else if (entry.isDirectory) {
             output.mkdirs()
           } else {
             output.parentFile?.mkdirs()
@@ -1374,3 +1370,58 @@ private const val DOC_DETECT_KIND = "doc_detect"
 // Not a catalog pack kind: the NewSupportAvailable event key for a finished
 // repair download, so availability listeners refresh like any support install.
 private const val REPAIR_KIND = "repair"
+
+/**
+ * Normalizes a zip entry name the way pack extraction expects: it strips a
+ * leading `/` or `./` and, when the pack has a known install root
+ * ([installRootName]), re-roots the entry under it so archives with or without a
+ * top-level directory land in the same place.
+ *
+ * This is purely a naming transform — it does NOT make the result safe to join
+ * onto the extraction directory (it does not neutralise `..` segments). Use
+ * [safeZipEntryTarget] to obtain a path that is guaranteed to stay inside the
+ * target directory.
+ */
+internal fun normalizeZipEntryName(
+  entryName: String,
+  installRootName: String?,
+): String {
+  val trimmed = entryName.trimStart('/').removePrefix("./")
+  if (trimmed.isBlank()) return trimmed
+  val rootName = installRootName ?: return trimmed
+  return if (trimmed == rootName || trimmed.startsWith("$rootName/")) {
+    trimmed
+  } else {
+    "$rootName/$trimmed"
+  }
+}
+
+/**
+ * Resolves a zip entry to the concrete file it would extract to under
+ * [extractTo], or returns `null` when the entry must be skipped because it is
+ * blank or because it would resolve outside [extractTo] via `..` segments, an
+ * absolute path, or similar.
+ *
+ * This is the Zip Slip guard (CWE-22): [normalizeZipEntryName] only trims a
+ * leading `/`/`./` and, when a root is known, prefixes it — which still lets a
+ * name like `../../x` (or `root/../../x`) escape the target. Comparing the
+ * canonicalised target against the canonicalised [extractTo] closes that hole so
+ * a malicious or corrupt archive can never write (or trigger a delete) outside
+ * the intended directory.
+ */
+internal fun safeZipEntryTarget(
+  extractTo: File,
+  entryName: String,
+  installRootName: String?,
+): File? {
+  val normalized = normalizeZipEntryName(entryName, installRootName)
+  if (normalized.isBlank()) return null
+  val target = File(extractTo, normalized)
+  val root = extractTo.canonicalFile
+  val canonical = target.canonicalFile
+  return if (canonical == root || canonical.path.startsWith(root.path + File.separator)) {
+    target
+  } else {
+    null
+  }
+}

--- a/app/src/test/java/dev/davidv/translator/ZipEntrySanitizationTest.kt
+++ b/app/src/test/java/dev/davidv/translator/ZipEntrySanitizationTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ZipEntrySanitizationTest {
+  @get:Rule
+  val temp = TemporaryFolder()
+
+  private fun extractTo(): File = temp.newFolder("models")
+
+  private fun assertContained(
+    root: File,
+    target: File?,
+  ) {
+    assertNotNull("expected a resolved target", target)
+    val canonicalRoot = root.canonicalPath
+    val canonicalTarget = target!!.canonicalPath
+    assertTrue(
+      "expected $canonicalTarget to stay under $canonicalRoot",
+      canonicalTarget == canonicalRoot || canonicalTarget.startsWith(canonicalRoot + File.separator),
+    )
+  }
+
+  // --- normalizeZipEntryName: pure naming transform -----------------------
+
+  @Test
+  fun `normalize strips leading slash and dot-slash`() {
+    assertEquals("a/b.bin", normalizeZipEntryName("/a/b.bin", null))
+    assertEquals("a/b.bin", normalizeZipEntryName("./a/b.bin", null))
+  }
+
+  @Test
+  fun `normalize re-roots entries under the install root`() {
+    assertEquals("models/en-es/model.bin", normalizeZipEntryName("en-es/model.bin", "models"))
+    // Already rooted entries are left as-is.
+    assertEquals("models/en-es/model.bin", normalizeZipEntryName("models/en-es/model.bin", "models"))
+  }
+
+  // --- safeZipEntryTarget: Zip Slip (CWE-22) guard ------------------------
+
+  @Test
+  fun `benign entry resolves inside extractTo`() {
+    val root = extractTo()
+    val target = safeZipEntryTarget(root, "en-es/model.bin", "models")
+    assertContained(root, target)
+    assertEquals(File(root, "models/en-es/model.bin").canonicalPath, target!!.canonicalPath)
+  }
+
+  @Test
+  fun `traversal entry without install root is rejected`() {
+    val root = extractTo()
+    // Would have resolved to <parent>/databases/evil.db before the guard.
+    assertNull(safeZipEntryTarget(root, "../../../databases/evil.db", null))
+  }
+
+  @Test
+  fun `traversal entry escapes even when an install root is present`() {
+    val root = extractTo()
+    // Re-rooting to "models/" absorbs only ONE `..`, so multiple `..` still escape.
+    assertNull(safeZipEntryTarget(root, "../../../../evil.so", "models"))
+  }
+
+  @Test
+  fun `leading-slash traversal is rejected`() {
+    val root = extractTo()
+    assertNull(safeZipEntryTarget(root, "/../../evil", null))
+  }
+
+  @Test
+  fun `blank and dot entries are skipped`() {
+    val root = extractTo()
+    assertNull(safeZipEntryTarget(root, "", null))
+    assertNull(safeZipEntryTarget(root, "./", null))
+    assertNull(safeZipEntryTarget(root, "/", null))
+  }
+
+  @Test
+  fun `a valid entry named exactly like the root is contained`() {
+    val root = extractTo()
+    assertContained(root, safeZipEntryTarget(root, "models", "models"))
+  }
+}


### PR DESCRIPTION
## Summary

`DownloadService.downloadAndExtractZip` extracts downloaded packs (translation models, dictionaries, OCR, adblock lists, …) by joining each zip **entry name** onto the target directory after only:

- stripping a leading `/` or `./`, and
- (when the pack has a known install dir) re-rooting the entry under it.

That transform never neutralizes `..` path segments, so a crafted entry name escapes the extraction directory — a classic **Zip Slip** / path traversal (CWE-22).

## Root cause

The pre-fix sink was, in `downloadAndExtractZip` (`app/src/main/java/dev/davidv/translator/DownloadService.kt`):

```kotlin
fun normalizedEntryName(entryName: String): String {
  val trimmed = entryName.trimStart('/').removePrefix("./")
  if (trimmed.isBlank()) return trimmed
  val rootName = installRootName ?: return trimmed
  return if (trimmed == rootName || trimmed.startsWith("$rootName/")) trimmed
         else "$rootName/$trimmed"
}
// ...
val output = File(extractTo, normalizedEntryName(entry.name))   // write
// ...and the same name feeds the pre-extract cleanup that deleteRecursively()s dirs
```

`trimStart('/')` / `removePrefix("./")` do nothing to `..`, and re-rooting under `installRootName` only ever absorbs **one** `..`:

| entry name | install root | resolves to | escapes `extractTo`? |
|---|---|---|---|
| `../../../databases/evil.db` | *(none)* | `…/files/databases/evil.db`* | **yes** |
| `../../../../evil.so` | `models` | `models/../../../../evil.so` → `…/evil.so`* | **yes** |
| `/../../evil` | *(none)* | `…/evil`* | **yes** |
| `en-es/model.bin` | `models` | `…/models/en-es/model.bin` | no (benign) |

<sub>*outside the intended `extractTo` directory.</sub>

Because the normalized name is *also* used to build the set of directories that get `deleteRecursively()`-ed before extraction, a traversal entry additionally enables **deleting** directories outside the target, not just writing.

## Impact / threat model

Pack archives are fetched over `URLConnection` from URLs in a catalog whose index URL is **user-configurable** (`Settings → catalogIndexUrl`) and for which there is currently **no checksum/signature verification**. So the bytes of the archive — including entry names — are attacker-influenced whenever the catalog host is malicious/compromised (or a plain-`http` mirror is MITM'd). With `MANAGE_EXTERNAL_STORAGE` + `requestLegacyExternalStorage`, the write/delete primitive is not confined to the app sandbox.

This PR is scoped to closing the Zip Slip hole (defense-in-depth that should hold regardless of the catalog's trustworthiness). Adding integrity verification of downloaded packs is a separate, larger change and is left out on purpose.

## Fix

- Split the naming transform into a top-level, testable `normalizeZipEntryName(entryName, installRootName)` (behavior unchanged).
- Add `safeZipEntryTarget(extractTo, entryName, installRootName)`: it resolves the entry and returns the target `File` **only if the canonicalized target stays inside the canonicalized `extractTo`**, otherwise `null`.
- Skip unsafe entries (with a `Log.w`) in **both** the cleanup-planning pass and the extraction pass. Benign archives are unaffected.

The change is minimal and self-contained; no public API or on-disk layout changes.

## Testing

Added `app/src/test/java/dev/davidv/translator/ZipEntrySanitizationTest.kt` (plain JUnit, matches the existing `TargetTabsTest` style) covering the naming transform and the traversal cases above.

I verified the exact new functions and the exact new test against a standalone Kotlin/JUnit harness (the full Gradle unit-test task pulls in the Rust/NDK `preBuild`, so I ran the pure logic in isolation):

- **New logic:** `OK (8 tests)`.
- **Same test against the pre-fix logic** (no containment guard): the three traversal tests **fail** — e.g. `expected null, but was:<…/models/../../../databases/evil.db>` — confirming the tests are a real regression guard, not tautologies.

## References

- Snyk — *Zip Slip Vulnerability*: https://security.snyk.io/research/zip-slip-vulnerability
- CWE-22 — *Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')*: https://cwe.mitre.org/data/definitions/22.html
- OWASP — *Path Traversal*: https://owasp.org/www-community/attacks/Path_Traversal

---

<sub>Prepared and submitted on behalf of @MiMoHo. Finding surfaced during a security/logic review of the project; the fix is deliberately narrow and covered by tests.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
