### PR TITLE
Reject cross-origin Host headers on the LibreTranslate server (anti DNS-rebinding)

### DIFF
--- a/app/src/main/java/dev/davidv/translator/LibreTranslateHttpServer.kt
+++ b/app/src/main/java/dev/davidv/translator/LibreTranslateHttpServer.kt
@@ -56,6 +56,15 @@ class LibreTranslateHttpServer(
   }
 
   override fun serve(session: IHTTPSession): Response {
+    // DNS-rebinding guard: a page on any origin can fetch() this loopback server,
+    // and one that rebinds its own hostname to 127.0.0.1 could then read the
+    // responses (ACAO is `*`). Reject requests whose Host header is a registered
+    // domain name; loopback names and raw IP literals — what real LibreTranslate
+    // clients use — are still accepted. Not cors()-wrapped, so a blocked browser
+    // caller cannot read the body either.
+    if (!isAllowedHost(session.headers["host"])) {
+      return error(Response.Status.FORBIDDEN, "host not allowed")
+    }
     if (session.method == Method.OPTIONS) return cors(newFixedLengthResponse(Response.Status.OK, MIME_JSON, "{}"))
     return try {
       val response =
@@ -381,6 +390,38 @@ class LibreTranslateHttpServer(
     // The native robust detector returns a single best language code without a
     // score, so we report full confidence to satisfy the LibreTranslate schema.
     private const val DETECTED_CONFIDENCE = 100.0
+
+    private val IPV4 = Regex("""^\d{1,3}(\.\d{1,3}){3}$""")
+    private val IPV6 = Regex("""^[0-9a-fA-F:]+$""")
+
+    /**
+     * Whether a request's `Host` header is safe to serve. Accepts a missing
+     * Host, `localhost`, and raw IPv4/IPv6 literals; rejects registered domain
+     * names. This is the DNS-rebinding defense (see [serve]): rebinding relies on
+     * a hostname that re-resolves to a loopback/LAN address, so refusing
+     * hostnames — while still allowing the IPs and `localhost` that real clients
+     * target — closes the hole without breaking normal use.
+     */
+    internal fun isAllowedHost(hostHeader: String?): Boolean {
+      if (hostHeader.isNullOrBlank()) return true
+      val host = hostNameOnly(hostHeader).lowercase()
+      if (host.isEmpty()) return false
+      if (host == "localhost") return true
+      return IPV4.matches(host) || (host.contains(':') && IPV6.matches(host))
+    }
+
+    // Extracts the host from a `Host` header value, dropping any `:port`.
+    // IPv6 literals are bracketed per RFC 3986 (`[::1]:5000`); a bare IPv6
+    // address (multiple colons, no brackets) carries no port.
+    private fun hostNameOnly(hostHeader: String): String {
+      val h = hostHeader.trim()
+      if (h.startsWith("[")) {
+        val end = h.indexOf(']')
+        return if (end >= 0) h.substring(1, end).trim() else h.substring(1).trim()
+      }
+      if (h.count { it == ':' } > 1) return h
+      return h.substringBefore(':')
+    }
   }
 }
 

--- a/app/src/test/java/dev/davidv/translator/LibreTranslateHostValidationTest.kt
+++ b/app/src/test/java/dev/davidv/translator/LibreTranslateHostValidationTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 David V
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.davidv.translator
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LibreTranslateHostValidationTest {
+  // Loopback + raw IP literals are what real LibreTranslate clients target.
+  @Test
+  fun `loopback and ip literal hosts are allowed`() {
+    for (host in
+      listOf(
+        null,
+        "",
+        "localhost",
+        "localhost:5000",
+        "127.0.0.1",
+        "127.0.0.1:5000",
+        "192.168.1.5:5000",
+        "10.0.0.2",
+        "0.0.0.0:5000",
+        "::1",
+        "[::1]:5000",
+        "[fe80::1]:5000",
+      )) {
+      assertTrue("expected host '$host' to be allowed", LibreTranslateHttpServer.isAllowedHost(host))
+    }
+  }
+
+  // DNS-rebinding relies on a registered domain name that re-resolves to a
+  // loopback/LAN address; those must be rejected.
+  @Test
+  fun `registered domain names are rejected`() {
+    for (host in
+      listOf(
+        "evil.com",
+        "evil.com:5000",
+        "attacker.example.org",
+        "translator.attacker.com:5000",
+        "myphone.local",
+        // rebinding-service style names that embed the target IP as a label
+        "app.127.0.0.1.nip.io",
+        "127.0.0.1.evil.com",
+      )) {
+      assertFalse("expected host '$host' to be rejected", LibreTranslateHttpServer.isAllowedHost(host))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The bundled LibreTranslate-compatible HTTP server (`LibreTranslateHttpServer`, hosted by `TranslationApiService`) answers every request with `Access-Control-Allow-Origin: *` and **never validates the `Host` header**. That makes the loopback server reachable cross-origin from the browser, which opens a **DNS-rebinding** hole.

## The problem

`serve()` dispatches straight to the handlers, and every response gets wildcard CORS:

```kotlin
override fun serve(session: IHTTPSession): Response {
  if (session.method == Method.OPTIONS) return cors(newFixedLengthResponse(...))
  // ...handlers...
}

private fun cors(response: Response): Response =
  response.apply {
    addHeader("Access-Control-Allow-Origin", "*")
    addHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
    addHeader("Access-Control-Allow-Headers", "Content-Type, Authorization")
  }
```

Even in the **default** `127.0.0.1` bind mode:

1. Any web page the user visits can script `fetch("http://127.0.0.1:5000/translate", …)` (a form-encoded POST is a CORS "simple request", so it isn't even preflighted), and with `ACAO: *` it can **read the response**.
2. More seriously, a malicious site can point its own hostname at `127.0.0.1` via **DNS rebinding**; the browser then connects to the loopback server but still sends `Host: attacker.example`. Because nothing checks the Host, the request is served and the response is readable.

Impact is bounded but real: an attacker page can drive translation/OCR (CPU/battery DoS) and pull translated-file outputs via `/download/<id>`. In `all interfaces` bind mode the same applies to any LAN page.

## Fix

Add an allow-list check at the very top of `serve()`:

```kotlin
if (!isAllowedHost(session.headers["host"])) {
  return error(Response.Status.FORBIDDEN, "host not allowed")
}
```

`isAllowedHost` accepts a **missing Host**, `localhost`, and **raw IPv4/IPv6 literals** — exactly what real LibreTranslate clients target (`127.0.0.1:5000`, the device's LAN IP, `[::1]:5000`) — and **rejects registered domain names**, which is what a rebinding attack must use (`evil.com`, `app.127.0.0.1.nip.io`, `127.0.0.1.evil.com`, …). The 403 is deliberately **not** `cors()`-wrapped, so a blocked browser caller can't read the body either.

This is a minimal, standard "same-origin-ish" guard for a localhost service; it doesn't change the API surface and doesn't affect legitimate clients. It complements, but is independent of, the existing bind-mode setting.

## Testing

Added `app/src/test/java/dev/davidv/translator/LibreTranslateHostValidationTest.kt` (plain JUnit; calls the real `LibreTranslateHttpServer.isAllowedHost`). It asserts that loopback names / IPv4 / IPv6 / `null` Host are allowed and that domain names — including rebinding-service names that embed the target IP as a label — are rejected.

Verified by running the exact function against the exact test in a standalone Kotlin/JUnit harness (the full Gradle unit-test task pulls in the Rust/NDK `preBuild`): `OK (2 tests)`.

## Notes / possible follow-ups (out of scope here)

- The wildcard CORS itself could be tightened, but the Host check is the load-bearing defense against rebinding.
- Separately, `all interfaces` bind mode exposes the unauthenticated server to the whole LAN with no in-app warning — worth a note in Settings, but left out to keep this PR focused.

## References

- Tavis Ormandy / Project Zero and general guidance on **DNS rebinding** against localhost services
- OWASP — *Server-Side Request Forgery / DNS Rebinding* background: https://owasp.org/www-community/attacks/Server_Side_Request_Forgery
- MDN — CORS "simple requests" (why form POSTs aren't preflighted): https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests

---

<sub>Prepared and submitted on behalf of @MiMoHo. Surfaced during a security review; fix is deliberately narrow and unit-tested.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
